### PR TITLE
Several more polynomial functor operations

### DIFF
--- a/geb/src/LanguageDef/ADTCat.idr
+++ b/geb/src/LanguageDef/ADTCat.idr
@@ -59,6 +59,24 @@ stCata = pfCata {p=SubstTermPF}
 -------------------
 
 public export
+InSTUnit : STMu
+InSTUnit = InPFM STPosLeaf $ \d => case d of _ impossible
+
+public export
+InSTLeft : STMu -> STMu
+InSTLeft x = InPFM STPosLeft $ \d => case d of STDirL => x
+
+public export
+InSTRight : STMu -> STMu
+InSTRight y = InPFM STPosRight $ \d => case d of STDirR => y
+
+public export
+InSTPair : STMu -> STMu -> STMu
+InSTPair x y = InPFM STPosPair $ \d => case d of
+  STDirFst => x
+  STDirSnd => y
+
+public export
 STSizeAlg : STAlg Nat
 STSizeAlg STPosLeaf dir = 0
 STSizeAlg STPosLeft dir = 1 + dir STDirL
@@ -79,6 +97,17 @@ STDepthAlg STPosPair dir = smax (dir STDirFst) (dir STDirSnd)
 public export
 stDepth : STMu -> Nat
 stDepth = stCata STDepthAlg
+
+public export
+STShowAlg : STAlg String
+STShowAlg STPosLeaf dir = "!"
+STShowAlg STPosLeft dir = "< [" ++ dir STDirL ++ "]"
+STShowAlg STPosRight dir = "> [" ++ dir STDirR ++ "]"
+STShowAlg STPosPair dir = "(" ++ dir STDirFst ++ ", " ++ dir STDirSnd ++ ")"
+
+public export
+Show STMu where
+  show = stCata STShowAlg
 
 ---------------------
 ---- Refinements ----

--- a/geb/src/LanguageDef/PolyCat.idr
+++ b/geb/src/LanguageDef/PolyCat.idr
@@ -695,6 +695,18 @@ PolyCFCMInterpToScale : (p : PolyFunc) -> (a : Type) ->
   InterpPolyFuncCofreeCM p a -> PolyFuncCofreeCMFromScale p a
 PolyCFCMInterpToScale p a (em ** d) = PolyCFCMInterpToScaleCurried p a em d
 
+public export
+PolyCFCMScaleToInterpAlg : (p : PolyFunc) -> (a : Type) ->
+  (i : PFScalePos p a) ->
+  (PFScaleDir p a i -> InterpPolyFuncCofreeCM p a) ->
+  InterpPolyFuncCofreeCM p a
+PolyCFCMScaleToInterpAlg (pos ** dir) a = ?PolyCFCMScaleToInterpAlg_hole
+
+public export
+PolyCFCMScaleToInterp : (p : PolyFunc) -> (a : Type) ->
+  PolyFuncCofreeCMFromScale p a -> InterpPolyFuncCofreeCM p a
+PolyCFCMScaleToInterp p a = ?PolyCFCMScaleToInterp_hole
+
 ---------------------------------------
 ---------------------------------------
 ---- Dependent polynomial functors ----

--- a/geb/src/LanguageDef/PolyCat.idr
+++ b/geb/src/LanguageDef/PolyCat.idr
@@ -630,6 +630,12 @@ pfAna : {0 p : PolyFunc} -> {0 a : Type} -> PFCoalg p a -> a -> PolyFuncNu p
 pfAna {p=p@(pos ** dir)} {a} coalg e = case coalg e of
   (i ** da) => InPFN i $ \d : dir i => pfAna coalg $ da d
 
+public export
+partial
+pfNuCata : {0 p : PolyFunc} -> {0 a : Type} -> PFAlg p a -> PolyFuncNu p -> a
+pfNuCata {p=p@(pos ** dir)} {a} alg (InPFN i da) =
+  alg i $ \d : dir i => pfNuCata {p} alg $ da d
+
 --------------------------------------
 ---- Polynomial (cofree) comonads ----
 --------------------------------------
@@ -661,7 +667,10 @@ PolyFuncCofreeCMPosFromFunc = PolyTree
 public export
 PolyFuncCofreeCMPosScaleToFunc : {p : PolyFunc} ->
   PolyFuncCofreeCMPosFromScale p -> PolyFuncCofreeCMPosFromFunc p
-PolyFuncCofreeCMPosScaleToFunc = ?PolyFuncCofreeCMPosScaleToFunc_hole
+PolyFuncCofreeCMPosScaleToFunc {p=(pos ** dir)}
+  (InPFN (PFNode () i) d) [] = i
+PolyFuncCofreeCMPosScaleToFunc {p=(pos ** dir)}
+  (InPFN (PFNode () i) d) ((i' ** d') :: l) = ?PolyFuncCofreeCMPosScaleToFunc_hole_1
 
 public export
 PolyFuncCofreeCMPosFuncToScale : {p : PolyFunc} ->

--- a/geb/src/LanguageDef/PolyCat.idr
+++ b/geb/src/LanguageDef/PolyCat.idr
@@ -304,6 +304,12 @@ pfSetProductArena {a} ps =
    (\fpos : ((x' : a) -> fst $ ps x') => (x' : a ** snd (ps x') $ fpos x')))
 
 public export
+pfSetParProductArena : {a : Type} -> (a -> PolyFunc) -> PolyFunc
+pfSetParProductArena {a} ps =
+  (((x : a) -> fst $ ps x) **
+   (\fpos : ((x' : a) -> fst $ ps x') => ((x' : a) -> snd (ps x') $ fpos x')))
+
+public export
 pfHomObj : PolyFunc -> PolyFunc -> PolyFunc
 pfHomObj q r =
   pfSetProductArena {a=(pfPos q)} $

--- a/geb/src/LanguageDef/PolyCat.idr
+++ b/geb/src/LanguageDef/PolyCat.idr
@@ -34,6 +34,10 @@ pfDir : {p : PolyFunc} -> pfPos p -> Type
 pfDir {p=(pos ** dir)} i = dir i
 
 public export
+pfPDir : PolyFunc -> Type
+pfPDir p = DPair (pfPos p) (pfDir {p})
+
+public export
 InterpPolyFunc : PolyFunc -> Type -> Type
 InterpPolyFunc (pos ** dir) x = (i : pos ** (dir i -> x))
 
@@ -429,6 +433,18 @@ InPFMN : {0 p : PolyFuncN} ->
   (i : pfnPos p) -> Vect (pfnDir p i) (PolyFuncNMu p) -> PolyFuncNMu p
 InPFMN {p=(pos ** dir)} i = InPFM i . flip index
 
+-------------------------------
+---- Paths through p-trees ----
+-------------------------------
+
+public export
+PolyPath : PolyFunc -> Type
+PolyPath = List . pfPDir
+
+public export
+PolyTree : PolyFunc -> Type
+PolyTree p = PolyPath p -> pfPos p
+
 ----------------------------------------------
 ---- Catamorphisms of polynomial functors ----
 ----------------------------------------------
@@ -633,6 +649,51 @@ PFScale p a = (PFScalePos p a ** PFScaleDir p a)
 public export
 PolyFuncCofreeCMFromScale : PolyFunc -> Type -> Type
 PolyFuncCofreeCMFromScale = PolyFuncNu .* PFScale
+
+public export
+PolyFuncCofreeCMPosFromScale : PolyFunc -> Type
+PolyFuncCofreeCMPosFromScale p = PolyFuncCofreeCMFromScale p ()
+
+public export
+PolyFuncCofreeCMPosFromFunc : PolyFunc -> Type
+PolyFuncCofreeCMPosFromFunc = PolyTree
+
+public export
+PolyFuncCofreeCMPosScaleToFunc : {p : PolyFunc} ->
+  PolyFuncCofreeCMPosFromScale p -> PolyFuncCofreeCMPosFromFunc p
+PolyFuncCofreeCMPosScaleToFunc = ?PolyFuncCofreeCMPosScaleToFunc_hole
+
+public export
+PolyFuncCofreeCMPosFuncToScale : {p : PolyFunc} ->
+  PolyFuncCofreeCMPosFromFunc p -> PolyFuncCofreeCMPosFromScale p
+PolyFuncCofreeCMPosFuncToScale = ?PolyFuncCofreeCMPosFuncToScale_hole
+
+public export
+PolyFuncCofreeCMPos : PolyFunc -> Type
+PolyFuncCofreeCMPos = PolyFuncCofreeCMPosFromFunc
+
+public export
+PolyFuncCofreeCMDir : (p : PolyFunc) -> PolyFuncCofreeCMPos p -> Type
+PolyFuncCofreeCMDir p = ?PolyFuncCofreeCMDirFromScale_hole
+
+public export
+PolyFuncCofreeCM: PolyFunc -> PolyFunc
+PolyFuncCofreeCM p = (PolyFuncCofreeCMPos p ** PolyFuncCofreeCMDir p)
+
+public export
+InterpPolyFuncCofreeCM : PolyFunc -> Type -> Type
+InterpPolyFuncCofreeCM = InterpPolyFunc . PolyFuncCofreeCM
+
+public export
+PolyCFCMInterpToScaleCurried : (p : PolyFunc) -> (a : Type) ->
+  (mpos : PolyFuncCofreeCMPos p) -> (PolyFuncCofreeCMDir p mpos -> a) ->
+  PolyFuncCofreeCMFromScale p a
+PolyCFCMInterpToScaleCurried (pos ** dir) a = ?PolyCFCMInterpToScaleCurried_hole
+
+public export
+PolyCFCMInterpToScale : (p : PolyFunc) -> (a : Type) ->
+  InterpPolyFuncCofreeCM p a -> PolyFuncCofreeCMFromScale p a
+PolyCFCMInterpToScale p a (em ** d) = PolyCFCMInterpToScaleCurried p a em d
 
 ---------------------------------------
 ---------------------------------------

--- a/geb/src/LanguageDef/PolyCat.idr
+++ b/geb/src/LanguageDef/PolyCat.idr
@@ -789,7 +789,11 @@ PolyCFCMScaleToInterpAlg : (p : PolyFunc) -> (a : Type) ->
   (i : PFScalePos p a) ->
   (PFScaleDir p a i -> InterpPolyFuncCofreeCM p a) ->
   InterpPolyFuncCofreeCM p a
-PolyCFCMScaleToInterpAlg (pos ** dir) a = ?PolyCFCMScaleToInterpAlg_hole
+PolyCFCMScaleToInterpAlg (pos ** dir) a (PFNode x i) hyp =
+  (InPFM (PFNode () i) (fst . hyp) **
+   \dp => case dp of
+    Left () => x
+    Right (di ** cmdi) => snd (hyp di) cmdi)
 
 public export
 partial

--- a/geb/src/LanguageDef/PolyCat.idr
+++ b/geb/src/LanguageDef/PolyCat.idr
@@ -483,18 +483,6 @@ InPFMN : {0 p : PolyFuncN} ->
   (i : pfnPos p) -> Vect (pfnDir p i) (PolyFuncNMu p) -> PolyFuncNMu p
 InPFMN {p=(pos ** dir)} i = InPFM i . flip index
 
--------------------------------
----- Paths through p-trees ----
--------------------------------
-
-public export
-PolyPath : PolyFunc -> Type
-PolyPath = List . pfPDir
-
-public export
-PolyTree : PolyFunc -> Type
-PolyTree p = PolyPath p -> pfPos p
-
 ----------------------------------------------
 ---- Catamorphisms of polynomial functors ----
 ----------------------------------------------
@@ -686,6 +674,14 @@ pfNuCata : {0 p : PolyFunc} -> {0 a : Type} -> PFAlg p a -> PolyFuncNu p -> a
 pfNuCata {p=p@(pos ** dir)} {a} alg (InPFN i da) =
   alg i $ \d : dir i => pfNuCata {p} alg $ da d
 
+-------------------------------
+---- Paths through p-trees ----
+-------------------------------
+
+public export
+PolyTree : PolyFunc -> Type
+PolyTree p = (a : Type ** PFCoalg p a)
+
 --------------------------------------
 ---- Polynomial (cofree) comonads ----
 --------------------------------------
@@ -717,10 +713,8 @@ PolyFuncCofreeCMPosFromFunc = PolyTree
 public export
 PolyFuncCofreeCMPosScaleToFunc : {p : PolyFunc} ->
   PolyFuncCofreeCMPosFromScale p -> PolyFuncCofreeCMPosFromFunc p
-PolyFuncCofreeCMPosScaleToFunc {p=(pos ** dir)}
-  (InPFN (PFNode () i) d) [] = i
-PolyFuncCofreeCMPosScaleToFunc {p=(pos ** dir)}
-  (InPFN (PFNode () i) d) ((i' ** d') :: l) = ?PolyFuncCofreeCMPosScaleToFunc_hole_1
+PolyFuncCofreeCMPosScaleToFunc {p=(pos ** dir)} =
+  ?PolyFuncCofreeCMPosScaleToFunc_hole
 
 public export
 PolyFuncCofreeCMPosFuncToScale : {p : PolyFunc} ->

--- a/geb/src/LanguageDef/PolyCat.idr
+++ b/geb/src/LanguageDef/PolyCat.idr
@@ -240,6 +240,10 @@ PFIdentityArena : PolyFunc
 PFIdentityArena = (PFIdentityPos ** PFIdentityDir)
 
 public export
+PFConstArena : Type -> PolyFunc
+PFConstArena a = (a ** const Void)
+
+public export
 pfCoproductPos : PolyFunc -> PolyFunc -> Type
 pfCoproductPos (ppos ** pdir) (qpos ** qdir) = Either ppos qpos
 
@@ -289,6 +293,34 @@ pfCompositionArena : PolyFunc -> PolyFunc -> PolyFunc
 pfCompositionArena p q = (pfCompositionPos p q ** pfCompositionDir p q)
 
 public export
+pfSetCoproductArena : {a : Type} -> (a -> PolyFunc) -> PolyFunc
+pfSetCoproductArena {a} ps =
+  ((x : a ** fst $ ps x) ** (\xpos => snd (ps $ fst xpos) $ snd xpos))
+
+public export
+pfSetProductArena : {a : Type} -> (a -> PolyFunc) -> PolyFunc
+pfSetProductArena {a} ps =
+  (((x : a) -> fst $ ps x) **
+   (\fpos : ((x' : a) -> fst $ ps x') => (x' : a ** snd (ps x') $ fpos x')))
+
+public export
+pfHomObj : PolyFunc -> PolyFunc -> PolyFunc
+pfHomObj q r =
+  pfSetProductArena {a=(pfPos q)} $
+    \j =>
+      pfCompositionArena r $
+        pfCoproductArena PFIdentityArena $ PFConstArena $ pfDir {p=q} j
+
+public export
+pfExpObj : PolyFunc -> PolyFunc -> PolyFunc
+pfExpObj = flip pfHomObj
+
+public export
+pfParProdClosure : PolyFunc -> PolyFunc -> PolyFunc
+pfParProdClosure q r =
+  (PolyNatTrans q r ** \f => (j : pfPos q ** pfDir {p=r} $ pntOnPos f j))
+
+public export
 pfBaseChangePos : (p : PolyFunc) -> {a : Type} -> (a -> pfPos p) -> Type
 pfBaseChangePos p {a} f = a
 
@@ -300,6 +332,10 @@ pfBaseChangeDir (pos ** dir) {a} f i = dir $ f i
 public export
 pfBaseChangeArena : (p : PolyFunc) -> {a : Type} -> (a -> pfPos p) -> PolyFunc
 pfBaseChangeArena p {a} f = (pfBaseChangePos p {a} f ** pfBaseChangeDir p {a} f)
+
+public export
+pfLeftCoclosure : (q, p : PolyFunc) -> PolyFunc
+pfLeftCoclosure q p = (pfPos p ** InterpPolyFunc q . pfDir {p})
 
 ------------------------------------
 ------------------------------------

--- a/geb/src/LanguageDef/PolyCat.idr
+++ b/geb/src/LanguageDef/PolyCat.idr
@@ -786,9 +786,10 @@ PolyCFCMScaleToInterpAlg : (p : PolyFunc) -> (a : Type) ->
 PolyCFCMScaleToInterpAlg (pos ** dir) a = ?PolyCFCMScaleToInterpAlg_hole
 
 public export
+partial
 PolyCFCMScaleToInterp : (p : PolyFunc) -> (a : Type) ->
   PolyFuncCofreeCMFromScale p a -> InterpPolyFuncCofreeCM p a
-PolyCFCMScaleToInterp p a = ?PolyCFCMScaleToInterp_hole
+PolyCFCMScaleToInterp p a = pfNuCata $ PolyCFCMScaleToInterpAlg p a
 
 ----------------------------------------------
 ----------------------------------------------

--- a/geb/src/LanguageDef/PolyCat.idr
+++ b/geb/src/LanguageDef/PolyCat.idr
@@ -711,10 +711,19 @@ PolyFuncCofreeCMPosFromFunc : PolyFunc -> Type
 PolyFuncCofreeCMPosFromFunc = PolyTree
 
 public export
+partial
 PolyFuncCofreeCMPosScaleToFunc : {p : PolyFunc} ->
   PolyFuncCofreeCMPosFromScale p -> PolyFuncCofreeCMPosFromFunc p
-PolyFuncCofreeCMPosScaleToFunc {p=(pos ** dir)} =
-  ?PolyFuncCofreeCMPosScaleToFunc_hole
+PolyFuncCofreeCMPosScaleToFunc {p=p@(pos ** dir)} (InPFN (PFNode () i) d) =
+  (PolyTree p ** (\coalg => (i ** \d' =>
+    let
+      (coalgty ** coalgf) = coalg
+      (recty ** recf) = PolyFuncCofreeCMPosScaleToFunc $ d d'
+    in
+    (Either coalgty recty **
+     eitherElim
+      (\coalgx => (fst (coalgf coalgx) ** Left . snd (coalgf coalgx)))
+      (\rectyx => (fst (recf rectyx) ** Right . snd (recf rectyx)))))))
 
 public export
 PolyFuncCofreeCMPosFuncToScale : {p : PolyFunc} ->

--- a/geb/src/LanguageDef/PolyCat.idr
+++ b/geb/src/LanguageDef/PolyCat.idr
@@ -743,15 +743,21 @@ PolyFuncCofreeCMPosScaleToFunc {p=p@(pos ** dir)} (InPFN (PFNode () i) d) =
 public export
 PolyFuncCofreeCMPosFuncToScale : {p : PolyFunc} ->
   PolyFuncCofreeCMPosFromFunc p -> PolyFuncCofreeCMPosFromScale p
-PolyFuncCofreeCMPosFuncToScale = ?PolyFuncCofreeCMPosFuncToScale_hole
+PolyFuncCofreeCMPosFuncToScale {p=p@(pos ** dir)} (InPFM (PFNode () i) d) =
+  InPFN (PFNode () i) $ \di : dir i => PolyFuncCofreeCMPosFuncToScale (d di)
 
 public export
 PolyFuncCofreeCMPos : PolyFunc -> Type
 PolyFuncCofreeCMPos = PolyFuncCofreeCMPosFromFunc
 
 public export
+PolyFuncCofreeCMDirAlg : (p : PolyFunc) -> PFAlg (PFScale p ()) Type
+PolyFuncCofreeCMDirAlg (pos ** dir) (PFNode () i) d =
+  Pair Unit $ (di : dir i) -> d di
+
+public export
 PolyFuncCofreeCMDir : (p : PolyFunc) -> PolyFuncCofreeCMPos p -> Type
-PolyFuncCofreeCMDir p = ?PolyFuncCofreeCMDirFromScale_hole
+PolyFuncCofreeCMDir p = pfCata $ PolyFuncCofreeCMDirAlg p
 
 public export
 PolyFuncCofreeCM: PolyFunc -> PolyFunc

--- a/geb/src/LanguageDef/Test/ADTCatTest.idr
+++ b/geb/src/LanguageDef/Test/ADTCatTest.idr
@@ -213,6 +213,15 @@ showPMRaise n = do
   putStrLn $ "npos(pmMaybeSqRaise " ++ show n ++ ") = " ++
     show (polyNPos $ pmMaybeSqRaise n)
 
+--------------
+--------------
+---- STMu ----
+--------------
+--------------
+
+stMuExp1 : STMu
+stMuExp1 = InSTPair (InSTLeft InSTUnit) (InSTRight InSTUnit)
+
 ----------------------------------
 ----------------------------------
 ----- Exported test function -----
@@ -310,6 +319,12 @@ adtCatTest = do
   showPMRaise 8
   putStrLn ""
   putStrLn "---------------"
+  putStrLn "---- PolyF ----"
+  putStrLn "---------------"
+  putStrLn "---------------"
+  putStrLn ""
+  putStrLn $ "stMu1 = " ++ show stMuExp1
+  putStrLn ""
   putStrLn "End ADTCatTest."
   putStrLn "==============="
   pure ()


### PR DESCRIPTION
Add a number of operations on `PolyFunc`, the arena representation of a polynomial endofunctor on Idris's `Type`.

In particular, compute the positions and directions of the cofree comonoid of a given polynomial endofunctor, in terms of least fixed points -- `Mu` rather than an explicit built-in `Nu` --  and implement an equivalence with Idris's built-in `Nu`.  This demonstrates that the cofree comonoid is polynomial, and also that there is a least-fixed-point _representation_ (`Mu`) of a greatest fixed-point (`Nu`) using closures.