### PR TITLE
Code Coverage and Profiling

### DIFF
--- a/docs/documentation.lisp
+++ b/docs/documentation.lisp
@@ -21,6 +21,20 @@
 Here is the [official repository](https://github.com/anoma/geb/)
 
 and the [HTML documentation](https://anoma.github.io/geb/) for the latest version
+"""
+  (@coverage pax:section))
+
+(pax:defsection @coverage (:title "code coverage")
+  """
+For test coverage it can be found at the following links:
+
+[CCL test coverage](./tests/report.html)
+
+[SBCL test coverage](./tests/cover-index.html)
+
+I recommend reading the CCL code coverage version, as it has proper tags.
+
+Currently they are manually generated, and thus for a more accurate assessment see @
 """)
 
 (pax:defsection @math-playground (:title "math-playground")

--- a/test/package.lisp
+++ b/test/package.lisp
@@ -18,4 +18,5 @@ as our testing framework.
 Please read the
 [manual](https://quickref.common-lisp.net/parachute.html) for extra
 features and how to better lay out future tests"
-  (run-tests pax:function))
+  (run-tests pax:function)
+  (code-coverage pax:function))

--- a/test/run-tests.lisp
+++ b/test/run-tests.lisp
@@ -90,3 +90,20 @@ tests ought to work
   (setq ccl:*compile-code-coverage* nil)
   (asdf:compile-system :geb :force t)
   (asdf:compile-system :geb/test :force t))
+
+#+sbcl
+(eval-when (:compile-toplevel :load-toplevel :execute)
+  (require :sb-cover))
+
+#+sbcl
+(defun code-coverage ()
+  nil
+  (declaim (optimize (sb-cover:store-coverage-data 3)))
+  (asdf:oos 'asdf:load-op :geb :force t)
+  (asdf:oos 'asdf:load-op :geb/test :force t)
+  (run-tests :summary? t)
+  (sb-cover:report "../docs/tests/")
+
+  (declaim (optimize (sb-cover:store-coverage-data 3)))
+  (asdf:oos 'asdf:load-op :geb :force t)
+  (asdf:oos 'asdf:load-op :geb/test :force t))

--- a/test/run-tests.lisp
+++ b/test/run-tests.lisp
@@ -35,3 +35,33 @@ tests ought to work
                   ((and plain? interactive?)   'noisy-interactive)
                   (interactive?                'interactive)
                   (t                           'plain))))
+
+#+slynk
+(defun profile-all ()
+  (let* ((packages
+           (list-all-packages))
+         (alu-packages
+           (remove-if-not (lambda (p)
+                            (let ((search (search "GEB" (package-name p))))
+                              (and search (= 0 search))))
+                          packages))
+         (without-aluser
+             (remove-if (lambda (p)
+                          (member (package-name p) '("geb-test")
+                                  :test #'equalp))
+                        alu-packages)))
+    (mapc (lambda (alu)
+            (slynk-backend:profile-package alu t t))
+          without-aluser)))
+
+#+slynk
+(defun unprofile-all ()
+  (slynk-backend:unprofile-all))
+
+#+slynk
+(defun profiler-report ()
+  (slynk-backend:profile-report))
+
+#+slynk
+(defun profiler-reset ()
+  (slynk-backend:profile-reset))

--- a/test/run-tests.lisp
+++ b/test/run-tests.lisp
@@ -68,6 +68,14 @@ tests ought to work
 
 #+ccl
 (defun code-coverage ()
+  "generates code coverage, for CCL the coverage can be found at
+
+[CCL test coverage](../docs/tests/report.html)
+
+[SBCL test coverage](../docs/tests/cover-index.html)
+
+simply run this function to generate a fresh one
+"
   (ccl:reset-incremental-coverage)
   (ccl:reset-coverage)
 
@@ -97,6 +105,14 @@ tests ought to work
 
 #+sbcl
 (defun code-coverage ()
+  "generates code coverage, for CCL the coverage can be found at
+
+[CCL test coverage](../docs/tests/report.html)
+
+[SBCL test coverage](../docs/tests/cover-index.html)
+
+simply run this function to generate a fresh one
+"
   nil
   (declaim (optimize (sb-cover:store-coverage-data 3)))
   (asdf:oos 'asdf:load-op :geb :force t)
@@ -107,3 +123,14 @@ tests ought to work
   (declaim (optimize (sb-cover:store-coverage-data 3)))
   (asdf:oos 'asdf:load-op :geb :force t)
   (asdf:oos 'asdf:load-op :geb/test :force t))
+
+#-(or sbcl ccl)
+(defun code-coverage ()
+  "generates code coverage, for CCL the coverage can be found at
+
+[CCL test coverage](../docs/tests/report.html)
+
+[SBCL test coverage](../docs/tests/cover-index.html)
+
+simply run this function to generate a fresh one
+")


### PR DESCRIPTION
This PR adds code coverage functions for both SBCL and CCL, along with a profiling tool available if one is using `sly`