### PR TITLE
Binary creation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,15 @@
+all:
+	make clean || true
+	ros run --load "geb.asd" --eval "(progn (load \"geb.asd\") (make-system))"
+
+install:
+	make clean || true
+	make all
+	mkdir -p '${HOME}/.local/bin/'
+	mv "./build/geb.image" '${HOME}/.local/bin/'
+
+clean:
+	rm "./build/geb.image"
+
+uninstall:
+	rm '${HOME}/.local/bin/geb.image'

--- a/README
+++ b/README
@@ -5,17 +5,11 @@ Welcome to the GEB project.
 
 ## Links
 
-
-
 Here is the [official repository](https://github.com/anoma/geb/)
 
 and [HTML documentation](https://anoma.github.io/geb/) for the latest version.
 
-
-
 ### code coverage
-
-
 
 For test coverage it can be found at the following links:
 
@@ -33,8 +27,6 @@ CCL tests are not currently displaying
 I recommend reading the CCL code coverage version, as it has proper tags.
 
 Currently they are manually generated, and thus for a more accurate assessment see GEB-TEST:CODE-COVERAGE
-
-
 
 ## Getting Started
 
@@ -94,6 +86,73 @@ writing:
 (geb-test:run-tests)
 ```
 
+
+### Geb as a binary
+
+###### \[in package GEB.ENTRY\]
+The standard way to use geb currently is by loading the code into
+one's lisp environment
+
+```lisp
+(ql:quickload :geb)
+```
+
+However, one may be interested in running geb in some sort of
+compilation process, that is why we also give out a binary for people
+to use
+
+An example use of this binary is as follows
+
+```bash
+mariari@Gensokyo % ./geb.image -i "foo.lisp" -e "geb.lambda.spec::*entry*" -l -v -o "foo.pir"
+
+mariari@Gensokyo % cat foo.pir
+def *entry* x {
+  0
+}%
+mariari@Gensokyo % ./geb.image -i "foo.lisp" -e "geb.lambda.spec::*entry*" -l -v
+def *entry* x {
+  0
+}
+
+./geb.image -h
+  -i --input                      string   Input geb file location
+  -e --entry-point                string   The function to run, should be fully qualified I.E.
+                                           geb::my-main
+  -l --stlc                       boolean  Use the simply typed lambda calculus frontend
+  -o --output                     string   Save the output to a file rather than printing
+  -v --vampir                     string   Return a vamp-ir expression
+  -h -? --help                    boolean  The current help message
+
+```
+
+starting from a file *foo.lisp* that has
+
+```lisp
+(in-package :geb.lambda.spec)
+
+(defparameter *entry*
+  (typed unit geb:so1))
+```
+
+inside of it.
+
+The command needs an entry-point (-e or --entry-point), as we are
+simply call LOAD on the given file, and need to know what to
+translate.
+
+from STLC, we expect the form to be wrapped in the
+GEB.LAMBDA.SPEC.TYPED which takes both the type and the value to
+properly have enough context to evaluate.
+
+It is advised to bind this to a parameter like in our example as -e
+expects a symbol.
+
+the -l flag means that we are not expecting a geb term, but rather a
+lambda frontend term, this is to simply notify us to compile it as a
+lambda term rather than a geb term. In time this will go away
+
+- [function] COMPILE-DOWN &KEY VAMPIR STLC ENTRY (STREAM \*STANDARD-OUTPUT\*)
 
 ## Glossary
 
@@ -217,8 +276,6 @@ conjectures about GEB
 
 ## Categorical Model
 
-
-
 Geb is organizing programming language concepts (and entities!) using
 [category theory](https://plato.stanford.edu/entries/category-theory/),
 originally developed by mathematicians,
@@ -332,8 +389,6 @@ Benjamin Pierce's
 [*Basic Category Theory for Computer Scientists*](https://mitpress.mit.edu/9780262660716/) deserves being pointed out
 as it is very amenable *and*
 covers the background we need in 60 short pages.
-
-
 
 ### Morphisms
 
@@ -1255,23 +1310,41 @@ Various utility functions ontop of @GEB-CATEGORIES
 
 - [function] COMMUTES X Y
 
+- [function] COMMUTES-LEFT MORPH
+
+    swap the input domain of the given <SUBSTMORPH>
+    
+    In order to swap the domain we expect the <SUBSTMORPH> to
+    be a PROD
+    
+    Thus if: `(dom morph) ≡ (prod x y)`, for any `x`, `y` <SUBSTOBJ>
+    
+    then: `(commutes-left (dom morph)) ≡ (prod y x)`
+    
+    ```
+    Γ, f : x × y → a
+    ------------------------------
+    (commutes-left f) : y × x → a
+    ```
+
+
 - [function] !-> A B
 
 - [function] SO-EVAL X Y
 
 - [generic-function] SO-CARD-ALG OBJ
 
-    Gets the cardinality of the given object
+    Gets the cardinality of the given object, returns a FIXNUM
 
 - [method] SO-CARD-ALG (OBJ \<SUBSTOBJ\>)
 
 - [generic-function] DOM SUBSTMORPH
 
-    Grabs the domain of the morphism
+    Grabs the domain of the morphism. Returns a <SUBSTOBJ>
 
 - [generic-function] CODOM SUBSTMORPH
 
-    Grabs the codomain of the morphism
+    Grabs the codomain of the morphism. Returns a <SUBSTOBJ>
 
 - [generic-function] CURRY F
 

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@
 - [2 Getting Started][3d47]
     - [2.1 installation][8fa5]
     - [2.2 loading][a7d5]
+    - [2.3 Geb as a binary][8eb0]
 - [3 Glossary][25f0]
 - [4 Original Efforts][3686]
     - [4.1 Geb's Idris Code][8311]
@@ -49,18 +50,12 @@ Welcome to the GEB project.
 <a id="x-28GEB-DOCS-2FDOCS-3A-40LINKS-20MGL-PAX-3ASECTION-29"></a>
 ## 1 Links
 
-
-
 Here is the [official repository](https://github.com/anoma/geb/)
 
 and [HTML documentation](https://anoma.github.io/geb/) for the latest version.
 
-
-
 <a id="x-28GEB-DOCS-2FDOCS-3A-40COVERAGE-20MGL-PAX-3ASECTION-29"></a>
 ### 1.1 code coverage
-
-
 
 For test coverage it can be found at the following links:
 
@@ -78,8 +73,6 @@ CCL tests are not currently displaying
 I recommend reading the CCL code coverage version, as it has proper tags.
 
 Currently they are manually generated, and thus for a more accurate assessment see [`GEB-TEST:CODE-COVERAGE`][417f]
-
-
 
 <a id="x-28GEB-DOCS-2FDOCS-3A-40GETTING-STARTED-20MGL-PAX-3ASECTION-29"></a>
 ## 2 Getting Started
@@ -142,6 +135,75 @@ writing:
 (geb-test:run-tests)
 ```
 
+
+<a id="x-28GEB-2EENTRY-3A-40GEB-ENTRY-20MGL-PAX-3ASECTION-29"></a>
+### 2.3 Geb as a binary
+
+###### \[in package GEB.ENTRY\]
+The standard way to use geb currently is by loading the code into
+one's lisp environment
+
+```lisp
+(ql:quickload :geb)
+```
+
+However, one may be interested in running geb in some sort of
+compilation process, that is why we also give out a binary for people
+to use
+
+An example use of this binary is as follows
+
+```bash
+mariari@Gensokyo % ./geb.image -i "foo.lisp" -e "geb.lambda.spec::*entry*" -l -v -o "foo.pir"
+
+mariari@Gensokyo % cat foo.pir
+def *entry* x {
+  0
+}%
+mariari@Gensokyo % ./geb.image -i "foo.lisp" -e "geb.lambda.spec::*entry*" -l -v
+def *entry* x {
+  0
+}
+
+./geb.image -h
+  -i --input                      string   Input geb file location
+  -e --entry-point                string   The function to run, should be fully qualified I.E.
+                                           geb::my-main
+  -l --stlc                       boolean  Use the simply typed lambda calculus frontend
+  -o --output                     string   Save the output to a file rather than printing
+  -v --vampir                     string   Return a vamp-ir expression
+  -h -? --help                    boolean  The current help message
+
+```
+
+starting from a file *foo.lisp* that has
+
+```lisp
+(in-package :geb.lambda.spec)
+
+(defparameter *entry*
+  (typed unit geb:so1))
+```
+
+inside of it.
+
+The command needs an entry-point (-e or --entry-point), as we are
+simply call [`LOAD`][f766] on the given file, and need to know what to
+translate.
+
+from `STLC`, we expect the form to be wrapped in the
+GEB.LAMBDA.SPEC.TYPED which takes both the type and the value to
+properly have enough context to evaluate.
+
+It is advised to bind this to a parameter like in our example as -e
+expects a symbol.
+
+the -l flag means that we are not expecting a geb term, but rather a
+lambda frontend term, this is to simply notify us to compile it as a
+lambda term rather than a geb term. In time this will go away
+
+<a id="x-28GEB-2EENTRY-3ACOMPILE-DOWN-20FUNCTION-29"></a>
+- [function] **COMPILE-DOWN** *&KEY VAMPIR STLC ENTRY (STREAM \*STANDARD-OUTPUT\*)*
 
 <a id="x-28GEB-DOCS-2FDOCS-3A-40GLOSSARY-20MGL-PAX-3ASECTION-29"></a>
 ## 3 Glossary
@@ -273,8 +335,6 @@ conjectures about GEB
 <a id="x-28GEB-DOCS-2FDOCS-3A-40MODEL-20MGL-PAX-3ASECTION-29"></a>
 ## 5 Categorical Model
 
-
-
 Geb is organizing programming language concepts (and entities!) using
 [category theory](https://plato.stanford.edu/entries/category-theory/),
 originally developed by mathematicians,
@@ -388,8 +448,6 @@ Benjamin Pierce's
 [*Basic Category Theory for Computer Scientists*](https://mitpress.mit.edu/9780262660716/) deserves being pointed out
 as it is very amenable *and*
 covers the background we need in 60 short pages.
-
-
 
 <a id="x-28GEB-DOCS-2FDOCS-3A-40MORPHISMS-20MGL-PAX-3ASECTION-29"></a>
 ### 5.1 Morphisms
@@ -1407,6 +1465,25 @@ Various utility functions ontop of [Core Category][cb9e]
 <a id="x-28GEB-3ACOMMUTES-20FUNCTION-29"></a>
 - [function] **COMMUTES** *X Y*
 
+<a id="x-28GEB-3ACOMMUTES-LEFT-20FUNCTION-29"></a>
+- [function] **COMMUTES-LEFT** *MORPH*
+
+    swap the input [domain][3e8b] of the given [`<SUBSTMORPH>`][97fb]
+    
+    In order to swap the [domain][3e8b] we expect the [`<SUBSTMORPH>`][97fb] to
+    be a [`PROD`][77c2]
+    
+    Thus if: `(dom morph) ≡ (prod x y)`, for any `x`, `y` [`<SUBSTOBJ>`][8214]
+    
+    then: `(commutes-left (dom morph)) ≡ (prod y x)`
+    
+    ```
+    Γ, f : x × y → a
+    ------------------------------
+    (commutes-left f) : y × x → a
+    ```
+
+
 <a id="x-28GEB-3A-21--3E-20FUNCTION-29"></a>
 - [function] **!-\>** *A B*
 
@@ -1416,7 +1493,7 @@ Various utility functions ontop of [Core Category][cb9e]
 <a id="x-28GEB-3ASO-CARD-ALG-20GENERIC-FUNCTION-29"></a>
 - [generic-function] **SO-CARD-ALG** *OBJ*
 
-    Gets the cardinality of the given object
+    Gets the cardinality of the given object, returns a [`FIXNUM`][ceb9]
 
 <a id="x-28GEB-3ASO-CARD-ALG-20-28METHOD-20NIL-20-28GEB-2ESPEC-3A-3CSUBSTOBJ-3E-29-29-29"></a>
 - [method] **SO-CARD-ALG** *(OBJ \<SUBSTOBJ\>)*
@@ -1424,12 +1501,12 @@ Various utility functions ontop of [Core Category][cb9e]
 <a id="x-28GEB-3ADOM-20GENERIC-FUNCTION-29"></a>
 - [generic-function] **DOM** *SUBSTMORPH*
 
-    Grabs the domain of the morphism
+    Grabs the domain of the morphism. Returns a [`<SUBSTOBJ>`][8214]
 
 <a id="x-28GEB-3ACODOM-20GENERIC-FUNCTION-29"></a>
 - [generic-function] **CODOM** *SUBSTMORPH*
 
-    Grabs the codomain of the morphism
+    Grabs the codomain of the morphism. Returns a [`<SUBSTOBJ>`][8214]
 
 <a id="x-28GEB-3ACURRY-20GENERIC-FUNCTION-29"></a>
 - [generic-function] **CURRY** *F*
@@ -1942,6 +2019,7 @@ features and how to better lay out future tests
   [8bf3]: #x-28GEB-2EPOLY-2ESPEC-3APOLY-20TYPE-29 "GEB.POLY.SPEC:POLY TYPE"
   [8c99]: http://www.lispworks.com/documentation/HyperSpec/Body/f_car_c.htm "CAR FUNCTION"
   [8da6]: #x-28GEB-2EUTILS-3APREDICATE-20GENERIC-FUNCTION-29 "GEB.UTILS:PREDICATE GENERIC-FUNCTION"
+  [8eb0]: #x-28GEB-2EENTRY-3A-40GEB-ENTRY-20MGL-PAX-3ASECTION-29 "Geb as a binary"
   [8fa5]: #x-28GEB-DOCS-2FDOCS-3A-40INSTALLATION-20MGL-PAX-3ASECTION-29 "installation"
   [9162]: #x-28GEB-2EPOLY-2ESPEC-3ACOMPOSE-20TYPE-29 "GEB.POLY.SPEC:COMPOSE TYPE"
   [925b]: #x-28GEB-DOCS-2FDOCS-3A-40POLY-SETS-20MGL-PAX-3ASECTION-29 "Poly in Sets"
@@ -1983,6 +2061,7 @@ features and how to better lay out future tests
   [cc51]: #x-28GEB-2EUTILS-3A-40GEB-ACCESSORS-20MGL-PAX-3ASECTION-29 "Accessors"
   [cc87]: #x-28GEB-2EUTILS-3AMCADR-20GENERIC-FUNCTION-29 "GEB.UTILS:MCADR GENERIC-FUNCTION"
   [cd11]: #x-28GEB-2ESPEC-3AMCASE-20FUNCTION-29 "GEB.SPEC:MCASE FUNCTION"
+  [ceb9]: http://www.lispworks.com/documentation/HyperSpec/Body/t_fixnum.htm "FIXNUM TYPE"
   [d2d1]: #x-28GEB-2ESPEC-3A-40GEB-SUBSTMORPH-20MGL-PAX-3ASECTION-29 "Subst Morph"
   [d5d3]: #x-28GEB-2EMIXINS-3A-40POINTWISE-20MGL-PAX-3ASECTION-29 "Pointwise Mixins"
   [d908]: http://www.lispworks.com/documentation/HyperSpec/Body/f_typep.htm "TYPEP FUNCTION"
@@ -1998,6 +2077,7 @@ features and how to better lay out future tests
   [f1e6]: #x-28GEB-2EUTILS-3AOBJ-20GENERIC-FUNCTION-29 "GEB.UTILS:OBJ GENERIC-FUNCTION"
   [f4ba]: #x-28GEB-2ESPEC-3ASO1-20MGL-PAX-3ASYMBOL-MACRO-29 "GEB.SPEC:SO1 MGL-PAX:SYMBOL-MACRO"
   [f5ac]: #x-28GEB-2EPOLY-2ESPEC-3A-40POLY-MANUAL-20MGL-PAX-3ASECTION-29 "Polynomial Specification"
+  [f766]: http://www.lispworks.com/documentation/HyperSpec/Body/f_load.htm "LOAD FUNCTION"
   [f899]: #x-28GEB-2ESPEC-3AINIT-20TYPE-29 "GEB.SPEC:INIT TYPE"
   [f914]: #x-28GEB-2ESPEC-3ACOMP-20TYPE-29 "GEB.SPEC:COMP TYPE"
   [fae9]: #x-28GEB-2ESPEC-3AINJECT-RIGHT-20TYPE-29 "GEB.SPEC:INJECT-RIGHT TYPE"

--- a/docs/documentation.lisp
+++ b/docs/documentation.lisp
@@ -75,7 +75,8 @@ hello [foo](1-foo)
 (pax:defsection @getting-started (:title "Getting Started")
   "Welcome to the GEB Project!"
   (@installation pax:section)
-  (@loading pax:section))
+  (@loading pax:section)
+  (@geb-entry pax:section))
 
 (pax:defsection @original-efforts (:title "Original Efforts")
   "Originally GEB started off as an Idris codebase written by the

--- a/docs/package.lisp
+++ b/docs/package.lisp
@@ -6,4 +6,5 @@
   (:import-from #:geb-test   #:@geb-test-manual)
   (:import-from #:geb.poly   #:@poly-manual)
   (:import-from #:geb.specs  #:@geb-specs)
+  (:import-from #:geb.entry  #:@geb-entry)
   (:export build-docs))

--- a/geb.asd
+++ b/geb.asd
@@ -3,9 +3,13 @@
                        ;; wed are only importing this for now until I
                        ;; give good instructions to update the asdf of sbcl
                        :cl-reexport
-                       :mgl-pax)
+                       :mgl-pax
+                       :command-line-arguments)
   :version "0.0.1"
   :description "Gödel, Escher, Bach, a categorical view of computation"
+  :build-pathname "../build/geb.image"
+  :entry-point "geb.entry::entry"
+  :build-operation "program-op"
   :author "Mariari"
   :license "MIT"
   :pathname "src/"
@@ -60,7 +64,13 @@
     :description "A simple Lambda calculus model"
     :components ((:file package)
                  (:file lambda)
-                 (:file lambda-conversion))))
+                 (:file lambda-conversion)))
+   (:module entry
+    :serial t
+    :description "Entry point for the geb codebase"
+    :depends-on (util geb vampir specs poly lambda)
+    :components ((:file package)
+                 (:file entry))))
   :in-order-to ((asdf:test-op (asdf:test-op :geb/test))))
 
 (asdf:defsystem :geb/gui
@@ -83,6 +93,7 @@
    (:file lambda)
    (:file lambda-conversion)
    (:file poly)
+   (:file pipeline)
    (:file run-tests))
   :perform (asdf:test-op (o s)
                          (uiop:symbol-call :geb-test :run-tests)))
@@ -105,3 +116,10 @@
              (ql:quickload :geb/documentation))
       (progn (asdf:load-system :mgl-pax/navigate)
              (asdf:load-system :geb/documentation))))
+
+(defun make-system ()
+  (handler-case (asdf:load-system :geb)
+    (error (c)
+      (declare (ignorable c))
+      (ql:quickload :geb)))
+  (asdf:make :geb))

--- a/src/entry/entry.lisp
+++ b/src/entry/entry.lisp
@@ -1,0 +1,92 @@
+(in-package :geb.entry)
+
+(defparameter +command-line-spec+
+  '((("input" #\i)
+     :type string :documentation "Input geb file location")
+    (("entry-point" #\e)
+     :type string :documentation "The function to run, should be fully qualified I.E. geb::my-main")
+    (("stlc" #\l)
+     :type boolean :optional t :documentation "Use the simply typed lambda calculus frontend")
+    (("output" #\o)
+     :type string :optional t :documentation "Save the output to a file rather than printing")
+    (("vampir" #\v)
+     :type string :optional t :documentation "Return a vamp-ir expression")
+    (("help" #\h #\?)
+     :type boolean :optional t :documentation "The current help message")))
+
+(defun entry ()
+  (setf uiop:*command-line-arguments* (uiop:command-line-arguments))
+  (command-line-arguments:handle-command-line
+   +command-line-spec+
+   #'argument-handlers
+   :name "geb"))
+
+(defun argument-handlers (&key help stlc output input entry-point vampir)
+  (flet ((run (stream)
+           (cond (help
+                  (command-line-arguments:show-option-help +command-line-spec+
+                                                           :sort-names t))
+                 (t
+                  (load input)
+                  (compile-down :vampir vampir
+                                :stlc stlc
+                                :entry entry-point
+                                :stream stream)))))
+    (if output
+        (with-open-file (file output :direction :output
+                                     :if-exists :overwrite
+                                     :if-does-not-exist :create)
+          (run file))
+        (run *standard-output*))))
+
+
+
+;; this code is very bad please abstract out many of the components
+(defun compile-down (&key vampir stlc entry (stream *standard-output*))
+  (let* ((name        (read-from-string entry))
+         (eval        (eval name))
+         (vampir-name (renaming-scheme (intern (symbol-name name) 'keyword))))
+    (cond ((and vampir stlc)
+           (geb.vampir:extract
+            (list
+             (stlc-to-vampir nil
+                             (lambda:typed-stlc-type eval)
+                             (lambda:typed-stlc-value eval)
+                             vampir-name))
+            stream))
+          (stlc
+           (format stream
+                   (stlc-to-morph nil
+                                  (lambda:typed-stlc-type eval)
+                                  (lambda:typed-stlc-value eval))))
+          (vampir
+           (geb.vampir:extract (list (morph-to-vampir eval vampir-name))))
+          (t
+           (format stream eval)))))
+
+;; Very bad of me, copying alucard code, please move elsewhere as
+;; well!!
+
+(-> renaming-scheme (symbol) keyword)
+(defun renaming-scheme (symb)
+  "Renames certain names to be valid for vampir"
+  ;; the n here mutates a once only list, so no mutation at all!
+  ;; at least after the first substitute
+  (intern
+   (~>> symb symbol-name
+        (substitute #\_ #\-)
+        (nsubstitute #\V #\&)
+        (nsubstitute #\V #\%))
+   :keyword))
+
+;; Very bad of me, please move this to a proper pipeline and properly
+;; set it up
+
+(defun morph-to-vampir (morph name)
+  (poly::to-circuit (geb:to-poly morph) name))
+
+(defun stlc-to-morph (ctx ty term)
+  (conversion:compile-checked-term ctx ty term))
+
+(defun stlc-to-vampir (ctx ty term name)
+  (morph-to-vampir (stlc-to-morph ctx ty term) name))

--- a/src/entry/package.lisp
+++ b/src/entry/package.lisp
@@ -1,0 +1,76 @@
+(in-package :geb.utils)
+
+(muffle-package-variance
+ (defpackage #:geb.entry
+   (:documentation "Entry point for the geb codebase")
+   (:local-nicknames  (#:poly #:geb.poly)
+                      (:conversion :geb.lambda-conversion)
+                      (:lambda     :geb.lambda.spec))
+   (:use #:serapeum #:common-lisp)))
+
+
+(in-package :geb.entry)
+
+(pax:defsection @geb-entry (:title "Geb as a binary")
+  "The standard way to use geb currently is by loading the code into
+one's lisp environment
+
+```lisp
+(ql:quickload :geb)
+```
+
+However, one may be interested in running geb in some sort of
+compilation process, that is why we also give out a binary for people
+to use
+
+An example use of this binary is as follows
+
+```bash
+mariari@Gensokyo % ./geb.image -i \"foo.lisp\" -e \"geb.lambda.spec::*entry*\" -l -v -o \"foo.pir\"
+
+mariari@Gensokyo % cat foo.pir
+def *entry* x {
+  0
+}%
+mariari@Gensokyo % ./geb.image -i \"foo.lisp\" -e \"geb.lambda.spec::*entry*\" -l -v
+def *entry* x {
+  0
+}
+
+./geb.image -h
+  -i --input                      string   Input geb file location
+  -e --entry-point                string   The function to run, should be fully qualified I.E.
+                                           geb::my-main
+  -l --stlc                       boolean  Use the simply typed lambda calculus frontend
+  -o --output                     string   Save the output to a file rather than printing
+  -v --vampir                     string   Return a vamp-ir expression
+  -h -? --help                    boolean  The current help message
+
+```
+
+starting from a file *foo.lisp* that has
+
+```lisp
+(in-package :geb.lambda.spec)
+
+(defparameter *entry*
+  (typed unit geb:so1))
+```
+
+inside of it.
+
+The command needs an entry-point (-e or --entry-point), as we are
+simply call LOAD on the given file, and need to know what to
+translate.
+
+from STLC, we expect the form to be wrapped in the
+GEB.LAMBDA.SPEC.TYPED which takes both the type and the value to
+properly have enough context to evaluate.
+
+It is advised to bind this to a parameter like in our example as -e
+expects a symbol.
+
+the -l flag means that we are not expecting a geb term, but rather a
+lambda frontend term, this is to simply notify us to compile it as a
+lambda term rather than a geb term. In time this will go away"
+  (compile-down pax:function))

--- a/src/lambda/lambda-conversion.lisp
+++ b/src/lambda/lambda-conversion.lisp
@@ -7,7 +7,6 @@
 (defgeneric compile-checked-term (context type term)
   (:documentation "Compiles a checked term into SubstMorph category"))
 
-
 (defmethod empty ((class (eql (find-class 'list)))) nil)
 
 (defmethod compile-checked-term (context type (term <stlc>))

--- a/src/specs/lambda.lisp
+++ b/src/specs/lambda.lisp
@@ -18,3 +18,11 @@
   (lamb (vty geb.spec:substmorph) (tty geb.spec:substmorph) (value t))
   (app  (dom geb.spec:substmorph) (cod geb.spec:substmorph) (func t) (obj t))
   (index (index fixnum)))
+
+
+(defstruct-read-only typed-stlc
+  (value unit :type <stlc>)
+  (type t :type t))
+
+(defun typed (v typ)
+  (make-typed-stlc :value v :type typ))

--- a/src/specs/package.lisp
+++ b/src/specs/package.lisp
@@ -26,7 +26,9 @@
     :snd  :snd-lty  :snd-rty  :snd-value
     :lamb :lamb-vty :lamb-tty :lamb-value
     :app  :app-dom  :app-cod  :app-func :app-bj
-    :index :index-index)))
+    :index :index-index
+
+    :typed :typed-stlc-type :typed-stlc-value)))
 
 (pax:define-package #:geb.spec
   (:documentation "Gödel, Escher, Bach categorical model")

--- a/test/pipeline.lisp
+++ b/test/pipeline.lisp
@@ -1,0 +1,14 @@
+(in-package :geb-test)
+
+(define-test geb-pipeline :parent geb-test-suite)
+
+(def test-compilation-eval-2
+  (geb.lambda.spec:typed geb.lambda.spec:unit geb:so1))
+
+
+(define-test pipeline-works-for-stlc-to-vampir
+  :parent geb-pipeline
+  (parachute:finish
+   (geb.entry:compile-down :vampir t
+                           :stlc t
+                           :entry "geb-test::test-compilation-eval-2")))


### PR DESCRIPTION
This gives geb a dirty entry point to building the project and using it in a batch compilation mode.

The standard way should still be using it like a CL library that loads