### PR TITLE
Create an Implicit piplein

### DIFF
--- a/README
+++ b/README
@@ -1266,6 +1266,10 @@ into other categorical data structures.
 
     Turns a @GEB-SUBSTMORPH into a POLY:POLY
 
+- [function] TO-CIRCUIT OBJ NAME
+
+    Turns a @GEB-SUBSTMORPH to a Vamp-IR Term
+
 #### Utility
 
 ###### \[in package GEB.MAIN\]
@@ -1474,6 +1478,19 @@ Every accessor for each of the CLASS's found here are from @GEB-ACCESSORS
 
     Checks if the MCAR is less than the MCADR and chooses the appropriate branch
 
+### Polynomial Transformations
+
+###### \[in package GEB.POLY.TRANS\]
+This covers transformation functions from
+
+- [generic-function] TO-VAMPIR MORPHISM VALUE
+
+    Turns a POLY term into a Vamp-IR term with a given value
+
+- [function] TO-CIRCUIT MORPHISM NAME
+
+    Turns a POLY term into a Vamp-IR Gate with the given name
+
 ## The Simply Typed Lambda Calculus model
 
 ###### \[in package GEB.LAMBDA\]
@@ -1608,6 +1625,10 @@ data types
 - [generic-function] COMPILE-CHECKED-TERM CONTEXT TYPE TERM
 
     Compiles a checked term into SubstMorph category
+
+- [function] TO-POLY CONTEXT TYPE OBJ
+
+- [function] TO-CIRCUIT CONTEXT TYPE OBJ NAME
 
 #### Utility Functionality
 

--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@
 - [8 Polynomial Specification][94a8]
     - [8.1 Polynomial Types][bd81]
     - [8.2 Polynomial Constructors][b76d]
+    - [8.3 Polynomial Transformations][0f3e]
 - [9 The Simply Typed Lambda Calculus model][db8f]
     - [9.1 Lambda Specification][34d0]
     - [9.2 Main functionality][d2d5]
@@ -1420,6 +1421,11 @@ into other categorical data structures.
 
     Turns a [Subst Morph][d2d1] into a [`POLY:POLY`][8bf3]
 
+<a id="x-28GEB-2ETRANS-3ATO-CIRCUIT-20FUNCTION-29"></a>
+- [function] **TO-CIRCUIT** *OBJ NAME*
+
+    Turns a [Subst Morph][d2d1] to a Vamp-IR Term
+
 <a id="x-28GEB-2EMAIN-3A-40GEB-UTILITY-20MGL-PAX-3ASECTION-29"></a>
 #### 7.4.3 Utility
 
@@ -1666,6 +1672,22 @@ Every accessor for each of the [`CLASS`][7e58]'s found here are from [Accessors]
 
     Checks if the [`MCAR`][f1ce] is less than the [`MCADR`][cc87] and chooses the appropriate branch
 
+<a id="x-28GEB-2EPOLY-2ETRANS-3A-40POLY-TRANS-20MGL-PAX-3ASECTION-29"></a>
+### 8.3 Polynomial Transformations
+
+###### \[in package GEB.POLY.TRANS\]
+This covers transformation functions from
+
+<a id="x-28GEB-2EPOLY-2ETRANS-3ATO-VAMPIR-20GENERIC-FUNCTION-29"></a>
+- [generic-function] **TO-VAMPIR** *MORPHISM VALUE*
+
+    Turns a [`POLY`][8bf3] term into a Vamp-IR term with a given value
+
+<a id="x-28GEB-2EPOLY-2ETRANS-3ATO-CIRCUIT-20FUNCTION-29"></a>
+- [function] **TO-CIRCUIT** *MORPHISM NAME*
+
+    Turns a [`POLY`][8bf3] term into a Vamp-IR Gate with the given name
+
 <a id="x-28GEB-2ELAMBDA-3A-40STLC-20MGL-PAX-3ASECTION-29"></a>
 ## 9 The Simply Typed Lambda Calculus model
 
@@ -1848,6 +1870,12 @@ data types
 - [generic-function] **COMPILE-CHECKED-TERM** *CONTEXT TYPE TERM*
 
     Compiles a checked term into SubstMorph category
+
+<a id="x-28GEB-2ELAMBDA-2ETRANS-3ATO-POLY-20FUNCTION-29"></a>
+- [function] **TO-POLY** *CONTEXT TYPE OBJ*
+
+<a id="x-28GEB-2ELAMBDA-2ETRANS-3ATO-CIRCUIT-20FUNCTION-29"></a>
+- [function] **TO-CIRCUIT** *CONTEXT TYPE OBJ NAME*
 
 <a id="x-28GEB-2ELAMBDA-2ETRANS-3A-40UTILITY-20MGL-PAX-3ASECTION-29"></a>
 #### 9.3.1 Utility Functionality
@@ -2176,6 +2204,7 @@ features and how to better lay out future tests
   [0dcc]: #x-28GEB-2ESPEC-3APROJECT-LEFT-20TYPE-29 "GEB.SPEC:PROJECT-LEFT TYPE"
   [0dfe]: #x-28GEB-2ESPEC-3A-3C-RIGHT-20FUNCTION-29 "GEB.SPEC:<-RIGHT FUNCTION"
   [0e00]: #x-28GEB-DOCS-2FDOCS-3A-40YONEDA-LEMMA-20MGL-PAX-3ASECTION-29 "The Yoneda Lemma"
+  [0f3e]: #x-28GEB-2EPOLY-2ETRANS-3A-40POLY-TRANS-20MGL-PAX-3ASECTION-29 "Polynomial Transformations"
   [1791]: http://www.lispworks.com/documentation/HyperSpec/Body/f_car_c.htm "CADDDR FUNCTION"
   [1f3a]: #x-28GEB-2ESPEC-3ASO0-20TYPE-29 "GEB.SPEC:SO0 TYPE"
   [2276]: #x-28GEB-2EUTILS-3ASUBCLASS-RESPONSIBILITY-20FUNCTION-29 "GEB.UTILS:SUBCLASS-RESPONSIBILITY FUNCTION"

--- a/geb.asd
+++ b/geb.asd
@@ -31,6 +31,30 @@
     :components ((:file package)
                  (:file spec)
                  (:file vampir)))
+   (:module geb
+    :serial t
+    :description "The Main Geb Module"
+    :depends-on (util specs)
+    :components ((:file package)
+                 (:file geb)
+                 (:file bool)))
+   (:module poly
+    :serial t
+    :description "Polynomial"
+    :depends-on (util geb vampir specs)
+    :components ((:file package)))
+   (:module lambda
+    :serial t
+    :depends-on (geb specs)
+    :description "A simple Lambda calculus model"
+    :components ((:file package)
+                 (:module experimental
+                  :serial t
+                  :description "Experimental lambda code"
+                  :components
+                  ((:file package)
+                   (:file lambda)))
+                 (:file lambda)))
    (:module specs
     :serial t
     :depends-on (util mixins)
@@ -44,33 +68,17 @@
                  ;; HACK: to make the package properly refer to the
                  ;; right symbols
                  (:file ../util/package)))
-   (:module geb
-    :serial t
-    :description "The Main Geb Module"
-    :depends-on (util specs)
-    :components ((:file package)
-                 (:file geb)
-                 (:file bool)
-                 (:file trans)))
-   (:module poly
-    :serial t
-    :description "Polynomial"
-    :depends-on (util geb vampir specs)
-    :components ((:file package)
-                 (:file trans)))
-   (:module lambda
-    :serial t
-    :depends-on (geb specs)
-    :description "A simple Lambda calculus model"
-    :components ((:file package)
-                 (:module experimental
-                  :serial t
-                  :description "Experimental lambda code"
-                  :components
-                  ((:file package)
-                   (:file lambda)))
-                 (:file lambda)
-                 (:file trans)))
+   ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+   ;; !IMPORTANT!
+   ;; All trans files go here, as they rely on other trans files
+   ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+   (:module trans
+    :description "All the trans modules so they can all know about the
+    other transformation functions before we compile them!"
+    :pathname "../src/"
+    :components ((:file lambda/trans)
+                 (:file geb/trans)
+                 (:file poly/trans)))
    (:module entry
     :serial t
     :description "Entry point for the geb codebase"

--- a/src/entry/entry.lisp
+++ b/src/entry/entry.lisp
@@ -39,8 +39,6 @@
           (run file))
         (run *standard-output*))))
 
-
-
 ;; this code is very bad please abstract out many of the components
 (defun compile-down (&key vampir stlc entry (stream *standard-output*))
   (let* ((name        (read-from-string entry))
@@ -49,19 +47,19 @@
     (cond ((and vampir stlc)
            (geb.vampir:extract
             (list
-             (stlc-to-vampir nil
-                             (lambda:typed-stlc-type eval)
-                             (lambda:typed-stlc-value eval)
-                             vampir-name))
+             (lambda:to-circuit nil
+                                (lambda:typed-stlc-type eval)
+                                (lambda:typed-stlc-value eval)
+                                vampir-name))
             stream))
           (stlc
            (format stream
                    "~A"
-                   (stlc-to-morph nil
-                                  (lambda:typed-stlc-type eval)
-                                  (lambda:typed-stlc-value eval))))
+                   (lambda:compile-checked-term nil
+                                                (lambda:typed-stlc-type eval)
+                                                (lambda:typed-stlc-value eval))))
           (vampir
-           (geb.vampir:extract (list (morph-to-vampir eval vampir-name))))
+           (geb.vampir:extract (list (geb:to-circuit eval vampir-name))))
           (t
            (format stream eval)))))
 
@@ -79,15 +77,3 @@
         (nsubstitute #\V #\&)
         (nsubstitute #\V #\%))
    :keyword))
-
-;; Very bad of me, please move this to a proper pipeline and properly
-;; set it up
-
-(defun morph-to-vampir (morph name)
-  (poly::to-circuit (geb:to-poly morph) name))
-
-(defun stlc-to-morph (ctx ty term)
-  (conversion:compile-checked-term ctx ty term))
-
-(defun stlc-to-vampir (ctx ty term name)
-  (morph-to-vampir (stlc-to-morph ctx ty term) name))

--- a/src/entry/package.lisp
+++ b/src/entry/package.lisp
@@ -4,8 +4,7 @@
  (defpackage #:geb.entry
    (:documentation "Entry point for the geb codebase")
    (:local-nicknames  (#:poly #:geb.poly)
-                      (:conversion :geb.lambda.trans)
-                      (:lambda     :geb.lambda.spec))
+                      (:lambda     :geb.lambda))
    (:use #:serapeum #:common-lisp)))
 
 

--- a/src/geb/package.lisp
+++ b/src/geb/package.lisp
@@ -45,7 +45,8 @@
 (pax:defsection @geb-translation (:title "Translation Functions")
   "These cover various conversions from @GEB-SUBSTMORPH and @GEB-SUBSTMU
 into other categorical data structures."
-  (to-poly pax:generic-function))
+  (to-poly    pax:generic-function)
+  (to-circuit pax:function))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;; bool module

--- a/src/geb/trans.lisp
+++ b/src/geb/trans.lisp
@@ -76,3 +76,9 @@
 
 (defun obj-to-nat (obj)
   (so-card-alg obj))
+
+(-> to-circuit (<substmorph> keyword) geb.vampir.spec:statement)
+(defun to-circuit (obj name)
+  "Turns a @GEB-SUBSTMORPH to a Vamp-IR Term"
+  (assure geb.vampir.spec:statement
+    (geb.poly:to-circuit (to-poly obj) name)))

--- a/src/lambda/package.lisp
+++ b/src/lambda/package.lisp
@@ -30,6 +30,7 @@
 (geb.utils:muffle-package-variance
  (uiop:define-package #:geb.lambda.trans
    (:documentation "A basic lambda translator into other parts of geb")
+   (:shadow #:to-poly #:to-circuit)
    #.(mix :geb.lambda.main)))
 
 (in-package #:geb.lambda.trans)
@@ -42,6 +43,8 @@
   "These functions deal with transforming the data structure to other
 data types"
   (compile-checked-term pax:generic-function)
+  (to-poly              pax:function)
+  (to-circuit           pax:function)
   (@utility             pax:section))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
@@ -54,6 +57,7 @@ data types"
    (:documentation "A basic lambda calculus model")
    #.(mix)
    ;; we also reexport lambda.trans see the documentation below
+   (:shadowing-import-from #:geb.lambda.trans :to-poly :to-circuit)
    (:use-reexport #:geb.lambda.spec #:geb.lambda.main #:geb.lambda.trans))
 
 (in-package #:geb.lambda)

--- a/src/lambda/trans.lisp
+++ b/src/lambda/trans.lisp
@@ -4,8 +4,25 @@
 
 (deftype stlc-context () `list)
 
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;; Main Transformers
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
 (defgeneric compile-checked-term (context type term)
   (:documentation "Compiles a checked term into SubstMorph category"))
+
+(-> to-poly (list t <stlc>) (or geb.poly:<poly> geb.poly:poly))
+(defun to-poly (context type obj)
+  (assure (or geb.poly:<poly> geb.poly:poly)
+    (~>> obj
+         (compile-checked-term context type)
+         geb:to-poly)))
+
+(-> to-circuit (list t <stlc> keyword) geb.vampir.spec:statement)
+(defun to-circuit (context type obj name)
+  (assure geb.vampir.spec:statement
+    (~> (to-poly context type obj)
+        (geb.poly:to-circuit name))))
 
 (defmethod empty ((class (eql (find-class 'list)))) nil)
 
@@ -58,6 +75,10 @@
 (defun stlc-ctx-to-mu (context)
   "Converts a generic [<STLC>][type] context into a [SUBSTMORPH][type]"
   (mvfoldr #'prod context so1))
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;; Utility Functions
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (defun stlc-ctx-proj (context depth)
   (if (zerop depth)

--- a/src/poly/package.lisp
+++ b/src/poly/package.lisp
@@ -1,16 +1,37 @@
 (in-package :geb.utils)
 
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;; trans module
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
 (muffle-package-variance
- (defpackage #:geb.poly
+ (defpackage #:geb.poly.trans
    (:local-nicknames (:vamp :geb.vampir.spec))
    (:use #:geb.utils #:geb.poly.spec #:cl #:serapeum)
    (:shadowing-import-from #:geb.poly.spec :+ :* :/ :- :mod)))
 
+(in-package :geb.poly.trans)
+
+(pax:defsection @poly-trans (:title "Polynomial Transformations")
+  "This covers transformation functions from"
+  (to-vampir  pax:generic-function)
+  (to-circuit pax:function))
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;; poly module
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(geb.utils:muffle-package-variance
+ (uiop:define-package #:geb.poly
+   (:use #:geb.utils #:cl #:serapeum)
+   (:shadowing-import-from #:geb.poly.spec :+ :* :/ :- :mod)
+   (:use-reexport #:geb.poly.trans #:geb.poly.spec)))
+
 (in-package :geb.poly)
-(cl-reexport:reexport-from :geb.poly.spec)
 
 (pax:defsection @poly-manual (:title "Polynomial Specification")
   "This covers a GEB view of Polynomials. In particular this type will
 be used in translating GEB's view of Polynomials into Vampir"
   (@poly              pax:section)
-  (@poly-constructors pax:section))
+  (@poly-constructors pax:section)
+  (@poly-trans        pax:section))

--- a/src/poly/trans.lisp
+++ b/src/poly/trans.lisp
@@ -1,4 +1,4 @@
-(in-package :geb.poly)
+(in-package :geb.poly.trans)
 
 (defgeneric to-vampir (morphism value)
   (:documentation "Turns a POLY term into a Vamp-IR term with a given value"))

--- a/test/pipeline.lisp
+++ b/test/pipeline.lisp
@@ -3,12 +3,23 @@
 (define-test geb-pipeline :parent geb-test-suite)
 
 (def test-compilation-eval-2
-  (geb.lambda.spec:typed geb.lambda.spec:unit geb:so1))
+  (lambda:typed geb.lambda.spec:unit geb:so1))
 
+
+(defparameter *entry*
+  (lambda:typed
+   (lambda:app (coprod so1 so1)
+               (coprod so1 so1)
+               (lambda:lamb (coprod so1 so1) (coprod so1 so1) (lambda:index 0))
+               (lambda:left lambda:unit))
+   (coprod so1 so1)))
 
 (define-test pipeline-works-for-stlc-to-vampir
   :parent geb-pipeline
   (parachute:finish
    (geb.entry:compile-down :vampir t
                            :stlc t
-                           :entry "geb-test::test-compilation-eval-2")))
+                           :entry "geb-test::test-compilation-eval-2"))
+  (parachute:finish
+   (geb.entry:compile-down :stlc t
+                           :entry "geb-test::*entry*")))


### PR DESCRIPTION
This PR fixes up the mess created in #45  where the pipeline was implicitly defined in the `geb.entry` package

This entails

1. Making trans files load last
2. Making functions in the trans file that goes from the current stage, to any downstream stage


This means, that instead of an explicit, `PIPELINE` we instead have a function `to-circuit` which is the pipeline for any single stage.

This means things work much closer to how smalltalk works, and we can pause the compiler at any point, given we can just stop it before it gets to a stage. I still prefer the berlin pipeline, but this seems a promising route 