### PR TITLE
Fixup default pair function from lambda

### DIFF
--- a/src/lambda/package.lisp
+++ b/src/lambda/package.lisp
@@ -58,6 +58,7 @@ data types"
    #.(mix)
    ;; we also reexport lambda.trans see the documentation below
    (:shadowing-import-from #:geb.lambda.trans :to-poly :to-circuit)
+   (:shadowing-import-from #:geb.lambda.spec :pair)
    (:use-reexport #:geb.lambda.spec #:geb.lambda.main #:geb.lambda.trans))
 
 (in-package #:geb.lambda)


### PR DESCRIPTION
Previously it was taking geb's pair which took two arguments, now it's restored to the proper 4 argument version