### PR TITLE
Various STLC fixes

### DIFF
--- a/README
+++ b/README
@@ -1548,7 +1548,7 @@ The specification follows from the sum type declaration
 
 ```lisp
 (defunion stlc
-  (absurd (value t))
+  (absurd (cod geb.spec:substmorph) (value t))
   unit
   (left (value t))
   (right (value t))
@@ -1570,6 +1570,8 @@ The specification follows from the sum type declaration
 - [type] STLC
 
 - [type] ABSURD
+
+- [function] ABSURD-COD INSTANCE
 
 - [function] ABSURD-VALUE INSTANCE
 

--- a/README
+++ b/README
@@ -1690,6 +1690,10 @@ These are utility functions relating to translating lambda terms to other types
 
     Converts a generic <STLC> context into a SUBSTMORPH
 
+- [function] SO-HOM DOM COD
+
+    Computes the hom-object `DOM -> COD`
+
 ## Mixins
 
 ###### \[in package GEB.MIXINS\]

--- a/README
+++ b/README
@@ -1550,8 +1550,8 @@ The specification follows from the sum type declaration
 (defunion stlc
   (absurd (cod geb.spec:substmorph) (value t))
   unit
-  (left (value t))
-  (right (value t))
+  (left (lty geb.spec:substmorph) (rty geb.spec:substmorph) (value t))
+  (right (lty geb.spec:substmorph) (rty geb.spec:substmorph) (value t))
   (case-on (lty geb.spec:substmorph)
            (rty geb.spec:substmorph)
            (cod geb.spec:substmorph)
@@ -1589,9 +1589,17 @@ The specification follows from the sum type declaration
 
 - [type] LEFT
 
+- [function] LEFT-LTY INSTANCE
+
+- [function] LEFT-RTY INSTANCE
+
 - [function] LEFT-VALUE INSTANCE
 
 - [type] RIGHT
+
+- [function] RIGHT-LTY INSTANCE
+
+- [function] RIGHT-RTY INSTANCE
 
 - [function] RIGHT-VALUE INSTANCE
 

--- a/README.md
+++ b/README.md
@@ -1757,7 +1757,7 @@ The specification follows from the sum type declaration
 
 ```lisp
 (defunion stlc
-  (absurd (value t))
+  (absurd (cod geb.spec:substmorph) (value t))
   unit
   (left (value t))
   (right (value t))

--- a/README.md
+++ b/README.md
@@ -1759,8 +1759,8 @@ The specification follows from the sum type declaration
 (defunion stlc
   (absurd (cod geb.spec:substmorph) (value t))
   unit
-  (left (value t))
-  (right (value t))
+  (left (lty geb.spec:substmorph) (rty geb.spec:substmorph) (value t))
+  (right (lty geb.spec:substmorph) (rty geb.spec:substmorph) (value t))
   (case-on (lty geb.spec:substmorph)
            (rty geb.spec:substmorph)
            (cod geb.spec:substmorph)

--- a/geb-idris/src/LanguageDef/PolyCat.idr
+++ b/geb-idris/src/LanguageDef/PolyCat.idr
@@ -8732,8 +8732,10 @@ compileCheckedTerm {ctx} {ty=lty} (Checked_STLC_Fst {lty} {rty} p) =
 compileCheckedTerm {ctx} {ty=rty} (Checked_STLC_Snd {lty} {rty} p) =
   SMProjRight lty rty <! compileCheckedTerm {ctx} {ty=(lty !* rty)} p
 compileCheckedTerm
-  {ctx} {ty=(vty !-> tty)} (Checked_STLC_Lambda {vty} {tty} t) =
-    soCurry $ soProdCommutesLeft $ compileCheckedTerm t
+  {ctx} {ty=(vty !-> tty)} (Checked_STLC_Lambda {ctx} {vty} {tty} t) =
+    soCurry {x=(stlcCtxToSOMu ctx)} {y=vty} {z=tty} $
+    soProdCommutesLeft {x=vty} {y=(stlcCtxToSOMu ctx)} {z=tty} $
+    compileCheckedTerm {ctx=(vty :: ctx)} {ty=tty} t
 compileCheckedTerm {ctx} {ty=cod} (Checked_STLC_App {dom} {cod} f x) =
   soEval dom cod <! SMPair (compileCheckedTerm f) (compileCheckedTerm x)
 compileCheckedTerm

--- a/src/geb/geb.lisp
+++ b/src/geb/geb.lisp
@@ -257,8 +257,8 @@ In category terms, `a → c^b` is isomorphic to `a → b → c`
            (labels ((rec (fun fst snd)
                       (match-of substobj snd
                         (alias        (rec fun fst (obj snd)))
-                        (so0          (terminal snd))
-                        (so1          (comp fun (pair snd
+                        (so0          (terminal fst))
+                        (so1          (comp fun (pair fst
                                                       (terminal fst))))
                         ((coprod x y) (pair (curry (left (comp fun (gather fst x y))))
                                             (curry (right (comp fun (gather fst x y))))))

--- a/src/geb/package.lisp
+++ b/src/geb/package.lisp
@@ -22,6 +22,7 @@
   (commutes-left     pax:function)
   (!->               pax:function)
   (so-eval           pax:function)
+  (so-hom-obj        pax:function)
   (so-card-alg       pax:generic-function)
   (so-card-alg       (pax:method () (<substobj>)))
   (dom               pax:generic-function)

--- a/src/lambda/package.lisp
+++ b/src/lambda/package.lisp
@@ -37,7 +37,8 @@
 
 (pax:defsection @utility (:title "Utility Functionality")
   "These are utility functions relating to translating lambda terms to other types"
-  (stlc-ctx-to-mu  pax:function))
+  (stlc-ctx-to-mu  pax:function)
+  (so-hom  pax:function))
 
 (pax:defsection @stlc-conversion (:title "Transition Functions")
   "These functions deal with transforming the data structure to other

--- a/src/lambda/trans.lisp
+++ b/src/lambda/trans.lisp
@@ -60,7 +60,6 @@
        (comp (<-right lty rty) (compile-checked-term context (prod lty rty) value)))
       ((lamb vty tty term)
        (curry (commutes-left
-               ;; is this correct?
                (compile-checked-term (cons vty context) tty term))))
       ((app dom com f x)
        (assert (geb.mixins:obj-equalp dom type) nil "Types should match for application: ~A ~A" dom type)

--- a/src/lambda/trans.lisp
+++ b/src/lambda/trans.lisp
@@ -81,6 +81,11 @@
   "Converts a generic [<STLC>][type] context into a [SUBSTMORPH][type]"
   (mvfoldr #'prod context so1))
 
+(-> so-hom (substobj substobj) substobj)
+(defun so-hom (dom cod)
+  "Computes the hom-object of two [SUBSTMORPH]s"
+  (geb:so-hom-obj dom cod))
+
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Utility Functions
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;

--- a/src/lambda/trans.lisp
+++ b/src/lambda/trans.lisp
@@ -34,12 +34,18 @@
              (compile-checked-term context so0 v)))
       (unit
        (terminal (stlc-ctx-to-mu context)))
-      ((left term)
+      ((left lty rty term)
        (assert (typep type '(or alias coprod)) nil "invalid lambda type to left ~A" type)
+       ;; (assert
+           ;; (geb.mixins:obj-equalp (coprod lty rty) (class-of type))
+           ;; nil "Types should match for left ~A ~A ~A" lty rty type)
        (comp (->left (mcar type) (mcadr type))
              (compile-checked-term context (mcar type) term)))
-      ((right term)
+      ((right lty rty term)
        (assert (typep type '(or alias coprod)) nil "invalid lambda type to right ~A" type)
+       ;; (assert
+           ;; (geb.mixins:obj-equalp (coprod lty rty) (class-of type))
+           ;; nil "Types should match for right ~A ~A ~A" lty rty type)
        (comp (->right (mcar type) (mcadr type))
              (compile-checked-term context (mcar type) term)))
       ((case-on lty rty cod on l r)

--- a/src/lambda/trans.lisp
+++ b/src/lambda/trans.lisp
@@ -29,7 +29,7 @@
 (defmethod compile-checked-term (context type (term <stlc>))
   (assure <substmorph>
     (match-of stlc term
-      ((absurd v)
+      ((absurd type v)
        (comp (init type)
              (compile-checked-term context so0 v)))
       (unit

--- a/src/poly/trans.lisp
+++ b/src/poly/trans.lisp
@@ -89,4 +89,4 @@
 
 (defmethod to-vampir ((obj if-lt) value)
   (declare (ignore obj value))
-  (error "mod logic not in yet"))
+  (error "less-than logic not in yet"))

--- a/src/specs/lambda.lisp
+++ b/src/specs/lambda.lisp
@@ -6,8 +6,8 @@
 (defunion stlc
   (absurd (cod geb.spec:substmorph) (value t))
   unit
-  (left (value t))
-  (right (value t))
+  (left (lty geb.spec:substmorph) (rty geb.spec:substmorph) (value t))
+  (right (lty geb.spec:substmorph) (rty geb.spec:substmorph) (value t))
   (case-on (lty geb.spec:substmorph)
            (rty geb.spec:substmorph)
            (cod geb.spec:substmorph)

--- a/src/specs/lambda.lisp
+++ b/src/specs/lambda.lisp
@@ -4,7 +4,7 @@
 ;; class declaration. We avoid typing it as we don't actually want to
 ;; be exhaustive, but rather open.
 (defunion stlc
-  (absurd (value t))
+  (absurd (cod geb.spec:substmorph) (value t))
   unit
   (left (value t))
   (right (value t))

--- a/test/lambda-conversion.lisp
+++ b/test/lambda-conversion.lisp
@@ -5,6 +5,9 @@
 
 (def bool geb-bool:bool)
 
+(def so-void-type
+  geb:so0)
+
 (def so-unit-type
   geb:so1)
 
@@ -47,6 +50,11 @@
 
 (def unit-to-unit-circuit
   (lambda:to-circuit nil so-unit-type stlc-unit-term :tc_unit_to_unit))
+
+(def void-to-unit-circuit
+  (lambda:to-circuit
+    (list so-void-type) so-unit-type
+    (lambda:absurd so-unit-type (lambda:index 0)) :tc_void_to_unit))
 
 (def issue-58-circuit
   (lambda:to-circuit
@@ -98,6 +106,10 @@
 (define-test vampir-test-unit-to-unit
   :parent geb.lambda.trans
   (of-type geb.vampir.spec:alias unit-to-unit-circuit))
+
+(define-test vampir-test-void-to-unit
+  :parent geb.lambda.trans
+  (of-type geb.vampir.spec:alias void-to-unit-circuit))
 
 (define-test vampir-test-unit-to-bool-left
   :parent geb.lambda.trans

--- a/test/lambda-conversion.lisp
+++ b/test/lambda-conversion.lisp
@@ -103,6 +103,12 @@
       (geb:prod geb-bool:bool (geb:prod geb:so0 (geb:prod geb:so1 geb:so1)))
       "fold multi-object context"))
 
+(define-test so-hom-so1-so1 :parent compile-checked-term
+  (is equalp
+      (lambda:so-hom geb:so1 geb:so1)
+      geb:so1
+      "compute hom(so1,so1)"))
+
 (define-test vampir-test-unit-to-unit
   :parent geb.lambda.trans
   (of-type geb.vampir.spec:alias unit-to-unit-circuit))

--- a/test/lambda-conversion.lisp
+++ b/test/lambda-conversion.lisp
@@ -20,26 +20,26 @@
 (def unit-to-bool-left-circuit
   (lambda:to-circuit
     nil bool
-    (lambda:left stlc-unit-term)
+    (lambda:left so-unit-type so-unit-type stlc-unit-term)
     :tc_unit_to_bool_left))
 
 (def unit-to-bool-right-circuit
   (lambda:to-circuit
     nil bool
-    (lambda:right stlc-unit-term)
+    (lambda:right so-unit-type so-unit-type stlc-unit-term)
     :tc_unit_to_bool_right))
 
 (def pair-bool-stlc
   (lambda:pair bool bool
-               (lambda:right stlc-unit-term)
-               (lambda:left stlc-unit-term)))
+               (lambda:right so-unit-type so-unit-type stlc-unit-term)
+               (lambda:left so-unit-type so-unit-type stlc-unit-term)))
 
 (def pair-bool-circuit
   (lambda:to-circuit
    nil (geb:prod bool bool)
    (lambda:pair bool bool
-                (lambda:right stlc-unit-term)
-                (lambda:left stlc-unit-term))
+                (lambda:right so-unit-type so-unit-type stlc-unit-term)
+                (lambda:left so-unit-type so-unit-type stlc-unit-term))
    :tc_pair_bool))
 
 (def fst-bool-circuit
@@ -63,13 +63,13 @@
     (lambda:case-on
       so-unit-type so-unit-type
       (coprod so-unit-type so-unit-type)
-      (lambda:left stlc-unit-term)
+      (lambda:left so-unit-type so-unit-type stlc-unit-term)
       (lambda:lamb
         so-unit-type (coprod so-unit-type so-unit-type)
-        (lambda:right stlc-unit-term))
+        (lambda:right so-unit-type so-unit-type stlc-unit-term))
       (lambda:lamb
         so-unit-type (coprod so-unit-type so-unit-type)
-        (lambda:left stlc-unit-term))
+        (lambda:left so-unit-type so-unit-type stlc-unit-term))
       )
     :tc_issue_58))
 

--- a/test/lambda-conversion.lisp
+++ b/test/lambda-conversion.lisp
@@ -48,6 +48,23 @@
 (def unit-to-unit-circuit
   (lambda:to-circuit nil so-unit-type stlc-unit-term :tc_unit_to_unit))
 
+(def issue-58-circuit
+  (lambda:to-circuit
+    nil
+    (coprod so-unit-type so-unit-type)
+    (lambda:case-on
+      so-unit-type so-unit-type
+      (coprod so-unit-type so-unit-type)
+      (lambda:left stlc-unit-term)
+      (lambda:lamb
+        so-unit-type (coprod so-unit-type so-unit-type)
+        (lambda:right stlc-unit-term))
+      (lambda:lamb
+        so-unit-type (coprod so-unit-type so-unit-type)
+        (lambda:left stlc-unit-term))
+      )
+    :tc_issue_58))
+
 (define-test compile-checked-term :parent geb.lambda.trans
   (is obj-equalp
       (lambda:compile-checked-term nil so-unit-type stlc-unit-term)
@@ -93,3 +110,7 @@
 (define-test vampir-test-pair-bool
   :parent geb.lambda.trans
   (of-type geb.vampir.spec:alias pair-bool-circuit))
+
+(define-test vampir-test-issue-58
+  :parent geb.lambda.trans
+  (of-type geb.vampir.spec:alias issue-58-circuit))

--- a/test/pipeline.lisp
+++ b/test/pipeline.lisp
@@ -11,7 +11,7 @@
    (lambda:app (coprod so1 so1)
                (coprod so1 so1)
                (lambda:lamb (coprod so1 so1) (coprod so1 so1) (lambda:index 0))
-               (lambda:left lambda:unit))
+               (lambda:left (coprod so1 so1) (coprod so1 so1) lambda:unit))
    (coprod so1 so1)))
 
 (define-test pipeline-works-for-stlc-to-vampir


### PR DESCRIPTION
I'm making this pull request a draft because we want to either break it up into several new PRs or integrate bits of it with existing PRs or something.  But I am creating the PR because I can't figure out how to test the code without CI; `asdf` doesn't seem to run newly-written tests no matter what I do (including deleting a bunch of files), at least for some unpredictable period of time; it eventually happens for reasons that I don't understand any more than I understand the reasons that it doesn't happen right away.

The contents of the PR:

- Convert some type parameters in the Idris-2 code for `lambda` from implicit to explicit, to make comparing the Lisp code to it easier
- Add a test for #58 
- Try to fix #58 by fixing a couple of parameters to morphism constructors in the `so0` and `so1` cases of `curry` that were using the wrong arguments
- Add the codomain type to the spec for the `absurd` STLC term (see comment https://github.com/anoma/geb/issues/53#issuecomment-1421093312 to #53)
- Add the left and right components of the codomain to the spec for the `left` and `right` STLC terms for #53 
- Add an external API for computing hom-objects for #60 