### PR TITLE
Ignore image build directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@
 *.*fsl
 *.*fas
 .vscode
+build/


### PR DESCRIPTION
Ignore the `build` directory generated by the Geb image build.