### PR TITLE
Add type information to several STLC terms

### DIFF
--- a/README
+++ b/README
@@ -1548,7 +1548,7 @@ The specification follows from the sum type declaration
 
 ```lisp
 (defunion stlc
-  (absurd (value t))
+  (absurd (cod geb.spec:substmorph) (value t))
   unit
   (left (value t))
   (right (value t))
@@ -1570,6 +1570,8 @@ The specification follows from the sum type declaration
 - [type] STLC
 
 - [type] ABSURD
+
+- [function] ABSURD-COD INSTANCE
 
 - [function] ABSURD-VALUE INSTANCE
 

--- a/README
+++ b/README
@@ -1550,8 +1550,8 @@ The specification follows from the sum type declaration
 (defunion stlc
   (absurd (cod geb.spec:substmorph) (value t))
   unit
-  (left (value t))
-  (right (value t))
+  (left (lty geb.spec:substmorph) (rty geb.spec:substmorph) (value t))
+  (right (lty geb.spec:substmorph) (rty geb.spec:substmorph) (value t))
   (case-on (lty geb.spec:substmorph)
            (rty geb.spec:substmorph)
            (cod geb.spec:substmorph)
@@ -1589,9 +1589,17 @@ The specification follows from the sum type declaration
 
 - [type] LEFT
 
+- [function] LEFT-LTY INSTANCE
+
+- [function] LEFT-RTY INSTANCE
+
 - [function] LEFT-VALUE INSTANCE
 
 - [type] RIGHT
+
+- [function] RIGHT-LTY INSTANCE
+
+- [function] RIGHT-RTY INSTANCE
 
 - [function] RIGHT-VALUE INSTANCE
 

--- a/README.md
+++ b/README.md
@@ -1757,7 +1757,7 @@ The specification follows from the sum type declaration
 
 ```lisp
 (defunion stlc
-  (absurd (value t))
+  (absurd (cod geb.spec:substmorph) (value t))
   unit
   (left (value t))
   (right (value t))

--- a/README.md
+++ b/README.md
@@ -1759,8 +1759,8 @@ The specification follows from the sum type declaration
 (defunion stlc
   (absurd (cod geb.spec:substmorph) (value t))
   unit
-  (left (value t))
-  (right (value t))
+  (left (lty geb.spec:substmorph) (rty geb.spec:substmorph) (value t))
+  (right (lty geb.spec:substmorph) (rty geb.spec:substmorph) (value t))
   (case-on (lty geb.spec:substmorph)
            (rty geb.spec:substmorph)
            (cod geb.spec:substmorph)

--- a/src/lambda/trans.lisp
+++ b/src/lambda/trans.lisp
@@ -34,12 +34,18 @@
              (compile-checked-term context so0 v)))
       (unit
        (terminal (stlc-ctx-to-mu context)))
-      ((left term)
+      ((left lty rty term)
        (assert (typep type '(or alias coprod)) nil "invalid lambda type to left ~A" type)
+       ;; (assert
+           ;; (geb.mixins:obj-equalp (coprod lty rty) (class-of type))
+           ;; nil "Types should match for left ~A ~A ~A" lty rty type)
        (comp (->left (mcar type) (mcadr type))
              (compile-checked-term context (mcar type) term)))
-      ((right term)
+      ((right lty rty term)
        (assert (typep type '(or alias coprod)) nil "invalid lambda type to right ~A" type)
+       ;; (assert
+           ;; (geb.mixins:obj-equalp (coprod lty rty) (class-of type))
+           ;; nil "Types should match for right ~A ~A ~A" lty rty type)
        (comp (->right (mcar type) (mcadr type))
              (compile-checked-term context (mcar type) term)))
       ((case-on lty rty cod on l r)

--- a/src/lambda/trans.lisp
+++ b/src/lambda/trans.lisp
@@ -29,7 +29,7 @@
 (defmethod compile-checked-term (context type (term <stlc>))
   (assure <substmorph>
     (match-of stlc term
-      ((absurd v)
+      ((absurd type v)
        (comp (init type)
              (compile-checked-term context so0 v)))
       (unit

--- a/src/specs/lambda.lisp
+++ b/src/specs/lambda.lisp
@@ -6,8 +6,8 @@
 (defunion stlc
   (absurd (cod geb.spec:substmorph) (value t))
   unit
-  (left (value t))
-  (right (value t))
+  (left (lty geb.spec:substmorph) (rty geb.spec:substmorph) (value t))
+  (right (lty geb.spec:substmorph) (rty geb.spec:substmorph) (value t))
   (case-on (lty geb.spec:substmorph)
            (rty geb.spec:substmorph)
            (cod geb.spec:substmorph)

--- a/src/specs/lambda.lisp
+++ b/src/specs/lambda.lisp
@@ -4,7 +4,7 @@
 ;; class declaration. We avoid typing it as we don't actually want to
 ;; be exhaustive, but rather open.
 (defunion stlc
-  (absurd (value t))
+  (absurd (cod geb.spec:substmorph) (value t))
   unit
   (left (value t))
   (right (value t))

--- a/test/lambda-conversion.lisp
+++ b/test/lambda-conversion.lisp
@@ -5,6 +5,9 @@
 
 (def bool geb-bool:bool)
 
+(def so-void-type
+  geb:so0)
+
 (def so-unit-type
   geb:so1)
 
@@ -47,6 +50,11 @@
 
 (def unit-to-unit-circuit
   (lambda:to-circuit nil so-unit-type stlc-unit-term :tc_unit_to_unit))
+
+(def void-to-unit-circuit
+  (lambda:to-circuit
+    (list so-void-type) so-unit-type
+    (lambda:absurd so-unit-type (lambda:index 0)) :tc_void_to_unit))
 
 (def issue-58-circuit
   (lambda:to-circuit
@@ -98,6 +106,10 @@
 (define-test vampir-test-unit-to-unit
   :parent geb.lambda.trans
   (of-type geb.vampir.spec:alias unit-to-unit-circuit))
+
+(define-test vampir-test-void-to-unit
+  :parent geb.lambda.trans
+  (of-type geb.vampir.spec:alias void-to-unit-circuit))
 
 (define-test vampir-test-unit-to-bool-left
   :parent geb.lambda.trans

--- a/test/lambda-conversion.lisp
+++ b/test/lambda-conversion.lisp
@@ -20,26 +20,26 @@
 (def unit-to-bool-left-circuit
   (lambda:to-circuit
     nil bool
-    (lambda:left stlc-unit-term)
+    (lambda:left so-unit-type so-unit-type stlc-unit-term)
     :tc_unit_to_bool_left))
 
 (def unit-to-bool-right-circuit
   (lambda:to-circuit
     nil bool
-    (lambda:right stlc-unit-term)
+    (lambda:right so-unit-type so-unit-type stlc-unit-term)
     :tc_unit_to_bool_right))
 
 (def pair-bool-stlc
   (lambda:pair bool bool
-               (lambda:right stlc-unit-term)
-               (lambda:left stlc-unit-term)))
+               (lambda:right so-unit-type so-unit-type stlc-unit-term)
+               (lambda:left so-unit-type so-unit-type stlc-unit-term)))
 
 (def pair-bool-circuit
   (lambda:to-circuit
    nil (geb:prod bool bool)
    (lambda:pair bool bool
-                (lambda:right stlc-unit-term)
-                (lambda:left stlc-unit-term))
+                (lambda:right so-unit-type so-unit-type stlc-unit-term)
+                (lambda:left so-unit-type so-unit-type stlc-unit-term))
    :tc_pair_bool))
 
 (def fst-bool-circuit
@@ -63,13 +63,13 @@
     (lambda:case-on
       so-unit-type so-unit-type
       (coprod so-unit-type so-unit-type)
-      (lambda:left stlc-unit-term)
+      (lambda:left so-unit-type so-unit-type stlc-unit-term)
       (lambda:lamb
         so-unit-type (coprod so-unit-type so-unit-type)
-        (lambda:right stlc-unit-term))
+        (lambda:right so-unit-type so-unit-type stlc-unit-term))
       (lambda:lamb
         so-unit-type (coprod so-unit-type so-unit-type)
-        (lambda:left stlc-unit-term))
+        (lambda:left so-unit-type so-unit-type stlc-unit-term))
       )
     :tc_issue_58))
 

--- a/test/pipeline.lisp
+++ b/test/pipeline.lisp
@@ -11,7 +11,7 @@
    (lambda:app (coprod so1 so1)
                (coprod so1 so1)
                (lambda:lamb (coprod so1 so1) (coprod so1 so1) (lambda:index 0))
-               (lambda:left lambda:unit))
+               (lambda:left (coprod so1 so1) (coprod so1 so1) lambda:unit))
    (coprod so1 so1)))
 
 (define-test pipeline-works-for-stlc-to-vampir


### PR DESCRIPTION
This commit adds explicit type information to three STLC terms:

- `absurd`
- `left`
- `right`

See #53 .