### PR TITLE
Add `so-hom` as an external API

### DIFF
--- a/README
+++ b/README
@@ -1690,6 +1690,10 @@ These are utility functions relating to translating lambda terms to other types
 
     Converts a generic <STLC> context into a SUBSTMORPH
 
+- [function] SO-HOM DOM COD
+
+    Computes the hom-object `DOM -> COD`
+
 ## Mixins
 
 ###### \[in package GEB.MIXINS\]

--- a/src/geb/package.lisp
+++ b/src/geb/package.lisp
@@ -22,6 +22,7 @@
   (commutes-left     pax:function)
   (!->               pax:function)
   (so-eval           pax:function)
+  (so-hom-obj        pax:function)
   (so-card-alg       pax:generic-function)
   (so-card-alg       (pax:method () (<substobj>)))
   (dom               pax:generic-function)

--- a/src/lambda/package.lisp
+++ b/src/lambda/package.lisp
@@ -37,7 +37,8 @@
 
 (pax:defsection @utility (:title "Utility Functionality")
   "These are utility functions relating to translating lambda terms to other types"
-  (stlc-ctx-to-mu  pax:function))
+  (stlc-ctx-to-mu  pax:function)
+  (so-hom  pax:function))
 
 (pax:defsection @stlc-conversion (:title "Transition Functions")
   "These functions deal with transforming the data structure to other

--- a/src/lambda/trans.lisp
+++ b/src/lambda/trans.lisp
@@ -81,6 +81,11 @@
   "Converts a generic [<STLC>][type] context into a [SUBSTMORPH][type]"
   (mvfoldr #'prod context so1))
 
+(-> so-hom (substobj substobj) substobj)
+(defun so-hom (dom cod)
+  "Computes the hom-object of two [SUBSTMORPH]s"
+  (geb:so-hom-obj dom cod))
+
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Utility Functions
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;

--- a/test/lambda-conversion.lisp
+++ b/test/lambda-conversion.lisp
@@ -103,6 +103,12 @@
       (geb:prod geb-bool:bool (geb:prod geb:so0 (geb:prod geb:so1 geb:so1)))
       "fold multi-object context"))
 
+(define-test so-hom-so1-so1 :parent compile-checked-term
+  (is equalp
+      (lambda:so-hom geb:so1 geb:so1)
+      geb:so1
+      "compute hom(so1,so1)"))
+
 (define-test vampir-test-unit-to-unit
   :parent geb.lambda.trans
   (of-type geb.vampir.spec:alias unit-to-unit-circuit))


### PR DESCRIPTION
Try to address issue #60 by adding an alias that clients can use to compute hom-objects.