### PR TITLE
Add Multiple Argument Functionality to STLC Interface

### DIFF
--- a/src/lambda/lambda.lisp
+++ b/src/lambda/lambda.lisp
@@ -51,8 +51,8 @@ to the codomain."
 (-> index-check (fixnum list) cat-obj)
 (defun index-check (i ctx)
   "Given an natural number [i] and a context, checks that the context is of
-length at least [i] and then produces the [i]'th entry of the context where
-contexts are read right to left."
+length at least [i] and then produces the [i]'th entry of the context counted
+from the left starting with 0."
   (let ((l (length ctx)))
     (if (< i l)
         (nth i ctx)
@@ -77,17 +77,30 @@ per above description. While not always, not doing so result in an error upon
 evaluation. As an example of a valid entry we have
 
 ```lisp
- (ann-term1 (list so1 (fun-type so1 so1)) (app (index 1) (index 0)))
+ (ann-term1 (list so1 (fun-type so1 so1)) (app (index 1) (list (index 0))))
 ```
 
 while
 
 ```lisp
-(ann-term1 (list so1 (so-hom-obj so1 so1)) (app (index 1) (index 0)))
+(ann-term1 (list so1 (so-hom-obj so1 so1)) (app (index 1) (list (index 0))))
 ```
 
 produces an error trying to use [HOM-COD]. This warning applies to other
-functions taking in context and terms below as well."))
+functions taking in context and terms below as well.
+
+Moreover, note that for terms whose typing needs addition of new context
+we append contexts on the left rather than on the right contra usual type
+theoretic notation for the convenience of computation. That means, e.g. that
+asking for a type of a lambda term as below produces:
+
+```lisp
+LAMBDA> (ttype (term (ann-term1 (lambda (list so1 so0) (index 0)))))
+s-1
+```
+
+as we count indeces from the left of the context while appending new types to
+the context on the left as well. For more info check [LAMB][class]"))
 
 
 (defmethod ann-term1 (ctx (tterm <stlc>))
@@ -145,7 +158,12 @@ functions taking in context and terms below as well."))
   "Given a [SUBSTOBJ][GEB.SPEC:SUBSTOBJ] whose subobjects might have a
 [FUN-TYPE][class] occurence replaces all occurences of [FUN-TYPE][class] with a
 suitable [SO-HOM-OBJ][GEB.MAIN:SO-HOM-OBJ], hence giving a pure
-[SUBSTOBJ][GEB.SPEC:SUBSTOBJ]"
+[SUBSTOBJ][GEB.SPEC:SUBSTOBJ]
+
+```lisp
+LAMBDA> (fun-to-hom (fun-type geb-bool:bool geb-bool:bool))
+(× (+ GEB-BOOL:FALSE GEB-BOOL:TRUE) (+ GEB-BOOL:FALSE GEB-BOOL:TRUE))
+```"
   (cond ((typep t1 'prod)     (prod (fun-to-hom (mcar t1))
                                     (fun-to-hom (mcadr t1))))
         ((typep t1 'coprod)   (coprod (fun-to-hom (mcar t1))

--- a/src/lambda/trans.lisp
+++ b/src/lambda/trans.lisp
@@ -85,17 +85,14 @@ produces an error. Error of such kind mind pop up both on the level of evaluatin
                   (comp (<-right (mcar tottt) (mcadr tottt))
                         (compile-checked-term context term))))
                ((lamb tdom term)
-                (curry (commutes-left
-                        (rec (cons tdom context) term))))
+                (rec (append tdom context) term))
                ((app fun term)
-                (let ((tofun (ttype fun)))
-                  (comp
-                   (so-eval (fun-to-hom (mcar tofun))
-                            (fun-to-hom (mcadr tofun)))
-                   (geb:pair (rec context
-                                  fun)
-                             (rec context
-                                  term)))))
+                (comp (rec context fun)
+                      (reduce #'geb:pair
+                              (mapcar (lambda (x) (rec context x))
+                                      term)
+                              :initial-value (stlc-ctx-to-mu context)
+                              :from-end t)))
                ((index pos)
                 (stlc-ctx-proj context pos)))))
     (let ((ann-term (ann-term1 context tterm)))

--- a/src/lambda/trans.lisp
+++ b/src/lambda/trans.lisp
@@ -23,17 +23,30 @@ always, not doing so result in an error upon evaluation. As an example of a
 valid entry we have
 
 ```lisp
- (compile-checked-term (list so1 (fun-type so1 so1)) (app (index 0) (index 1)))
+(compile-checked-term (list so1 (fun-type so1 so1)) (app (index 1) (list (index 0))))
 ```
 
 while
 
 ```lisp
-(compile-checked-term (list so1 (so-hom-obj so1 so1)) (app (index 0) (index 1)))
+(compile-checked-term (list so1 (so-hom-obj so1 so1)) (app (index 1) (list (index 0))))
 ```
 
 produces an error. Error of such kind mind pop up both on the level of evaluating
-[WELL-DEFP][generic-function] and [ANN-TERM1][generic-function]."))
+[WELL-DEFP][generic-function] and [ANN-TERM1][generic-function].
+
+Moreover, note that for terms whose typing needs addition of new context
+we append contexts on the left rather than on the right contra usual type
+theoretic notation for the convenience of computation. That means, e.g. that
+asking for a type of a lambda term as below produces:
+
+```lisp
+LAMBDA> (ttype (term (ann-term1 (lambda (list so1 so0) (index 0)))))
+s-1
+```
+
+as we count indeces from the left of the context while appending new types to
+the context on the left as well. For more info check [LAMB][class]"))
 
 (-> to-poly (list <stlc>) (or geb.poly:<poly> geb.poly:poly))
 (defun to-poly (context obj)
@@ -106,7 +119,14 @@ produces an error. Error of such kind mind pop up both on the level of evaluatin
   "Converts a generic [<STLC>][type] context into a
 [SUBSTMORPH][GEB.SPEC:SUBSTMORPH]. Note that usually contexts can be interpreted
 in a category as a $\Sigma$-type$, which in a non-dependent setting gives us a
-usual [PROD][type]"
+usual [PROD][type]
+
+```lisp
+LAMBDA> (stlc-ctx-to-mu (list so1 (fun-to-hom (fun-type geb-bool:bool geb-bool:bool))))
+(× s-1
+   (× (+ GEB-BOOL:FALSE GEB-BOOL:TRUE) (+ GEB-BOOL:FALSE GEB-BOOL:TRUE))
+   s-1)
+```"
   (mvfoldr #'prod (mapcar #'fun-to-hom context) so1))
 
 (-> so-hom (substobj substobj) (or t substobj))

--- a/src/specs/lambda.lisp
+++ b/src/specs/lambda.lisp
@@ -47,8 +47,10 @@ $$\\Gamma \\vdash \\text{tcod : Type}$$ and
 $$\\Gamma \\vdash \\text{term : so0}$$ one deduces
 $$\\Gamma \\vdash \\text{(absurd tcod term) : tcod}$$"))
 
+(-> absurd (cat-obj <stlc> &key (:ttype t)) absurd)
 (defun absurd (tcod term &key (ttype nil))
-  (make-instance 'absurd :tcod tcod :term term :ttype ttype))
+  (values
+   (make-instance 'absurd :tcod tcod :term term :ttype ttype)))
 
 (defclass unit (<stlc>)
   ((ttype :initarg :ttype
@@ -75,8 +77,10 @@ we provide all terms untyped.
 This grammar corresponds to the introduction rule of the unit type. Namely
 $$\\Gamma \\dashv \\text{(unit) : so1}$$"))
 
+(-> unit (&key (:ttype t)) unit)
 (defun unit (&key (ttype nil))
-  (make-instance 'unit :ttype ttype))
+  (values
+   (make-instance 'unit :ttype ttype)))
 
 (defclass left (<stlc>)
   ((rty :initarg :rty
@@ -117,8 +121,10 @@ $$\\Gamma \\dashv \\text{term : (ttype term)}$$ we deduce
 $$\\Gamma \\dashv \\text{(left rty term) : (coprod (ttype term) rty)}$$
 "))
 
+(-> left (cat-obj <stlc> &key (:ttype t)) left)
 (defun left (rty term &key (ttype nil))
-  (make-instance 'left :rty rty :term term :ttype ttype))
+  (values
+   (make-instance 'left :rty rty :term term :ttype ttype)))
 
 (defclass right (<stlc>)
   ((lty :initarg :lty
@@ -158,8 +164,10 @@ $$\\Gamma \\dashv \\text{term : (ttype term)}$$ we deduce
 $$\\Gamma \\dashv \\text{(right lty term) : (coprod lty (ttype term))}$$
 "))
 
+(-> right (cat-obj <stlc> &key (:ttype t)) right)
 (defun right (lty term &key (ttype nil))
-  (make-instance 'right :lty lty :term term :ttype ttype))
+  (values
+   (make-instance 'right :lty lty :term term :ttype ttype)))
 
 (defclass case-on (<stlc>)
   ((on :initarg :on
@@ -176,8 +184,8 @@ $$\\Gamma \\dashv \\text{(right lty term) : (coprod lty (ttype term))}$$
           :accessor ttype
           :documentation ""))
   (:documentation
-   "A term of an arbutrary type provided by casing on a coproduct term. The formal grammar of
-[CASE-ON][class] is
+   "A term of an arbutrary type provided by casing on a coproduct term. The
+formal grammar of [CASE-ON][class] is
 
 ```lisp
 (case-on on ltm rtm)
@@ -195,14 +203,20 @@ also [STLC][type]) of the same type in the context of - appropriately
 - (mcar (ttype on)) and (mcadr (ttype on)).
 
 This corresponds to the elimination rule of the coprodut type. Namely, given
-$$\\Gamma \\vdash \\text{on : (coprod (mcar (ttype on)) (mcadr (ttype on)))}$$ and
-$$\\Gamma, \\text{(mcar (ttype on))} \\vdash \\text{ltm : (ttype ltm)}$$
-, $$\\Gamma, \\text{(mcadr (ttype on))} \\vdash \\text{rtm : (ttype ltm)}$$ we get
+$$\\Gamma \\vdash \\text{on : (coprod (mcar (ttype on)) (mcadr (ttype on)))}$$
+and
+$$\\text{(mcar (ttype on))} , \\Gamma \\vdash \\text{ltm : (ttype ltm)}$$
+, $$\\text{(mcadr (ttype on))} , \\Gamma \\vdash \\text{rtm : (ttype ltm)}$$
+we get
 $$\\Gamma \\vdash \\text{(case-on on ltm rtm) : (ttype ltm)}$$
-"))
+Note that in practice we append contexts on the left as computation of
+[INDEX][class] is done from the left. Otherwise, the rules are the same as in
+usual type theory if context was read from right to left."))
 
+(-> case-on (<stlc> <stlc> <stlc> &key (:ttype t)) case-on)
 (defun case-on (on ltm rtm &key (ttype nil))
-  (make-instance 'case-on :on on :ltm ltm :rtm rtm :ttype ttype))
+  (values
+   (make-instance 'case-on :on on :ltm ltm :rtm rtm :ttype ttype)))
 
 (defclass pair (<stlc>)
   ((ltm :initarg :ltm
@@ -216,8 +230,8 @@ $$\\Gamma \\vdash \\text{(case-on on ltm rtm) : (ttype ltm)}$$
           :accessor ttype
           :documentation ""))
   (:documentation
-   "A term of the product type gotten by pairing a terms of a left and right parts of the product.
-The formal grammar of [PAIR][class] is
+   "A term of the product type gotten by pairing a terms of a left and right
+parts of the product. The formal grammar of [PAIR][class] is
 
 ```lisp
 (pair ltm rtm)
@@ -240,8 +254,10 @@ $$\\Gamma \\vdash \\text{rtm : (mcadr (ttype (pair ltm rtm)))}$$ we have
 $$\\Gamma \\vdash \\text{(pair ltm rtm) : (ttype (pair ltm rtm))}$$
 "))
 
+(-> pair (<stlc> <stlc> &key (:ttype t)) pair)
 (defun pair (ltm rtm &key (ttype nil))
-  (make-instance 'pair :ltm ltm :rtm rtm :ttype ttype))
+  (values
+   (make-instance 'pair :ltm ltm :rtm rtm :ttype ttype)))
 
 (defclass fst (<stlc>)
   ((term :initarg :term
@@ -272,8 +288,10 @@ we are projecting to.
 This corresponds to the first projection function gotten by induction
 on a term of a product type."))
 
+(-> fst (<stlc> &key (:ttype t)) fst)
 (defun fst (term &key (ttype nil))
-  (make-instance 'fst :term term :ttype ttype))
+  (values
+   (make-instance 'fst :term term :ttype ttype)))
 
 (defclass snd (<stlc>)
   ((term :initarg :term
@@ -304,12 +322,15 @@ part we are projecting to.
 This corresponds to the second projection function gotten by induction
 on a term of a product type."))
 
+(-> snd (<stlc> &key (:ttype t)) snd)
 (defun snd (term &key (ttype nil))
-  (make-instance 'snd :term term :ttype ttype))
+  (values
+   (make-instance 'snd :term term :ttype ttype)))
 
 (defclass lamb (<stlc>)
   ((tdom :initarg :tdom
          :accessor tdom
+         :type     list
          :documentation "Domain of the lambda term")
    (term :initarg :term
          :accessor term
@@ -321,7 +342,10 @@ on a term of a product type."))
   (:documentation
    "A term of a function type gotten by providing a term in the codomain
 of the function type by assuming one is given variables in the
-specified list of types. The formal grammar of [LAMB][class] is:
+specified list of types. [LAMB][class] takes in the [TDOM][generic-function]
+accessor a list of types - and hence of [SUBSTOBJ][class] - and in the
+[TERM][generic-function] a term - and hence an [STLC][class]. The formal grammar
+of [LAMB][class] is:
 
 ```lisp
 (lamb tdom term)
@@ -354,7 +378,7 @@ For a list of length n, this coreesponds to the iterated lambda type, e.g.
 is a term of
 
 ```lisp
-(so-hom-obj (prod so1 so0) so0) 
+(so-hom-obj (prod so1 so0) so0)
 ```
 
 or equivalently
@@ -363,10 +387,34 @@ or equivalently
 (so-hom-obj so1 (so-hom-obj so0 so0))
 ```
 
-due to Geb's computational definition of the function type."))
+due to Geb's computational definition of the function type.
 
+Note that [INDEX][class] 0 in the above code is of type [SO1][class].
+So that after annotating the term, one gets
+
+```lisp
+LAMBDA> (ttype (term (lamb (list so1 so0)) (index 0)))
+s-1
+```
+
+So the counting of indeces starts with the leftmost argument for
+computational reasons. In practice, typing of [LAMB][class] corresponds with
+taking a list of arguments provided to a lambda term, making it a context
+in that order and then counting the index of the varibale. Type-theoretically,
+
+$$\\Gamma \\vdash \\lambda \\Delta (index i)$$
+$$\\Delta, \\Gamma \\vdash (index i)$$
+
+So that by the operational semantics of [INDEX][class], the type of (index i)
+in the above context will be the i'th element of the Delta context counted from
+the left. Note that in practice we append contexts on the left as computation of
+[INDEX][class] is done from the left. Otherwise, the rules are the same as in
+usual type theory if context was read from right to left."))
+
+(-> lamb (list <stlc> &key (:ttype t)) lamb)
 (defun lamb (tdom term &key (ttype nil))
-  (make-instance 'lamb :tdom tdom :term term :ttype ttype))
+  (values
+   (make-instance 'lamb :tdom tdom :term term :ttype ttype)))
 
 (defclass app (<stlc>)
   ((fun :initarg :fun
@@ -374,7 +422,8 @@ due to Geb's computational definition of the function type."))
         :documentation "Term of exponential type")
    (term :initarg :term
          :accessor term
-         :documentation "Term of the domain")
+         :type list
+         :documentation "List of Terms of the domain")
    (ttype :initarg :ttype
           :initform nil
           :accessor ttype
@@ -382,7 +431,11 @@ due to Geb's computational definition of the function type."))
   (:documentation
    "A term of an arbitrary type gotten by applying a function of an iterated
 function type with a corresponding codomain iteratively to terms in the
-domains. The formal grammar of [APP][class] is
+domains. [APP][class] takes as argument for the [FUN][generic-function] accessor
+a function - and hence an [STLC][class] - whose function type has domain an
+iterated [PROD][class] of [SUBSTOBJ][clas] and for the [TERM][generic-function]
+a list of terms - and hence of [STLC][class] - matching the types of the
+product. The formal grammar of [APP][class] is
 
 ```lisp
 (app fun term)
@@ -408,16 +461,20 @@ $$\\Gamma \\vdash \\text{(app fun term) : y}$$
 
 For several arguments, this corresponds to successive function application.
 Using currying, this corresponds to, given
-$$\\Gamma \\vdash (so-hom-obj (A_1 , \\ldots , A_{n-1}))$$
-$$\\Gamma \\vdash A_n $$
-$$\\Gamma \\vdash f : (so-hom-obj (A_1 , \\ldots , A_{n-1}))$$
+$$\\Gamma \\vdash (so-hom-obj (A_1 x \\ldots , A_{n-1}) A_n)$$
+$$\\Gamma \\vdash f : (so-hom-obj (A1 , \\ldots , A_{n-1}))$$
 and
-$$\Gamma  \\vdash t_i : A_i
+$$\Gamma  \\vdash t_i : A_i$$
 for each i less than n gets us
-$$\Gamma \\vdash app(f , t_1 , .... t_{n-1}) : A_n$$"))
+$$\Gamma \\vdash app(f , t_1 , .... t_{n-1}) : A_n$$
 
+Note again that i'th term should correspond to the ith element of the product
+in the codomain counted from the left."))
+
+(-> app (<stlc> list &key (:ttype t)) app)
 (defun app (fun term &key (ttype nil))
-  (make-instance 'app :fun fun :term term :ttype ttype))
+  (values
+    (make-instance 'app :fun fun :term term :ttype ttype)))
 
 (defclass index (<stlc>)
   ((pos :initarg :pos
@@ -449,10 +506,12 @@ $$\\Gamma_1 , \\ldots , \\Gamma_{pos} , \\ldots , \\Gamma_k $$ we have
 
 $$\\Gamma_1 , \\ldots , \\Gamma_k \\vdash \\text{(index pos) :} \\Gamma_{pos}$$
 
-Note that we add contexts on the left rather than on the right as per classical
+Note that we add contexts on the left rather than on the right contra classical
 type-theoretic notation."))
 
+(-> index (fixnum &key (:ttype t)) index)
 (defun index (pos &key (ttype nil))
-  (make-instance 'index :pos pos :ttype ttype))
+  (values
+   (make-instance 'index :pos pos :ttype ttype)))
 
 

--- a/src/specs/package.lisp
+++ b/src/specs/package.lisp
@@ -13,7 +13,7 @@
 (muffle-package-variance
  (uiop:define-package #:geb.lambda.spec
    (:documentation "Basic spec for creating lambda terms")
-   (:mix #:trivia #:serapeum #:common-lisp)))
+   (:mix #:trivia #:serapeum #:common-lisp #:geb.mixins)))
 
 (pax:define-package #:geb.spec
   (:documentation "Gödel, Escher, Bach categorical model")

--- a/src/util/package.lisp
+++ b/src/util/package.lisp
@@ -16,6 +16,7 @@ used throughout the GEB codebase"
   (number-to-digits        pax:function)
   (digit-to-under          pax:function)
   (number-to-under         pax:function)
+  (apply-n                 pax:function)
   (@geb-accessors          pax:section))
 
 (pax:defsection @geb-accessors (:title "Accessors")

--- a/src/util/utils.lisp
+++ b/src/util/utils.lisp
@@ -201,3 +201,19 @@ Further this can be used in type signatures
   (:documentation
    "the then branch of the
 [object](http://www.lispworks.com/documentation/HyperSpec/Body/26_glo_o.htm#object)"))
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;               Additional Utils
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+
+(defun apply-n (times f initial)
+  "Applies a function, f, n TIMES to the INITIAL values
+
+```lisp
+GEB> (apply-n 10 #'1+ 0)
+10 (4 bits, #xA, #o12, #b1010)
+```"
+  (let ((value initial))
+    (dotimes (n times value)
+      (setf value (funcall f value)))))

--- a/test/lambda-conversion.lisp
+++ b/test/lambda-conversion.lisp
@@ -62,11 +62,11 @@
     (lambda:case-on
       (lambda:left so-unit-type stlc-unit-term)
       (lambda:lamb
-        so-unit-type
-        (lambda:right so-unit-type stlc-unit-term))
+       (list so-unit-type)
+       (lambda:right so-unit-type stlc-unit-term))
       (lambda:lamb
-        so-unit-type
-        (lambda:left so-unit-type stlc-unit-term))
+       (list so-unit-type)
+       (lambda:left so-unit-type stlc-unit-term))
       )
     :tc_issue_58))
 

--- a/test/lambda.lisp
+++ b/test/lambda.lisp
@@ -40,8 +40,17 @@
 (def lambterm
   (lambda:lamb (list so1-prod) unit-term))
 
+(def multilambterm
+  (lambda:lamb (list so1 so0) (lambda:index 0)))
+
+(def multilambterm-type
+  (lambda:type-of-term-w-fun nil multilambterm))
+
 (def appterm
   (lambda:app lambterm (list pair-of-units-term)))
+
+(def multiappterm
+  (lambda:app multilambterm (list (lambda:index 0) (lambda:index 1))))
 
 (def context-list
   (list so1 so0 so01-coprod (geb.lambda.main:fun-type so0 so1)))
@@ -244,4 +253,22 @@
                                                 (lambda:index 0)))))
                     (list (lambda:right so0
                                         (lambda:lamb (list so1) unit-term))))))))
+
+(define-test multi-lambda-test
+  :parent geb.lambda
+  (is obj-equalp
+      so1
+      (mcadr multilambterm-type))
+  (is obj-equalp
+      (prod so1 so0)
+      (mcar multilambterm-type)))
+
+(define-test multi-app-term
+  (is obj-equalp
+      so1
+      (lambda:type-of-term (list so1 so0) multiappterm))
+  (is obj-equalp
+      (prod so1 so0)
+      (mcar (lambda:fun (lambda:ann-term1 (list so1 so0) multiappterm)))))
+
 

--- a/test/lambda.lisp
+++ b/test/lambda.lisp
@@ -38,10 +38,10 @@
   (prod so1 so1))
 
 (def lambterm
-  (lambda:lamb so1-prod unit-term))
+  (lambda:lamb (list so1-prod) unit-term))
 
 (def appterm
-  (lambda:app lambterm pair-of-units-term))
+  (lambda:app lambterm (list pair-of-units-term)))
 
 (def context-list
   (list so1 so0 so01-coprod (geb.lambda.main:fun-type so0 so1)))
@@ -186,7 +186,7 @@
   :parent geb.lambda
   (is obj-equalp
       so1
-      (lambda:type-of-term nil (lambda:app lambterm pair-of-units-term))
+      (lambda:type-of-term nil (lambda:app lambterm (list pair-of-units-term)))
       "type of function application term")
   (is obj-equalp
       (so-hom-obj so1-prod so1)
@@ -198,23 +198,23 @@
   (is obj-equalp
       so1-prod
       (lambda:type-of-term nil
-                           (lambda:term
-                            (lambda:annotated-term nil
-                                                   appterm)))))
+                           (car (lambda:term
+                                 (lambda:annotated-term nil
+                                                        appterm))))))
 
 (define-test index-tests
   :parent geb.lambda
   (is obj-equalp
-      (so-hom-obj so0 so1)
+      so1
       (lambda:type-of-term context-list (lambda:index 0)))
   (is obj-equalp
-      so01-coprod
+      so0
       (lambda:type-of-term context-list (lambda:index 1)))
   (is obj-equalp
-      so0
+      so01-coprod
       (lambda:type-of-term context-list (lambda:index 2)))
   (is obj-equalp
-      so1
+      (so-hom-obj so0 so1)
       (lambda:type-of-term context-list (lambda:index 3))))
 
 
@@ -225,7 +225,7 @@
       (lambda:type-of-term
        context-list
        (lambda:term (lambda:annotated-term context-list
-                                           (lambda:absurd so1 (lambda:index 2)))))))
+                                           (lambda:absurd so1 (lambda:index 1)))))))
 
 (define-test exp-hom-test
   :parent geb.lambda
@@ -233,15 +233,15 @@
       (so-hom-obj (coprod so0 (so-hom-obj so1 so1))
                   (prod so1 (so-hom-obj so0 so1)))
       (lambda:type-of-term
-       (list so0 so1)
+       nil
        (lambda:fun
         (lambda:app (lambda:lamb
-                     (coprod so0 (geb.lambda.main:fun-type so0 so1))
+                     (list (coprod so0 (geb.lambda.main:fun-type so0 so1)))
                      (lambda:pair
                       unit-term
-                      (lambda:lamb so1
-                                   (lambda:lamb so0
+                      (lambda:lamb (list so1)
+                                   (lambda:lamb (list so0)
                                                 (lambda:index 0)))))
-                    (lambda:right so0
-                                  (lambda:lamb so1 unit-term)))))))
+                    (list (lambda:right so0
+                                        (lambda:lamb (list so1) unit-term))))))))
 

--- a/test/pipeline.lisp
+++ b/test/pipeline.lisp
@@ -8,8 +8,8 @@
 
 (defparameter *entry*
    (lambda:app
-    (lambda:lamb (coprod so1 so1) (lambda:index 0))
-    (lambda:left so1 (lambda:unit))))
+    (lambda:lamb (list (coprod so1 so1)) (lambda:index 0))
+    (list (lambda:left so1 (lambda:unit)))))
 
 (define-test pipeline-works-for-stlc-to-vampir
   :parent geb-pipeline


### PR DESCRIPTION
This commit adds following functionality:

1) `lamb` now accepts a list of types for its `tdom` accessor allowing for functions to be defined in a complex context. The domain of such a lambda term will then be the iterated product.

2) 'app' now accepts a list of terms for its `term` accessor allowing for a multi-argument function to be iteratively applied.

3) Change `index` functionality to follow usual convention of reading contexts from left to right.

4) Change the STLC -> GEB compilation to be uncurried solving #106 and allowing for a neater solution to #90 

 