### PR TITLE
Fix a bug where BITC gapply does not properly swap bytes

### DIFF
--- a/src/bitc/bitc.lisp
+++ b/src/bitc/bitc.lisp
@@ -67,7 +67,7 @@ GEB-TEST> (gapply (to-bitc geb-bool:and) #*00)
     (drop     #*)
     (swap
      (let ((n (mcar morphism)))
-       (concatenate 'bit-vector (subseq object 0) (subseq object 0 n))))
+       (concatenate 'bit-vector (subseq object n) (subseq object 0 n))))
     (parallel
      (let* ((cx (dom (mcar morphism)))
             (inp1 (subseq object 0 cx))

--- a/test/bitc.lisp
+++ b/test/bitc.lisp
@@ -28,3 +28,13 @@
   (is equalp #*0 (gapply (to-bitc geb-bool:and) #*10))
   (is equalp #*0 (gapply (to-bitc geb-bool:and) #*01))
   (is equalp #*0 (gapply (to-bitc geb-bool:and) #*00)))
+
+(define-test bitc-swap-evaluation
+  :parent geb-bitc
+  (is equalp #*011 (gapply (bitc:swap 0 3) #*011))
+  (is equalp #*011 (gapply (bitc:swap 3 0) #*011))
+  (is equalp #*101 (gapply (bitc:swap 2 1) #*011))
+  (is equalp #*110 (gapply (bitc:swap 2 1) #*101))
+  (is equalp #*011 (gapply (bitc:swap 2 1) #*110))
+  (is equalp #*01011 (gapply (bitc:swap 2 3) #*11010))
+  (is equalp #*100110 (gapply (bitc:swap 3 3) #*110100)))


### PR DESCRIPTION
Before the code would take the first n bytes twice, instead of actually swapping them. This causes evaluation issues.

This commit also contains a test that makes sure a regression won't happen