### PR TITLE
Remove Vampir from being printed on testing

### DIFF
--- a/test/pipeline.lisp
+++ b/test/pipeline.lisp
@@ -16,7 +16,9 @@
   (parachute:finish
    (geb.entry:compile-down :vampir t
                            :stlc t
-                           :entry "geb-test::test-compilation-eval-2"))
+                           :entry "geb-test::test-compilation-eval-2"
+                           :stream nil))
   (parachute:finish
    (geb.entry:compile-down :stlc t
-                           :entry "geb-test::*entry*")))
+                           :entry "geb-test::*entry*"
+                           :stream nil)))


### PR DESCRIPTION
Simply changes the stream to nil so that nothing is printed rather than dumping to standard out