### PR TITLE
Add New Division Primitive

### DIFF
--- a/src/vampir/spec.lisp
+++ b/src/vampir/spec.lisp
@@ -28,7 +28,8 @@
   `(or wire constant))
 
 (deftype primitive ()
-  `(or (eql :+) (eql :-) (eql :*) (eql :^) (eql :\\) (eql :%) (eql :/)))
+  `(or (eql :+) (eql :-) (eql :*) (eql :^) (eql :\\) (eql :%) (eql :/)
+       (eql :\|)))
 
 (deftype constraint-list ()
   `(satisfies constraint-list))


### PR DESCRIPTION
Adds a new primitive operation of conditional division to the VampIR spec. The primitive stands for the VampIR operation which is capable of dividing by 0, producing 0.