### PR TITLE
Move width Generic

### DIFF
--- a/src/geb/trans.lisp
+++ b/src/geb/trans.lisp
@@ -196,10 +196,10 @@ We use an optimized version in actual code, which happens to compute the same re
 
 (defmethod to-seqn ((obj <substobj>))
   "Preserves identity morphims"
-  (seqn:id (geb.seqn.main:width obj)))
+  (seqn:id (geb.common:width obj)))
 
 (defmethod to-seqn ((obj geb.extension.spec:<natobj>))
-  (seqn:id (geb.seqn.main:width obj)))
+  (seqn:id (geb.common:width obj)))
 
 (defmethod to-seqn ((obj comp))
   "Preserves composition"

--- a/src/generics/generics.lisp
+++ b/src/generics/generics.lisp
@@ -50,6 +50,11 @@ of [so1][geb.spec:so1]"))
    "Takes in X and Y Geb objects and provides an evaluation morphism
 (prod (so-hom-obj X Y) X) -> Y"))
 
+(defgeneric width (object)
+  (:documentation
+   "Given an OBJECT of Geb presents it as a SeqN object. That is,
+width corresponds the object part of the to-seqn functor."))
+
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Conversion functions
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;

--- a/src/generics/package.lisp
+++ b/src/generics/package.lisp
@@ -16,6 +16,7 @@ examples often given in the specific methods"
   (well-defp-cat  pax:generic-function)
   (maybe          pax:generic-function)
   (so-eval        pax:generic-function)
+  (width          pax:generic-function)
   (to-circuit     pax:generic-function)
   (to-bitc        pax:generic-function)
   (to-seqn        pax:generic-function)

--- a/src/seqn/package.lisp
+++ b/src/seqn/package.lisp
@@ -15,7 +15,6 @@
   (seq-max-fill        pax:function)
   (width              (pax:method () (<substobj>)))
   (width              (pax:method () (<natobj>)))
-  (width               pax:generic-function)
   (inj-coprod-parallel pax:function)
   (zero-list              pax:function)
   (dom                 (pax:method () (<seqn>)))


### PR DESCRIPTION
Moves `width` to the relevant package, creating an appropriate function and upgrades all references.