### PR TITLE
Introduce Compilation Through Maybe Monad

### DIFF
--- a/src/geb/geb.lisp
+++ b/src/geb/geb.lisp
@@ -354,14 +354,7 @@ turning [coproducts][coprod] of A | B into Maybe (Maybe A | Maybe B),
 turning [SO1] into Maybe [SO1]
 
 and [SO0] into Maybe [SO0]"
-  (typecase-of substobj obj
-    (so0    (coprod so1 so0))
-    (so1    (coprod so1 so1))
-    (coprod (coprod so1 (coprod (maybe (mcar obj))
-                                (maybe (mcadr obj)))))
-    (prod   (coprod so1 (prod (maybe (mcar obj))
-                              (maybe (mcadr obj)))))
-    (otherwise (subclass-responsibility obj))))
+  (coprod so1 obj))
 
 (defmethod maybe ((obj <natobj>))
   (coprod so1 obj))

--- a/src/lambda/lambda.lisp
+++ b/src/lambda/lambda.lisp
@@ -18,56 +18,6 @@ pointwise."))
 (defun fun-type (mcar mcadr)
   (make-instance 'fun-type :mcar mcar :mcadr mcadr))
 
-(defmethod maybe ((object fun-type))
-  "I recursively add maybe terms to my domain and codomain, and even
-return a maybe function. Thus if the original function was
-
-```
-f : a -> b
-```
-
-we would now be
-
-```
-f : maybe (maybe a -> maybe b)
-```
-
-for what maybe means checkout [my generic function documentation][maybe]."
-  (coprod so1
-          (fun-type (maybe (mcar object))
-                    (maybe (mcadr object)))))
-
-;; Below we list all possible ways of getting a term of the exponential,
-;; namely: projections, casing, absurd, lambda-abstraction and application
-
-;; Problem: this covers only canonical costructors, might need to
-;; further extend the definition
-
-(defun hom-cod (ctx f)
-  "Given a context of [SUBSTOBJ][GEB.SPEC:SUBSTOBJ] with occurences of
-[SO-HOM-OBJ][GEB.MAIN:SO-HOM-OBJ] replaced by [FUN-TYPE][class], and similarly
-an [STLC][type] term of the stand-in for the hom object, produces the stand-in
-to the codomain."
-  (let ((rec  (ann-term1 ctx f)))
-    (cond ((typep f 'fst)     (let ((tt (term f)))
-                                (if (typep tt 'pair)
-                                    (hom-cod ctx (ltm tt))
-                                    (hom-cod ctx tt))))
-          ((typep f 'snd)     (let ((tt (term f)))
-                                (if (typep tt 'pair)
-                                    (hom-cod ctx (rtm tt))
-                                    (hom-cod ctx tt))))
-          ((typep f 'case-on) (hom-cod
-                               (cons (mcar (ttype (ann-term1 ctx (on f))))
-                                     ctx)
-                               (ltm f)))
-          ((typep f 'absurd)  (hom-cod ctx (term f)))
-          ((typep f 'lamb)    (mcadr (ttype rec)))
-          ((typep f 'app)     (hom-cod ctx (fun f)))
-          ((typep f 'index)   (mcadr (ttype rec)))
-          ((typep f 'err)     (mcadr (ttype f)))
-          (t                  (error "not a valid STLC exponential term")))))
-
 (-> index-check (fixnum list) cat-obj)
 (defun index-check (i ctx)
   "Given an natural number I and a context, checks that the context is of
@@ -158,9 +108,10 @@ the context on the left as well. For more info check [LAMB][class]"))
                               (lamb tdom
                                     ant
                                     :ttype (fun-type (reduce #'prod tdom) (ttype ant)))))
-        ((app fun term)     (app (ann-term1 ctx fun)
-                                 (mapcar (lambda (trm) (ann-term1 ctx trm)) term)
-                                 :ttype (hom-cod ctx fun)))
+        ((app fun term)     (let ((anfun (ann-term1 ctx fun)))
+                              (app anfun
+                                   (mapcar (lambda (trm) (ann-term1 ctx trm)) term)
+                                   :ttype (mcadr (ttype anfun)))))
         ((index pos)        (index pos
                                    :ttype (index-check pos ctx)))
         ((err ttype)        (err ttype))

--- a/src/lambda/package.lisp
+++ b/src/lambda/package.lisp
@@ -30,9 +30,7 @@
   (reducer            pax:function)
 
   (mcar              (pax:method () (fun-type)))
-  (mcadr             (pax:method () (fun-type)))
-
-  (maybe             (pax:method () (fun-type))))
+  (mcadr             (pax:method () (fun-type))))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; trans module

--- a/test/lambda-trans.lisp
+++ b/test/lambda-trans.lisp
@@ -163,15 +163,11 @@
                                     (list so1)))
   (is obj-equalp (left so1) (gapply (to-cat (list (coprod so1 so1))
                                             context-dependent-case)
-                                    (list (right
-                                           (left
-                                            (right so1)))
+                                    (list (left so1)
                                           so1)))
   (is obj-equalp (right so1) (gapply (to-cat (list (coprod so1 so1))
                                              context-dependent-case)
-                                     (list (right
-                                            (right
-                                             (right so1)))
+                                     (list (right so1)
                                            so1))))
 
 (define-test arithmetic-compilation :parent lambda.trans-eval


### PR DESCRIPTION
Assuming 24-bit integer inputs as well as a reduced Lambda term, improves the compiler for Lambda objects with error terms by wrapping the compilation in an actual Maybe monad rather than a recursive one.