### PR TITLE
Add Library Printing Flag

### DIFF
--- a/src/entry/entry.lisp
+++ b/src/entry/entry.lisp
@@ -13,6 +13,8 @@
      :type boolean :optional t :documentation "Prints the current version of the compiler")
     (("vampir" #\p)
      :type string :optional t :documentation "Return a vamp-ir expression")
+    (("library" #\s)
+     :type boolean :optional t :documentation "Prints standard library")
     (("help" #\h #\?)
      :type boolean :optional t :documentation "The current help message")))
 
@@ -26,7 +28,7 @@
 (defparameter *no-input-text*
   "Please provide an input file with -p or see the help command with -h")
 
-(defun argument-handlers (&key help stlc output input entry-point vampir version)
+(defun argument-handlers (&key help stlc output input entry-point vampir library version)
   (flet ((run (stream)
            (cond (help
                   (command-line-arguments:show-option-help +command-line-spec+
@@ -39,6 +41,7 @@
                   (load input)
                   (compile-down :vampir vampir
                                 :stlc stlc
+                                :library library
                                 :entry entry-point
                                 :stream stream)))))
     (if output
@@ -49,16 +52,26 @@
         (run *standard-output*))))
 
 ;; this code is very bad please abstract out many of the components
-(defun compile-down (&key vampir stlc entry (stream *standard-output*))
-  (let* ((name        (read-from-string entry))
-         (eval        (eval name))
-         (vampir-name (renaming-scheme (intern (symbol-name name) 'keyword))))
-    (cond ((and vampir stlc)
+(defun compile-down (&key vampir stlc entry library (stream *standard-output*))
+  (let* ((name         (read-from-string entry))
+         (eval         (eval name))
+         (vampir-name  (renaming-scheme (intern (symbol-name name) 'keyword))))
+    (cond ((and vampir stlc library)
+           (geb.vampir:extract
+            (append geb.vampir::*standard-library*
+                    (to-circuit eval vampir-name))))
+          ((and vampir stlc)
            (geb.vampir:extract (to-circuit eval vampir-name) stream))
           (stlc
            (format stream "~A" (to-cat nil eval)))
+          ((and vampir library)
+           (geb.vampir:extract
+            (append geb.vampir::*standard-library*
+                    (to-circuit eval vampir-name))))
           (vampir
            (geb.vampir:extract (to-circuit eval vampir-name) stream))
+          (library
+           (geb.vampir:extract geb.vampir::*standard-library*))
           (t
            (format stream eval)))))
 

--- a/src/entry/package.lisp
+++ b/src/entry/package.lisp
@@ -45,6 +45,7 @@ mariari@Gensokyo % ./geb.image -h
   -o --output                     string   Save the output to a file rather than printing
   -v --version                    boolean  Prints the current version of the compiler
   -p --vampir                     string   Return a vamp-ir expression
+  -s --library                    boolean  Print standard library
   -h -? --help                    boolean  The current help message
 
 mariari@Gensokyo % ./geb.image -v
@@ -82,5 +83,9 @@ expects a symbol.
 
 the -l flag means that we are not expecting a geb term, but rather a
 lambda frontend term, this is to simply notify us to compile it as a
-lambda term rather than a geb term. In time this will go away"
+lambda term rather than a geb term. In time this will go away
+
+The flag -s prints the standard library the compiler uses. If -p is
+used alongside it, the standard library gets printed before the
+compiled circuit."
   (compile-down function))


### PR DESCRIPTION
Adds a `--library` entry flag used using `-s` allowing to print the standard VampIR library the Geb compiler uses when using the project as a binary. 

Adds relevant documentation.