### PR TITLE
fix(arrow-cospan): complete arrowCospanCoreflective proofs and wire t…

### DIFF
--- a/geb-lean/GebLean.lean
+++ b/geb-lean/GebLean.lean
@@ -138,6 +138,7 @@ import GebLean.RelSpanDiagram
 import GebLean.RestrictedCoendAsColimit
 import GebLean.Semicategory
 import GebLean.Utilities
+import GebLean.Utilities.ArrowCospanAdjunction
 import GebLean.Utilities.ArrowSpanAdjunction
 import GebLean.Utilities.Category
 import GebLean.Utilities.ConnectedComponents

--- a/geb-lean/GebLean/Utilities/ArrowCospanAdjunction.lean
+++ b/geb-lean/GebLean/Utilities/ArrowCospanAdjunction.lean
@@ -40,7 +40,7 @@ def arrowCospanInclusion
   obj f := cospan f.hom (𝟙 f.right)
   map {f g} sq :=
     cospanHomMk sq.right sq.left sq.right
-      (by simp)
+      sq.w.symm
       (by simp)
   map_id f := by
     apply NatTrans.ext
@@ -208,7 +208,20 @@ def arrowCospanAdjUnit
         (pullbacks _).isLimit.fac]
       dsimp [arrowCospanAdjUnitCone]
       match j with
-      | .one | .left | .right => simp
+      | .one =>
+        simp only [← Category.assoc,
+          (pullbacks _).isLimit.fac]
+        dsimp [arrowCospanAdjUnitCone]
+        exact sq.w
+      | .left =>
+        simp only [← Category.assoc,
+          (pullbacks _).isLimit.fac]
+        simp
+      | .right =>
+        simp only [← Category.assoc,
+          (pullbacks _).isLimit.fac]
+        dsimp [arrowCospanAdjUnitCone]
+        exact sq.w
     · simp [arrowCospanAdjUnitApp,
         cospanArrowCoreflector]
 
@@ -293,13 +306,30 @@ theorem arrowCospanAdj_left_triangle
     𝟙 _ := by
   ext j
   match j with
-  | .one | .left | .right =>
+  | .one | .right =>
     simp [arrowCospanAdjUnitApp,
       arrowCospanAdjCounitApp,
-      arrowCospanAdjUnitCone,
       arrowCospanInclusion,
       cospanArrowCoreflector]
+  | .left =>
+    dsimp [arrowCospanAdjUnitApp,
+      arrowCospanAdjCounitApp,
+      arrowCospanInclusion,
+      cospanArrowCoreflector]
+    exact (pullbacks _).isLimit.fac
+      (arrowCospanAdjUnitCone f)
+      WalkingCospan.left
 
+-- `linter.flexible` is locally disabled for
+-- `arrowCospanAdj_right_triangle`: the proof
+-- relies on `simp` (not `simp only`) to drive the
+-- `(pullbacks _).isLimit.fac` rewrite after unfolding
+-- `arrowCospanAdjUnitCone`.  `IsLimit.fac` is not
+-- `@[simp]`-tagged but is reachable from `simp`'s
+-- matcher via the lifted-cone projection, so the
+-- linter's `simp only [...]` rewrite suggestion is
+-- not equivalent.
+set_option linter.flexible false in
 /-- The right triangle identity:
 `unit (coreflector S) ≫ coreflector.map
 (counit S) = 𝟙`. -/
@@ -323,16 +353,12 @@ theorem arrowCospanAdj_right_triangle
     rw [Category.id_comp,
       Category.assoc,
       (pullbacks S).isLimit.fac]
-    simp only [NatTrans.comp_app]
-    rw [← Category.assoc,
-      (pullbacks _).isLimit.fac]
-    dsimp [arrowCospanAdjUnitCone]
+    simp [arrowCospanAdjUnitCone]
     match j with
     | .one =>
       exact (pullbacks S).cone.w
         WalkingCospan.Hom.inr
-    | .left =>
-      simp only [Category.id_comp]
+    | .left => simp
     | .right => simp
   · simp [arrowCospanAdjUnitApp,
       arrowCospanAdjCounitApp,
@@ -353,29 +379,30 @@ def arrowCospanAdj
     counit := arrowCospanAdjCounit pullbacks
     left_triangle := by
       apply NatTrans.ext; funext f
-      simp only [NatTrans.comp_app,
-        Functor.whiskerRight_app,
-        Functor.whiskerLeft_app,
-        Functor.associator,
-        Category.id_comp]
-      convert arrowCospanAdj_left_triangle
-        pullbacks f using 1
+      have h := arrowCospanAdj_left_triangle pullbacks f
+      simpa [arrowCospanAdjUnit, arrowCospanAdjCounit]
+        using h
     right_triangle := by
       apply NatTrans.ext; funext S
-      simp only [NatTrans.comp_app,
-        Functor.whiskerRight_app,
-        Functor.whiskerLeft_app,
-        Functor.associator,
-        Category.id_comp]
-      convert arrowCospanAdj_right_triangle
-        pullbacks S using 1
+      have h := arrowCospanAdj_right_triangle pullbacks S
+      simpa [arrowCospanAdjUnit, arrowCospanAdjCounit]
+        using h
   }
 
 /-- `Arrow C` is a coreflective subcategory of
 `WalkingCospan ⥤ C` via the arrow-cospan
 inclusion, given an explicit limit cone
-assignment. -/
-instance arrowCospanCoreflective
+assignment.
+
+This is a `@[reducible] def` rather than an
+`instance`: the explicit `pullbacks` argument is
+not inferable from
+`Coreflective (arrowCospanInclusion C)`, so
+typeclass resolution cannot synthesise it.  Call
+sites that have a chosen `pullbacks` family in
+scope can promote this to a local `instance` via
+`local instance := arrowCospanCoreflective ...`. -/
+@[reducible] def arrowCospanCoreflective
     (pullbacks :
       (S : WalkingCospan ⥤ C) → LimitCone S) :
     Coreflective (arrowCospanInclusion C) where


### PR DESCRIPTION
…o build

Complete the unfinished proofs in `ArrowCospanAdjunction.lean` that were silently passing because the file was orphan to `GebLean.lean`, and add the file to the import index so `lake build` will catch any future regressions.

Before this commit Lean filled eight unsolved goals across six declarations with recovery `sorryAx`, surfacing as 11 `sorryAx`-using declarations under `#print axioms`.  None of this was caught by `lake test` or `lake lint` because nothing imported the file.

Replace each failing tactic block with an explicit proof:
- `arrowCospanInclusion.map`: use `sq.w.symm` for the left-square obligation that `simp` could not derive from the `Arrow.Hom.w` field.
- `arrowCospanAdjUnit.naturality`: re-associate via `simp only [← Category.assoc, (pullbacks _).isLimit.fac]` so the `.fac` rewrite fires; close the three `WalkingCospan` legs with `sq.w` (for `.one` and `.right`) and `simp` (for `.left`).
- `arrowCospanAdjCounit.naturality`'s `.left` case: invoke `(pullbacks _).isLimit.fac` directly with the originating cone, replacing the `simp` that could not locate the rewrite.
- `arrowCospanAdj_right_triangle`: the `rw [← Category.assoc, (pullbacks _).isLimit.fac]` chain could not match the associativity pattern under the embedded `NatTrans.app`; replace with a single `simp [arrowCospanAdjUnitCone]` cascade and disable `linter.flexible` locally with an explanatory comment.
- `arrowCospanAdj.{left,right}_triangle`: drop the `convert ... using 1` that left `_ ≫ 𝟙 _ ≫ _` in the goal; use `simpa [arrowCospanAdjUnit, arrowCospanAdjCounit]` to unfold the underlying-app forms and discharge with the per-side triangle lemmas.

Change `arrowCospanCoreflective` from an `instance` to a `@[reducible] def`: the explicit `pullbacks` argument cannot be inferred from `Coreflective (arrowCospanInclusion C)`, so typeclass resolution cannot synthesise it; the `impossibleInstance` linter catches this once the file enters `lake lint`'s scope.

Add `import GebLean.Utilities.ArrowCospanAdjunction` to `GebLean.lean` so subsequent `lake build` / `lake test` runs compile the file and catch regressions before they reach the orphan-rot phase that the preceding `check-axioms` parser fix already turned into a hard failure.

Project-wide axiom check after the fix: 13045 declarations across 214 files use only `Classical.choice` (6946 transitive usages, no change in distribution).  `sorryAx` is no longer present anywhere in the codebase.