### PR TITLE
fix(hooks): replace session-start pinentry prompt with cache note

### DIFF
--- a/geb-lean/.claude/rules/ci-and-workflow.md
+++ b/geb-lean/.claude/rules/ci-and-workflow.md
@@ -104,8 +104,10 @@ Hook scripts in `scripts/hooks/` follow Claude Code's hook contract
 
 `scripts/hooks/block-mutating-git.sh` blocks raw mutating `git`
 and translates blocked commands to their `jj` equivalents in
-stderr. `scripts/hooks/check-signing-key.sh` warms the gpg-agent
-or ssh-agent at session start.
+stderr. `scripts/hooks/check-signing-key.sh` checks at session
+start that the configured signing key is usable (gpg-agent
+passphrase cache, or ssh-agent identities) and emits a hook-JSON
+note on a miss.
 
 ## Action pinning policy
 

--- a/geb-lean/scripts/hooks/check-signing-key.sh
+++ b/geb-lean/scripts/hooks/check-signing-key.sh
@@ -1,9 +1,17 @@
 #!/usr/bin/env bash
-# check-signing-key.sh — SessionStart hook.  Warms the gpg-agent / ssh-agent
-# if commit signing is configured on either git's or jj's side.  Never
-# blocks; exit 0 in all paths.
+# check-signing-key.sh — SessionStart hook.  If commit signing is configured
+# on either git's or jj's side and the signing key is not ready (gpg-agent
+# cache miss, or ssh-agent without identities), emits a hook-JSON note.
+# Never blocks; exit 0 in all paths.
 
 set -u
+
+# Emit a Claude Code hook JSON document carrying $1 as both a user-visible
+# note (systemMessage) and session context (additionalContext).  $1 must
+# not contain JSON-significant characters (double quotes, backslashes).
+note() {
+  printf '{"systemMessage": "%s", "hookSpecificOutput": {"hookEventName": "SessionStart", "additionalContext": "%s"}}\n' "$1" "$1"
+}
 
 # Determine if signing is active on either side.
 git_signing=""
@@ -38,18 +46,49 @@ fi
 
 case "$backend" in
   gpg)
-    if command -v gpg-connect-agent >/dev/null 2>&1; then
-      if ! gpg-connect-agent 'keyinfo --list' /bye 2>/dev/null | grep -q ' 1 '; then
-        # Cache miss: prompt pinentry by performing a small no-op signature.
-        echo warm | gpg --clearsign >/dev/null 2>&1 || true
-      fi
+    command -v gpg >/dev/null 2>&1 || exit 0
+    command -v gpg-connect-agent >/dev/null 2>&1 || exit 0
+
+    # The configured signing key; jj's signing.key takes precedence, then
+    # git's user.signingkey.  Empty selects all local secret keys.
+    key=""
+    if command -v jj >/dev/null 2>&1; then
+      key=$(jj config get signing.key 2>/dev/null || true)
     fi
+    if [[ -z "$key" ]]; then
+      key=$(git config --get user.signingkey 2>/dev/null || true)
+    fi
+
+    # Keygrips of the sign-capable components of the signing key (of all
+    # secret keys when no key is configured): a grp record carries the grip
+    # of the immediately preceding sec/ssb record, whose field 12 holds the
+    # per-key capability letters (lowercase s = sign).
+    grips=$(gpg --with-colons --list-secret-keys ${key:+"$key"} 2>/dev/null \
+      | awk -F: '$1 == "sec" || $1 == "ssb" { cap = $12 }
+                 $1 == "grp" && cap ~ /s/ { print $10 }')
+    if [[ -z "$grips" ]]; then
+      note "Note: gpg commit signing is configured but no sign-capable secret key matches the configured signing key, so any commit attempt will fail to sign."
+      exit 0
+    fi
+
+    # Keygrips whose passphrase gpg-agent currently caches: KEYINFO cached
+    # flag, field 7 of gpg-connect-agent's 'S KEYINFO <grip> ...' lines.
+    cached=$(gpg-connect-agent 'keyinfo --list' /bye 2>/dev/null \
+      | awk '$2 == "KEYINFO" && $7 == "1" { print $3 }')
+    for grip in $grips; do
+      if grep -qxF "$grip" <<<"$cached"; then
+        exit 0
+      fi
+    done
+    note "Note: gpg commit signing is configured but the signing key is not cached, so any automated commit attempt will block."
     ;;
   ssh)
-    # ssh-agent priming.  If SSH_AUTH_SOCK is set, list keys; if empty, the
-    # user's ssh-agent setup is local-policy and we don't try to seed it.
+    # If SSH_AUTH_SOCK is set, check that the agent has identities; if unset,
+    # the user's ssh-agent setup is local-policy and we don't inspect it.
     if [[ -n "${SSH_AUTH_SOCK:-}" ]] && command -v ssh-add >/dev/null 2>&1; then
-      ssh-add -l >/dev/null 2>&1 || true
+      if ! ssh-add -l >/dev/null 2>&1; then
+        note "Note: ssh commit signing is configured but ssh-agent reports no usable identities, so commit attempts may fail to sign."
+      fi
     fi
     ;;
 esac


### PR DESCRIPTION
The SessionStart hook shares the session terminal with the Claude Code TUI, so the previous warm-up (echo warm | gpg --clearsign) spawned pinentry-curses on a terminal already held in raw mode by the TUI; the two programs contend for input and display, corrupting both. The hook now never prompts: it resolves the configured signing key to its sign-capable keygrips, checks gpg-agent passphrase-cache state (or ssh-agent identities for the ssh backend), and emits a hook-JSON note on a miss.