### PR TITLE
implement `gcd` in finite-basis ERA

### DIFF
--- a/geb-lean/GebLean/EraCompleteness.lean
+++ b/geb-lean/GebLean/EraCompleteness.lean
@@ -17,6 +17,7 @@ elementary recursive functions as formalised by `ERMor1`
 * `erOfETm` — translation of an `Era` term to an `ERMor1` term.
 * `eraGeomSum` — the closed-form `ETm 2` for `Σ_{i<bound} q^i`.
 * `eraCentralBinom` — `centralBinomClosed` realised as an `ETm 1`.
+* `eraDelta` — `deltaBlock` realised as an `ETm 2`.
 
 ## Main statements
 
@@ -26,6 +27,7 @@ elementary recursive functions as formalised by `ERMor1`
 * `eraGeomSum_eval` — raw evaluation of `eraGeomSum`.
 * `eraGeomSum_natBSum` — `eraGeomSum` agrees with `natBSum` when the base is at least `2`.
 * `eraCentralBinom_eval` — `eraCentralBinom` evaluates to `centralBinomClosed`.
+* `eraDelta_eval` — `eraDelta` evaluates to `deltaBlock`.
 
 ## References
 
@@ -147,5 +149,18 @@ theorem eraCentralBinom_eval (n : ℕ) :
   simp [eraCentralBinom, centralBinomClosed, emod, ediv, emul, epow, epow2, eadd,
     Tm.eval, eraInterp, fcons]
   ring_nf
+
+/-- `deltaBlock` realised as an `Era` term (variable 0 = a, 1 = w). -/
+def eraDelta : ETm 2 :=
+  let a : ETm 2 := .var 0
+  let w : ETm 2 := .var 1
+  let pw := epow2 w
+  emul (etsub pw (.succ .zero)) (.succ (etsub pw a))
+
+/-- `eraDelta` evaluates to `deltaBlock`. -/
+theorem eraDelta_eval (a w : ℕ) :
+    Tm.eval eraInterp eraDelta ![a, w] = deltaBlock a w := by
+  simp [eraDelta, deltaBlock, emul, etsub, epow2, Tm.eval, eraInterp, fcons,
+    Matrix.cons_val_zero, Matrix.cons_val_one]
 
 end GebLean.EraCompleteness

--- a/geb-lean/GebLean/EraCompleteness.lean
+++ b/geb-lean/GebLean/EraCompleteness.lean
@@ -2,6 +2,7 @@ import GebLean.Era
 import GebLean.LawvereER
 import GebLean.Utilities.ERArith
 import GebLean.Utilities.EraBoundedSum
+import GebLean.Utilities.ArithClosedForms
 
 /-!
 # Era basis completeness bridge
@@ -15,6 +16,7 @@ elementary recursive functions as formalised by `ERMor1`
 * `eraOpToER` — the `ERMor1` witness for each basis operation.
 * `erOfETm` — translation of an `Era` term to an `ERMor1` term.
 * `eraGeomSum` — the closed-form `ETm 2` for `Σ_{i<bound} q^i`.
+* `eraCentralBinom` — `centralBinomClosed` realised as an `ETm 1`.
 
 ## Main statements
 
@@ -23,6 +25,7 @@ elementary recursive functions as formalised by `ERMor1`
   (the inclusion `Era ⊆ E³`).
 * `eraGeomSum_eval` — raw evaluation of `eraGeomSum`.
 * `eraGeomSum_natBSum` — `eraGeomSum` agrees with `natBSum` when the base is at least `2`.
+* `eraCentralBinom_eval` — `eraCentralBinom` evaluates to `centralBinomClosed`.
 
 ## References
 
@@ -124,5 +127,25 @@ theorem eraGeomSum_natBSum (q bound : ℕ) (hq : 2 ≤ q) :
   rw [eraGeomSum_eval]
   simp only [Matrix.cons_val_zero, Matrix.cons_val_one]
   rw [natBSum_geom q bound hq]
+
+/-- `centralBinomClosed` realised as an `Era` term (variable 0 = n).
+The term encodes `((1 + 2^(2n))^(2n) / 2^(2n²)) % 2^(2n)` with
+`twoN := n + n = 2n`, `epow2 twoN = 2^(2n)`,
+`epow2 (twoN *ᵉ var0) = 2^((2n)*n) = 2^(2n²)`. -/
+def eraCentralBinom : ETm 1 :=
+  let var0 : ETm 1 := .var 0
+  let twoN  := var0 +ᵉ var0
+  emod
+    (ediv
+      (epow (.succ (epow2 twoN)) twoN)
+      (epow2 (twoN *ᵉ var0)))
+    (epow2 twoN)
+
+/-- `eraCentralBinom` evaluates to `centralBinomClosed`. -/
+theorem eraCentralBinom_eval (n : ℕ) :
+    Tm.eval eraInterp eraCentralBinom ![n] = centralBinomClosed n := by
+  simp [eraCentralBinom, centralBinomClosed, emod, ediv, emul, epow, epow2, eadd,
+    Tm.eval, eraInterp, fcons]
+  ring_nf
 
 end GebLean.EraCompleteness

--- a/geb-lean/GebLean/Utilities/ArithClosedForms.lean
+++ b/geb-lean/GebLean/Utilities/ArithClosedForms.lean
@@ -19,12 +19,14 @@ digit-block indicator, each equated to a Mathlib reference function.
 * `nu2Closed` — the slow, log-free `2`-adic valuation closed form.
 * `centralBinomClosed` — the central binomial coefficient as a
   base-`2^(2n)` digit read-off of `(1 + 2^(2n))^(2n)`.
+* `hwClosed` — the binary Hamming weight as `ν₂(C(2n,n))` (Kummer).
 
 ## Main statements
 
 * `nu2Closed_eq` — `nu2Closed n = padicValNat 2 n` for `n ≥ 1`.
 * `centralBinomClosed_eq` — `centralBinomClosed n = Nat.centralBinom n`
   for `n ≥ 1`.
+* `hwClosed_eq` — `hwClosed n = (Nat.digits 2 n).sum` for `n ≥ 1`.
 
 ## References
 
@@ -177,5 +179,36 @@ theorem centralBinomClosed_eq (n : ℕ) (hn : 1 ≤ n) :
     rw [hgE] at h2
     exact List.head!_of_head? h2
   rw [hhead, Nat.mod_eq_of_lt (choose_two_mul_lt n n hn)]
+
+private theorem sum_digits_two_mul (n : ℕ) :
+    (Nat.digits 2 (2 * n)).sum = (Nat.digits 2 n).sum := by
+  rcases Nat.eq_zero_or_pos n with hn | hn
+  · simp [hn]
+  · rw [Nat.digits_base_mul (by norm_num) hn]; simp
+
+/-- Kummer's theorem at `p = 2`: the `2`-adic valuation of the central
+binomial coefficient equals the binary digit sum,
+`ν₂(C(2n,n)) = S₂(n)`. -/
+theorem padicValNat_centralBinom_two (n : ℕ) :
+    padicValNat 2 (Nat.centralBinom n) = (Nat.digits 2 n).sum := by
+  have hp : Fact (Nat.Prime 2) := ⟨Nat.prime_two⟩
+  have hkummer := sub_one_mul_padicValNat_choose_eq_sub_sum_digits
+    (p := 2) (k := n) (n := 2 * n) (by omega)
+  rw [Nat.centralBinom_eq_two_mul_choose]
+  have hsub : 2 * n - n = n := by omega
+  rw [hsub] at hkummer
+  rw [sum_digits_two_mul] at hkummer
+  omega
+
+/-- Binary Hamming weight (digit sum) `σ`, as `ν₂(C(2n,n))` (Kummer),
+using the slow log-free `ν₂`. -/
+def hwClosed (n : ℕ) : ℕ := nu2Closed (centralBinomClosed n)
+
+/-- The Hamming-weight closed form computes the binary digit sum: for
+`n ≥ 1`, `hwClosed n = (Nat.digits 2 n).sum`. -/
+theorem hwClosed_eq (n : ℕ) (hn : 1 ≤ n) :
+    hwClosed n = (Nat.digits 2 n).sum := by
+  rw [hwClosed, centralBinomClosed_eq n hn, nu2Closed_eq _ (Nat.centralBinom_pos n),
+    padicValNat_centralBinom_two]
 
 end GebLean

--- a/geb-lean/GebLean/Utilities/ArithClosedForms.lean
+++ b/geb-lean/GebLean/Utilities/ArithClosedForms.lean
@@ -21,6 +21,7 @@ digit-block indicator, each equated to a Mathlib reference function.
   base-`2^(2n)` digit read-off of `(1 + 2^(2n))^(2n)`.
 * `hwClosed` — the binary Hamming weight as `ν₂(C(2n,n))` (Kummer).
 * `deltaBlock` — the digit-block indicator `δ a w = (2^w - 1)(2^w - a + 1)`.
+* `solCount` — the number of `(x, y) ∈ ℕ²` with `a·x + b·y = n`.
 
 ## Main statements
 
@@ -30,6 +31,9 @@ digit-block indicator, each equated to a Mathlib reference function.
 * `hwClosed_eq` — `hwClosed n = (Nat.digits 2 n).sum` for `n ≥ 1`.
 * `hwClosed_deltaBlock` — `HW(δ a w) = 2w` if `a = 0`, else `w`, for
   `a < 2^w`.
+* `solCount_le_succ` — `solCount a b n ≤ n + 1` for `1 ≤ a, 1 ≤ b`.
+* `solCount_mul_eq_gcd_succ` — `solCount a b (a * b) = gcd a b + 1` for
+  `1 ≤ a, 1 ≤ b` (the Prunescu–Shunia gcd linear-Diophantine count).
 
 ## References
 
@@ -307,5 +311,140 @@ theorem hwClosed_deltaBlock {a w : ℕ} (ha : a < 2 ^ w) :
       have hcompl := sum_digits_two_compl w (a - 1) hlow
       have hcomp_eq : 2 ^ w - a = 2 ^ w - 1 - (a - 1) := by omega
       rw [hcomp_eq, hcompl, if_neg ha0]
+
+/-- The number of `(x, y) ∈ ℕ²` with `a·x + b·y = n`. Finite for
+`1 ≤ a, 1 ≤ b` (every solution lies in the `(n+1)×(n+1)` box). -/
+def solCount (a b n : ℕ) : ℕ :=
+  ((Finset.range (n + 1) ×ˢ Finset.range (n + 1)).filter
+    (fun p => a * p.1 + b * p.2 = n)).card
+
+private theorem mem_solCount_box (a b n x y : ℕ) (ha : 1 ≤ a) (hb : 1 ≤ b)
+    (h : a * x + b * y = n) : x < n + 1 ∧ y < n + 1 := by
+  have hx : x ≤ a * x := Nat.le_mul_of_pos_left x ha
+  have hy : y ≤ b * y := Nat.le_mul_of_pos_left y hb
+  omega
+
+/-- For `1 ≤ a, 1 ≤ b`, the solution count of `a·x + b·y = n` is at most
+`n + 1`: the map `(x, y) ↦ (a·x, b·y)` injects the solutions into
+`Finset.antidiagonal n`. Equality holds at `a = b = 1`. -/
+theorem solCount_le_succ (a b n : ℕ) (ha : 1 ≤ a) (hb : 1 ≤ b) :
+    solCount a b n ≤ n + 1 := by
+  rw [solCount, ← Finset.Nat.card_antidiagonal n]
+  apply Finset.card_le_card_of_injOn (fun p => (a * p.1, b * p.2))
+  · intro p hp
+    simp only [Finset.coe_filter, Set.mem_setOf_eq] at hp
+    simp only [Finset.mem_coe, Finset.mem_antidiagonal]
+    exact hp.2
+  · intro p hp q hq hpq
+    simp only [Finset.coe_filter, Set.mem_setOf_eq,
+      Finset.mem_product, Finset.mem_range] at hp hq
+    simp only [Prod.mk.injEq] at hpq
+    have h1 : p.1 = q.1 := Nat.eq_of_mul_eq_mul_left ha hpq.1
+    have h2 : p.2 = q.2 := Nat.eq_of_mul_eq_mul_left hb hpq.2
+    exact Prod.ext h1 h2
+
+/-- The Prunescu–Shunia gcd linear-Diophantine count: for `1 ≤ a, 1 ≤ b`,
+the number of `(x, y) ∈ ℕ²` with `a·x + b·y = a·b` equals
+`gcd a b + 1`. With `d = gcd a b`, the solutions are exactly
+`(b - (b/d)·t, (a/d)·t)` for `t = 0, …, d`. -/
+theorem solCount_mul_eq_gcd_succ (a b : ℕ) (ha : 1 ≤ a) (hb : 1 ≤ b) :
+    solCount a b (a * b) = Nat.gcd a b + 1 := by
+  set d := Nat.gcd a b with hd
+  have hdpos : 1 ≤ d := Nat.gcd_pos_of_pos_left b ha
+  have hda : d ∣ a := Nat.gcd_dvd_left a b
+  have hdb : d ∣ b := Nat.gcd_dvd_right a b
+  set a' := a / d with ha'
+  set b' := b / d with hb'
+  have hada : d * a' = a := Nat.mul_div_cancel' hda
+  have hbdb : d * b' = b := Nat.mul_div_cancel' hdb
+  have ha'pos : 1 ≤ a' := by
+    rcases Nat.eq_zero_or_pos a' with h | h
+    · rw [h, Nat.mul_zero] at hada; omega
+    · exact h
+  have hb'pos : 1 ≤ b' := by
+    rcases Nat.eq_zero_or_pos b' with h | h
+    · rw [h, Nat.mul_zero] at hbdb; omega
+    · exact h
+  -- a * b' = a' * b = a*b / d
+  have hcross : a * b' = b * a' := by
+    rw [← hada, ← hbdb]; ring
+  -- key equation: for t ≤ d, the forward map lands in the solution set
+  have hbt : ∀ t : ℕ, t ≤ d → b' * t ≤ b := by
+    intro t ht
+    have : b' * t ≤ b' * d := Nat.mul_le_mul_left b' ht
+    rw [Nat.mul_comm b' d, hbdb] at this; exact this
+  have hsol : ∀ t : ℕ, t ≤ d →
+      a * (b - b' * t) + b * (a' * t) = a * b := by
+    intro t ht
+    have hle := hbt t ht
+    have h1 : a * (b - b' * t) = a * b - a * (b' * t) := Nat.mul_sub a b (b' * t)
+    have h2 : a * (b' * t) = b * (a' * t) := by
+      rw [← Nat.mul_assoc, ← Nat.mul_assoc, hcross]
+    have h3 : a * (b' * t) ≤ a * b := Nat.mul_le_mul_left a hle
+    omega
+  have hcop : a'.Coprime b' := Nat.coprime_div_gcd_div_gcd (by omega)
+  -- characterization: every solution is `(b - b'*t, a'*t)` for some `t ≤ d`
+  have hchar : ∀ x y : ℕ, a * x + b * y = a * b →
+      a' ∣ y ∧ y / a' ≤ d ∧ x = b - b' * (y / a') ∧ y = a' * (y / a') := by
+    intro x y hxy
+    -- reduce by d : a'*x + b'*y = a'*b
+    have hred : a' * x + b' * y = a' * b := by
+      have hmul : d * (a' * x + b' * y) = d * (a' * b) := by
+        have e : d * (a' * x + b' * y) = a * x + b * y := by
+          rw [Nat.mul_add, ← Nat.mul_assoc, ← Nat.mul_assoc, hada, hbdb]
+        have e2 : d * (a' * b) = a * b := by
+          rw [← Nat.mul_assoc, hada]
+        rw [e, e2, hxy]
+      exact Nat.eq_of_mul_eq_mul_left (by omega) hmul
+    -- a' ∣ b'*y, hence a' ∣ y by coprimality
+    have hdvd : a' ∣ b' * y := by
+      have hsum : a' ∣ a' * x + b' * y := by rw [hred]; exact Dvd.intro b rfl
+      exact (Nat.dvd_add_right (Dvd.intro x rfl)).mp hsum
+    have hay : a' ∣ y := hcop.dvd_of_dvd_mul_left hdvd
+    set t := y / a' with htdef
+    have hyt : y = a' * t := (Nat.mul_div_cancel' hay).symm
+    -- substitute: a'*x + b'*a'*t = a'*b ⇒ x + b'*t = b
+    have hxbt : x + b' * t = b := by
+      have hstep : a' * (x + b' * t) = a' * b := by
+        rw [Nat.mul_add]
+        have hre : b' * y = a' * (b' * t) := by
+          rw [hyt]; ring
+        rw [hre] at hred; exact hred
+      exact Nat.eq_of_mul_eq_mul_left (by omega) hstep
+    have htd : t ≤ d := by
+      have : b' * t ≤ b := by omega
+      have h2 : b' * t ≤ b' * d := by rw [Nat.mul_comm b' d, hbdb]; omega
+      exact Nat.le_of_mul_le_mul_left h2 (by omega)
+    exact ⟨hay, htd, by omega, hyt⟩
+  rw [solCount, ← Finset.card_range (d + 1)]
+  symm
+  apply Finset.card_nbij' (fun t => (b - b' * t, a' * t)) (fun p => p.2 / a')
+  · -- MapsTo i : range (d+1) → solutions
+    intro t ht
+    simp only [Finset.coe_range, Set.mem_Iio] at ht
+    simp only [Finset.coe_filter, Set.mem_setOf_eq, Finset.mem_product,
+      Finset.mem_range]
+    have heq := hsol t (by omega)
+    obtain ⟨hx, hy⟩ := mem_solCount_box a b (a * b) (b - b' * t) (a' * t) ha hb heq
+    exact ⟨⟨hx, hy⟩, heq⟩
+  · -- MapsTo j : solutions → range (d+1)
+    intro p hp
+    simp only [Finset.coe_filter, Set.mem_setOf_eq, Finset.mem_product,
+      Finset.mem_range] at hp
+    simp only [Finset.coe_range, Set.mem_Iio]
+    obtain ⟨-, htd, -, -⟩ := hchar p.1 p.2 hp.2
+    omega
+  · -- left_inv : j (i t) = t for t ∈ range (d+1)
+    intro t ht
+    simp only [Finset.coe_range, Set.mem_Iio] at ht
+    simp only [Nat.mul_div_cancel_left t (by omega : 0 < a')]
+  · -- right_inv : i (j p) = p for solutions p
+    intro p hp
+    simp only [Finset.coe_filter, Set.mem_setOf_eq, Finset.mem_product,
+      Finset.mem_range] at hp
+    obtain ⟨-, -, hx, hy⟩ := hchar p.1 p.2 hp.2
+    apply Prod.ext
+    · simp only; rw [← hx]
+    · simp only; rw [← hy]
 
 end GebLean

--- a/geb-lean/GebLean/Utilities/ArithClosedForms.lean
+++ b/geb-lean/GebLean/Utilities/ArithClosedForms.lean
@@ -20,6 +20,7 @@ digit-block indicator, each equated to a Mathlib reference function.
 * `centralBinomClosed` — the central binomial coefficient as a
   base-`2^(2n)` digit read-off of `(1 + 2^(2n))^(2n)`.
 * `hwClosed` — the binary Hamming weight as `ν₂(C(2n,n))` (Kummer).
+* `deltaBlock` — the digit-block indicator `δ a w = (2^w - 1)(2^w - a + 1)`.
 
 ## Main statements
 
@@ -27,6 +28,8 @@ digit-block indicator, each equated to a Mathlib reference function.
 * `centralBinomClosed_eq` — `centralBinomClosed n = Nat.centralBinom n`
   for `n ≥ 1`.
 * `hwClosed_eq` — `hwClosed n = (Nat.digits 2 n).sum` for `n ≥ 1`.
+* `hwClosed_deltaBlock` — `HW(δ a w) = 2w` if `a = 0`, else `w`, for
+  `a < 2^w`.
 
 ## References
 
@@ -210,5 +213,99 @@ theorem hwClosed_eq (n : ℕ) (hn : 1 ≤ n) :
     hwClosed n = (Nat.digits 2 n).sum := by
   rw [hwClosed, centralBinomClosed_eq n hn, nu2Closed_eq _ (Nat.centralBinom_pos n),
     padicValNat_centralBinom_two]
+
+private theorem sum_digits_two_succ (n : ℕ) :
+    (Nat.digits 2 n).sum = n % 2 + (Nat.digits 2 (n / 2)).sum := by
+  rcases Nat.eq_zero_or_pos n with h | h
+  · simp [h]
+  · rw [Nat.digits_def' (by norm_num) h]; simp
+
+private theorem sum_digits_two_add (w x y : ℕ) (hx : x < 2 ^ w) :
+    (Nat.digits 2 (x + 2 ^ w * y)).sum
+      = (Nat.digits 2 x).sum + (Nat.digits 2 y).sum := by
+  induction w generalizing x with
+  | zero => simp_all
+  | succ k ih =>
+    have hpow : (2 : ℕ) ^ (k + 1) * y = 2 * (2 ^ k * y) := by rw [pow_succ]; ring
+    rw [sum_digits_two_succ (x + 2 ^ (k + 1) * y), sum_digits_two_succ x, hpow]
+    set t := 2 ^ k * y with ht
+    have hmod : (x + 2 * t) % 2 = x % 2 := by omega
+    have hdiv : (x + 2 * t) / 2 = x / 2 + t := by omega
+    rw [hmod, hdiv]
+    have hxd : x / 2 < 2 ^ k := by omega
+    rw [ht, ih (x / 2) hxd]
+    omega
+
+private theorem sum_digits_two_compl (w m : ℕ) (hm : m < 2 ^ w) :
+    (Nat.digits 2 m).sum + (Nat.digits 2 (2 ^ w - 1 - m)).sum = w := by
+  induction w generalizing m with
+  | zero => interval_cases m; simp
+  | succ k ih =>
+    have hpow : 2 ^ (k + 1) = 2 * 2 ^ k := by rw [pow_succ]; ring
+    have hmdiv : m / 2 < 2 ^ k := by omega
+    have hc : 2 ^ (k + 1) - 1 - m = 2 * (2 ^ k - 1 - m / 2) + (1 - m % 2) := by
+      have := Nat.div_add_mod m 2
+      have hk1 : (1 : ℕ) ≤ 2 ^ k := Nat.one_le_two_pow
+      omega
+    rw [sum_digits_two_succ m, sum_digits_two_succ (2 ^ (k + 1) - 1 - m), hc]
+    rw [Nat.mul_add_mod, Nat.mul_add_div (by norm_num)]
+    have hmod : m % 2 < 2 := Nat.mod_lt _ (by norm_num)
+    have hsub : (1 - m % 2) / 2 = 0 := by omega
+    rw [hsub, Nat.add_zero]
+    have := ih (m / 2) hmdiv
+    omega
+
+/-- The digit-block indicator (arXiv:2407.12928, Lemma 3.1):
+`δ a w = (2^w - 1)(2^w - a + 1)`. -/
+def deltaBlock (a w : ℕ) : ℕ := (2 ^ w - 1) * (2 ^ w - a + 1)
+
+/-- `HW(δ a w) = 2w` when `a = 0`, else `w`, for `0 ≤ a < 2^w`. -/
+theorem hwClosed_deltaBlock {a w : ℕ} (ha : a < 2 ^ w) :
+    hwClosed (deltaBlock a w) = if a = 0 then 2 * w else w := by
+  rcases Nat.eq_zero_or_pos w with hw | hw
+  · -- `w = 0` forces `a = 0` and `deltaBlock = 0`
+    subst hw
+    have ha0 : a = 0 := by simpa using ha
+    subst ha0
+    rfl
+  · have hbig : (2 : ℕ) ^ w ≥ 2 := by
+      calc (2 : ℕ) ^ w ≥ 2 ^ 1 := Nat.pow_le_pow_right (by norm_num) hw
+        _ = 2 := by norm_num
+    by_cases ha0 : a = 0
+    · -- high-bit-only block: `δ 0 w = 2^(2w) - 1`, digit sum `2w`
+      subst ha0
+      have hd : deltaBlock 0 w = 2 ^ (2 * w) - 1 := by
+        have hpow : (2 : ℕ) ^ (2 * w) = 2 ^ w * 2 ^ w := by rw [two_mul, pow_add]
+        unfold deltaBlock
+        rw [Nat.sub_zero, hpow, Nat.sub_one_mul, Nat.mul_add, Nat.mul_one]
+        omega
+      have h1d : 1 ≤ deltaBlock 0 w := by
+        rw [hd]
+        have : (2 : ℕ) ^ (2 * w) ≥ 2 := by
+          calc (2 : ℕ) ^ (2 * w) ≥ 2 ^ 1 := Nat.pow_le_pow_right (by norm_num) (by omega)
+            _ = 2 := by norm_num
+        omega
+      rw [hwClosed_eq _ h1d, hd]
+      have hcompl := sum_digits_two_compl (2 * w) 0 (by positivity)
+      simp only [Nat.digits_zero, List.sum_nil, Nat.sub_zero, Nat.zero_add] at hcompl
+      rw [hcompl, if_pos rfl]
+    · -- two-block: `δ a w = (a-1) + 2^w * (2^w - a)`, digit sum `w`
+      have ha1 : 1 ≤ a := Nat.one_le_iff_ne_zero.mpr ha0
+      have hd : deltaBlock a w = (a - 1) + 2 ^ w * (2 ^ w - a) := by
+        have hmul : (2 : ℕ) ^ w * (2 ^ w - a + 1) = 2 ^ w * (2 ^ w - a) + 2 ^ w := by
+          rw [Nat.mul_add, Nat.mul_one]
+        unfold deltaBlock
+        rw [Nat.sub_one_mul, hmul]
+        omega
+      have hlow : a - 1 < 2 ^ w := by omega
+      have h1d : 1 ≤ deltaBlock a w := by
+        rw [hd]
+        have hpos : 1 ≤ 2 ^ w - a := by omega
+        have : 2 ^ w ≤ 2 ^ w * (2 ^ w - a) := Nat.le_mul_of_pos_right _ hpos
+        omega
+      rw [hwClosed_eq _ h1d, hd, sum_digits_two_add w (a - 1) (2 ^ w - a) hlow]
+      have hcompl := sum_digits_two_compl w (a - 1) hlow
+      have hcomp_eq : 2 ^ w - a = 2 ^ w - 1 - (a - 1) := by omega
+      rw [hcomp_eq, hcompl, if_neg ha0]
 
 end GebLean

--- a/geb-lean/GebLean/Utilities/ArithClosedForms.lean
+++ b/geb-lean/GebLean/Utilities/ArithClosedForms.lean
@@ -1,4 +1,5 @@
 import GebLean.LawvereER
+import GebLean.Utilities.EraBoundedSum
 import Mathlib.NumberTheory.Padics.PadicVal.Basic
 import Mathlib.Data.Nat.Choose.Central
 import Mathlib.Data.Nat.Choose.Factorization
@@ -647,5 +648,79 @@ private theorem gcd_dena_pow (a b : ℕ) :
 private theorem gcd_denb_pow (a b : ℕ) :
     5 ^ (a * b ^ 2) = (5 ^ (a * b)) ^ b := by
   rw [← pow_mul]; congr 1; ring
+
+/-- The base-`5^(a·b)` comb `P = 5^((a·b+a+b) mod a) · Σ_{i<(a·b+a+b)/a} (5^(a·b))^(a·i)`,
+the exact quotient `⌊5^(a·b·(a·b+a+b)) / (5^(a²·b)−1)⌋` written in base `5^(a·b)`. -/
+private def gcdPComb (a b : ℕ) : ℕ :=
+  (5 ^ (a * b)) ^ ((a * b + a + b) % a) *
+    ∑ i ∈ Finset.range ((a * b + a + b) / a), (5 ^ (a * b)) ^ (a * i)
+
+/-- Two-step division identity: `(5^(a·b))^(a·b+a+b) = ((5^(a·b))^a − 1) · P + (5^(a·b))^r`,
+where `P = gcdPComb a b` and `r = (a·b+a+b) % a`. -/
+private theorem gcd_num_split (a b : ℕ) (ha : 1 ≤ a) (hb : 1 ≤ b) :
+    (5 ^ (a * b)) ^ (a * b + a + b)
+      = ((5 ^ (a * b)) ^ a - 1) * gcdPComb a b
+          + (5 ^ (a * b)) ^ ((a * b + a + b) % a) := by
+  simp only [gcdPComb]
+  -- Set B := 5^(a*b), E := a*b+a+b, q := E/a, r := E%a
+  set B := 5 ^ (a * b) with hBdef
+  set E := a * b + a + b with hEdef
+  set q := E / a with hqdef
+  set r := E % a with hrdef
+  -- r + a * q = E
+  have hEqr : r + a * q = E := by
+    have hdm : a * q + r = E := by
+      rw [hqdef, hrdef, hEdef]; exact Nat.div_add_mod (a * b + a + b) a
+    linarith
+  have hab : 1 ≤ a * b := Nat.one_le_iff_ne_zero.mpr (Nat.mul_ne_zero (by omega) (by omega))
+  have hB1 : 1 ≤ B := Nat.one_le_pow _ _ (by omega)
+  have hBa : 1 ≤ B ^ a := Nat.one_le_pow _ _ hB1
+  have hBaq_ge : 1 ≤ (B ^ a) ^ q := Nat.one_le_pow _ _ hBa
+  -- Rewrite summands: B^(a*i) = (B^a)^i
+  have hstep : ∀ i : ℕ, B ^ (a * i) = (B ^ a) ^ i := fun i => pow_mul B a i
+  simp_rw [hstep]
+  -- (B^a - 1) * ∑ i<q, (B^a)^i = (B^a)^q - 1
+  have hprod : (B ^ a - 1) * ∑ i ∈ Finset.range q, (B ^ a) ^ i = (B ^ a) ^ q - 1 := by
+    have hg := natGeomSum_mul (B ^ a) q hBa
+    linarith [Nat.mul_comm (∑ i ∈ Finset.range q, (B ^ a) ^ i) (B ^ a - 1)]
+  -- Rewrite lhs: B^E = B^(r + a*q) = B^r * (B^a)^q
+  conv_lhs => rw [← hEqr, pow_add, pow_mul]
+  -- Goal: B^r * (B^a)^q = (B^a-1)*(B^r * ∑ i<q, (B^a)^i) + B^r
+  -- Simplify rhs: (B^a-1)*(B^r*S) = B^r*((B^a-1)*S) = B^r*((B^a)^q - 1)
+  rw [show (B ^ a - 1) * (B ^ r * ∑ i ∈ Finset.range q, (B ^ a) ^ i) =
+      B ^ r * ((B ^ a) ^ q - 1) from by
+    rw [← Nat.mul_assoc, Nat.mul_comm (B ^ a - 1) (B ^ r), Nat.mul_assoc, hprod]]
+  -- Goal: B^r * (B^a)^q = B^r * ((B^a)^q - 1) + B^r
+  nth_rw 1 [← Nat.sub_add_cancel (Nat.le_mul_of_pos_right (B ^ r)
+    (by linarith [hBaq_ge] : 0 < (B ^ a) ^ q)), Nat.mul_sub_one]
+
+/-- The remainder is strictly less than the denominator factor:
+`(5^(a·b))^((a·b+a+b) % a) < (5^(a·b))^a − 1`. -/
+private theorem gcd_rem_lt_dena (a b : ℕ) (ha : 1 ≤ a) (hb : 1 ≤ b) :
+    (5 ^ (a * b)) ^ ((a * b + a + b) % a) < (5 ^ (a * b)) ^ a - 1 := by
+  set B := 5 ^ (a * b) with hBdef
+  set r := (a * b + a + b) % a with hrdef
+  have hr : r < a := Nat.mod_lt _ (by omega)
+  have hB1 : 1 ≤ B := Nat.one_le_pow _ _ (by omega)
+  -- B ≥ 5 since a*b ≥ 1 (a,b ≥ 1)
+  have hB5 : 5 ≤ B := by
+    rw [hBdef]
+    calc (5 : ℕ) = 5 ^ 1 := (pow_one 5).symm
+      _ ≤ 5 ^ (a * b) := Nat.pow_le_pow_right (by omega) (by nlinarith)
+  -- B^r ≤ B^(a-1) since r ≤ a-1
+  have hBr_le : B ^ r ≤ B ^ (a - 1) := Nat.pow_le_pow_right hB1 (by omega)
+  -- B^(a-1) ≥ 1
+  have hBa1 : 1 ≤ B ^ (a - 1) := Nat.one_le_pow _ _ hB1
+  -- B^a = B^(a-1) * B (since a = (a-1)+1)
+  have hBa_eq : B ^ a = B ^ (a - 1) * B := by
+    conv_lhs => rw [show a = a - 1 + 1 by omega]
+    rw [pow_succ]
+  -- B^(a-1) < B^a - 1
+  have hBa1_lt : B ^ (a - 1) < B ^ a - 1 := by
+    rw [hBa_eq]
+    have h5 : B ^ (a - 1) * 5 ≤ B ^ (a - 1) * B := Nat.mul_le_mul_left _ hB5
+    have hge : 1 ≤ B ^ (a - 1) * B := Nat.le_trans hBa1 (Nat.le_mul_of_pos_right _ (by linarith))
+    omega
+  linarith
 
 end GebLean

--- a/geb-lean/GebLean/Utilities/ArithClosedForms.lean
+++ b/geb-lean/GebLean/Utilities/ArithClosedForms.lean
@@ -630,4 +630,22 @@ private theorem gcdDigitSum_mod (a b : ℕ) (ha : 1 ≤ a) (hb : 1 ≤ b) :
   rw [hfactor, Nat.add_comm, Nat.add_mul_mod_self_left]
   exact Nat.mod_eq_of_lt (solCount_mul_lt_base a b ha hb)
 
+/-- Closed-form numerator exponent in base `5^(a·b)`:
+`5^(a·b·(a·b+a+b)) = (5^(a·b))^(a·b+a+b)`. -/
+private theorem gcd_num_pow (a b : ℕ) :
+    5 ^ (a * b * (a * b + a + b)) = (5 ^ (a * b)) ^ (a * b + a + b) := by
+  rw [← pow_mul]
+
+/-- First denominator factor exponent in base `5^(a·b)`:
+`5^(a²·b) = (5^(a·b))^a`. -/
+private theorem gcd_dena_pow (a b : ℕ) :
+    5 ^ (a ^ 2 * b) = (5 ^ (a * b)) ^ a := by
+  rw [← pow_mul]; congr 1; ring
+
+/-- Second denominator factor exponent in base `5^(a·b)`:
+`5^(a·b²) = (5^(a·b))^b`. -/
+private theorem gcd_denb_pow (a b : ℕ) :
+    5 ^ (a * b ^ 2) = (5 ^ (a * b)) ^ b := by
+  rw [← pow_mul]; congr 1; ring
+
 end GebLean

--- a/geb-lean/GebLean/Utilities/ArithClosedForms.lean
+++ b/geb-lean/GebLean/Utilities/ArithClosedForms.lean
@@ -596,4 +596,38 @@ private theorem solCount_recurrence (a b m : ℕ) (ha : 1 ≤ a) (hb : 1 ≤ b)
   rw [hSxcard, hSycard, hintercard, hScard] at hincl
   exact hincl
 
+/-- Base-`5^(a·b)` digit sum encoding the linear-Diophantine counts:
+`S = Σ_{k=0}^{a·b} solCount a b (a·b − k) · (5^(a·b))^k`. Equals
+`⌊5^(a·b·(a·b+a+b)) / ((5^(a²·b)−1)(5^(a·b²)−1))⌋` (proved later). -/
+private def gcdDigitSum (a b : ℕ) : ℕ :=
+  ∑ k ∈ Finset.range (a * b + 1),
+    solCount a b (a * b - k) * (5 ^ (a * b)) ^ k
+
+/-- Each digit `solCount a b (a*b)` is strictly less than the base `5^(a*b)`,
+so digits do not overflow into adjacent positions in `gcdDigitSum`. -/
+private theorem solCount_mul_lt_base (a b : ℕ) (ha : 1 ≤ a) (hb : 1 ≤ b) :
+    solCount a b (a * b) < 5 ^ (a * b) := by
+  have h1 : solCount a b (a * b) ≤ a * b + 1 := solCount_le_succ a b (a * b) ha hb
+  have h2 : a * b < 2 ^ (a * b) := Nat.lt_two_pow_self
+  have h3 : a * b ≠ 0 := Nat.mul_ne_zero (by omega) (by omega)
+  have h4 : (2 : ℕ) ^ (a * b) < 5 ^ (a * b) :=
+    Nat.pow_lt_pow_left (by norm_num) h3
+  omega
+
+/-- The least-significant digit of `gcdDigitSum a b` in base `5^(a*b)` equals
+`solCount a b (a*b)`: every higher-indexed term is divisible by `5^(a*b)`. -/
+private theorem gcdDigitSum_mod (a b : ℕ) (ha : 1 ≤ a) (hb : 1 ≤ b) :
+    gcdDigitSum a b % 5 ^ (a * b) = solCount a b (a * b) := by
+  simp only [gcdDigitSum]
+  rw [Finset.sum_range_succ']
+  simp only [pow_zero, mul_one]
+  have hfactor : ∑ k ∈ Finset.range (a * b),
+      solCount a b (a * b - (k + 1)) * (5 ^ (a * b)) ^ (k + 1) =
+      5 ^ (a * b) * ∑ k ∈ Finset.range (a * b),
+      solCount a b (a * b - (k + 1)) * (5 ^ (a * b)) ^ k := by
+    rw [Finset.mul_sum]
+    congr 1; ext k; rw [pow_succ']; ring
+  rw [hfactor, Nat.add_comm, Nat.add_mul_mod_self_left]
+  exact Nat.mod_eq_of_lt (solCount_mul_lt_base a b ha hb)
+
 end GebLean

--- a/geb-lean/GebLean/Utilities/ArithClosedForms.lean
+++ b/geb-lean/GebLean/Utilities/ArithClosedForms.lean
@@ -723,4 +723,143 @@ private theorem gcd_rem_lt_dena (a b : ℕ) (ha : 1 ≤ a) (hb : 1 ≤ b) :
     omega
   linarith
 
+/-- The Prunescu–Shunia tooth-count identity: the number of comb teeth
+`r + a·i` (`i < q`, `r := (a·b+a+b) % a`, `q := (a·b+a+b) / a`) congruent
+to `e` mod `b` and exceeding `e` equals `solCount a b (a·b − e)`, for
+`e ≤ a·b`. The combinatorial heart of the base-5 gcd closed form. -/
+private theorem gcd_tooth_count (a b e : ℕ) (ha : 1 ≤ a) (hb : 1 ≤ b)
+    (he : e ≤ a * b) :
+    ((Finset.range ((a * b + a + b) / a)).filter
+        (fun i => ((a * b + a + b) % a + a * i) % b = e % b
+          ∧ e < (a * b + a + b) % a + a * i)).card
+      = solCount a b (a * b - e) := by
+  set E := a * b + a + b with hEdef
+  set n := a * b with hndef
+  set q := E / a with hqdef
+  set r := E % a with hrdef
+  have hEqr : r + a * q = E := by
+    have hdm : a * q + r = E := by
+      rw [hqdef, hrdef, hEdef]; exact Nat.div_add_mod (a * b + a + b) a
+    omega
+  have hr : r < a := by rw [hrdef]; exact Nat.mod_lt _ (by omega)
+  have hElo : a ≤ E := by rw [hEdef]; omega
+  have hq1 : 1 ≤ q := by
+    rw [hqdef]; exact Nat.one_le_div_iff (by omega) |>.mpr hElo
+  -- `a * x = E - a - t` form, for `t = r + a*i`, `x = q - 1 - i`, `i ≤ q-1`.
+  have haq : a * q = E - r := by omega
+  have han : a ≤ n := by rw [hndef]; exact Nat.le_mul_of_pos_right a hb
+  have hbn : b ≤ n := by rw [hndef]; exact Nat.le_mul_of_pos_left b ha
+  rw [solCount]
+  symm
+  apply Finset.card_nbij'
+    (fun p => q - 1 - p.1)
+    (fun i => (q - 1 - i, (r + a * i - e) / b - 1))
+  · -- MapsTo : solutions → tooth indices
+    intro p hp
+    simp only [Finset.coe_filter, Set.mem_setOf_eq, Finset.mem_product,
+      Finset.mem_range] at hp
+    simp only [Finset.coe_filter, Set.mem_setOf_eq, Finset.mem_range]
+    obtain ⟨⟨hx1, hx2⟩, hsolve⟩ := hp
+    -- a*p.1 ≤ n, so p.1 ≤ q-1
+    have haxle : a * p.1 ≤ n - e := by omega
+    have hxle : p.1 ≤ n := by
+      have : a * p.1 ≤ n := by omega
+      have := Nat.le_mul_of_pos_left p.1 ha
+      omega
+    -- p.1 ≤ q - 1 : a*p.1 ≤ n ≤ E - a = a*(q-1) ... use a*p.1 ≤ E-a-r ⟹ p.1 ≤ q-1
+    have hxq : p.1 ≤ q - 1 := by
+      by_contra hcon
+      push_neg at hcon
+      have : q ≤ p.1 := by omega
+      have hmul : a * q ≤ a * p.1 := Nat.mul_le_mul_left a this
+      have : n < a * q := by
+        have : n - e ≤ a * p.1 := by omega
+        -- but a*p.1 + b*p.2 = n - e ≤ n; and a*q = E - r = a*b+a+b-r ≥ n + a - r > n
+        omega
+      have hn_aq : n < a * q := by omega
+      have : a * q = E - r := haq
+      rw [hEdef] at this
+      omega
+    -- a*(q-1-p.1) + a*p.1 = a*(q-1), giving r + a*(q-1-p.1) = e + b*p.2 + b
+    have e1 : a * (q - 1 - p.1) = a * (q - 1) - a * p.1 := by rw [Nat.mul_sub]
+    have e2 : a * (q - 1) = a * q - a := by rw [Nat.mul_sub, Nat.mul_one]
+    have hple : a * p.1 ≤ a * (q - 1) := Nat.mul_le_mul_left a hxq
+    have hsplit : a * (q - 1 - p.1) + a * p.1 = a * (q - 1) := by omega
+    have ht : r + a * (q - 1 - p.1) = e + b * p.2 + b := by omega
+    refine ⟨by omega, ?_, ?_⟩
+    · rw [ht, show e + b * p.2 + b = e + b * (p.2 + 1) by ring,
+        Nat.add_mul_mod_self_left]
+    · rw [ht]; omega
+  · -- MapsTo : tooth indices → solutions
+    intro i hi
+    simp only [Finset.coe_filter, Set.mem_setOf_eq, Finset.mem_range] at hi
+    simp only [Finset.coe_filter, Set.mem_setOf_eq, Finset.mem_product,
+      Finset.mem_range]
+    obtain ⟨hiq, hmod, hlt⟩ := hi
+    set t := r + a * i with htdef
+    -- b ∣ (t - e), and t - e ≥ b
+    have hdvd : b ∣ (t - e) := by
+      have hcong : Nat.ModEq b t e := hmod
+      exact (Nat.modEq_iff_dvd' (le_of_lt hlt)).mp hcong.symm
+    have hbpos : 0 < t - e := by omega
+    have hble : b ≤ t - e := Nat.le_of_dvd hbpos hdvd
+    have hbdiv : b * ((t - e) / b) = t - e := Nat.mul_div_cancel' hdvd
+    have hyge : 1 ≤ (t - e) / b := by
+      rw [Nat.one_le_div_iff hb]; exact hble
+    -- b*((t-e)/b - 1) = (t - e) - b
+    have hby : b * ((t - e) / b - 1) = t - e - b := by
+      rw [Nat.mul_sub, Nat.mul_one, hbdiv]
+    -- a*(q-1-i) = E - a - t, via a*(q-1-i) + a*i = a*(q-1)
+    have hile : i ≤ q - 1 := by omega
+    have e1 : a * (q - 1 - i) = a * (q - 1) - a * i := by rw [Nat.mul_sub]
+    have e2 : a * (q - 1) = a * q - a := by rw [Nat.mul_sub, Nat.mul_one]
+    have hile' : a * i ≤ a * (q - 1) := Nat.mul_le_mul_left a hile
+    have hsplit : a * (q - 1 - i) + a * i = a * (q - 1) := by omega
+    -- the solution equation
+    have hsol : a * (q - 1 - i) + b * ((t - e) / b - 1) = n - e := by
+      rw [hby, htdef]
+      omega
+    obtain ⟨hbx, hby2⟩ :=
+      mem_solCount_box a b (n - e) (q - 1 - i) ((t - e) / b - 1) ha hb hsol
+    exact ⟨⟨hbx, hby2⟩, hsol⟩
+  · -- left_inv : (x, y) round trip on solutions
+    intro p hp
+    simp only [Finset.coe_filter, Set.mem_setOf_eq, Finset.mem_product,
+      Finset.mem_range] at hp
+    obtain ⟨⟨hx1, hx2⟩, hsolve⟩ := hp
+    -- recover p.1 ≤ q - 1
+    have hxq : p.1 ≤ q - 1 := by
+      by_contra hcon
+      push_neg at hcon
+      have hqle : q ≤ p.1 := by omega
+      have hmul : a * q ≤ a * p.1 := Nat.mul_le_mul_left a hqle
+      have : a * p.1 ≤ n - e := by omega
+      rw [haq, hEdef] at hmul
+      omega
+    set i := q - 1 - p.1 with hidef
+    -- q - 1 - i = p.1
+    have hfst : q - 1 - i = p.1 := by omega
+    -- a*i + a*p.1 = a*(q-1), so t - e = b*p.2 + b for t = r + a*i
+    have e1 : a * i = a * (q - 1) - a * p.1 := by rw [hidef, Nat.mul_sub]
+    have e2 : a * (q - 1) = a * q - a := by rw [Nat.mul_sub, Nat.mul_one]
+    have hple : a * p.1 ≤ a * (q - 1) := Nat.mul_le_mul_left a hxq
+    have hsplit : a * i + a * p.1 = a * (q - 1) := by omega
+    have hte : r + a * i - e = b * p.2 + b := by omega
+    have hydiv : (r + a * i - e) / b - 1 = p.2 := by
+      rw [hte]
+      have hdv : (b * p.2 + b) / b = p.2 + 1 := by
+        rw [show b * p.2 + b = b * (p.2 + 1) by ring, Nat.mul_div_cancel_left _ hb]
+      omega
+    apply Prod.ext
+    · change q - 1 - i = p.1
+      exact hfst
+    · change (r + a * i - e) / b - 1 = p.2
+      exact hydiv
+  · -- right_inv : (q-1-i) round trip on tooth indices
+    intro i hi
+    simp only [Finset.coe_filter, Set.mem_setOf_eq, Finset.mem_range] at hi
+    obtain ⟨hiq, -, -⟩ := hi
+    change q - 1 - (q - 1 - i) = i
+    omega
+
 end GebLean

--- a/geb-lean/GebLean/Utilities/ArithClosedForms.lean
+++ b/geb-lean/GebLean/Utilities/ArithClosedForms.lean
@@ -35,11 +35,16 @@ digit-block indicator, each equated to a Mathlib reference function.
 * `solCount_le_succ` — `solCount a b n ≤ n + 1` for `1 ≤ a, 1 ≤ b`.
 * `solCount_mul_eq_gcd_succ` — `solCount a b (a * b) = gcd a b + 1` for
   `1 ≤ a, 1 ≤ b` (the Prunescu–Shunia gcd linear-Diophantine count).
+* `solCount_eq_floor_mod` — the Prunescu–Shunia base-5 floor read-off
+  `⌊5^(a·b·(a·b+a+b)) / ((5^(a²·b)−1)(5^(a·b²)−1))⌋ % 5^(a·b)
+  = solCount a b (a·b)` for `1 ≤ a, 1 ≤ b`.
 
 ## References
 
 * Prunescu, Sauras-Altuzarra, arXiv:2407.12928 (the method; `ν_p`
   Theorem 2.1).
+* Prunescu, Shunia, arXiv:2411.06430 (the base-5 gcd closed form;
+  Theorem 4.1).
 
 ## Tags
 
@@ -1145,5 +1150,31 @@ private theorem gcd_num_lt_den_mul_digitSum_succ (a b : ℕ) (ha : 1 ≤ a)
     omega
   rw [Nat.mul_assoc]
   exact hexpand
+
+/-- The Euclidean quotient `⌊(5^(a·b))^(a·b+a+b) / ((5^(a·b))^a−1)·
+((5^(a·b))^b−1)⌋ = gcdDigitSum a b`, pinned by the two consecutive-multiple
+bounds via `Nat.div_eq_of_lt_le`. -/
+private theorem gcd_div_eq_digitSum (a b : ℕ) (ha : 1 ≤ a) (hb : 1 ≤ b) :
+    (5 ^ (a * b)) ^ (a * b + a + b)
+        / (((5 ^ (a * b)) ^ a - 1) * ((5 ^ (a * b)) ^ b - 1))
+      = gcdDigitSum a b := by
+  apply Nat.div_eq_of_lt_le
+  · linarith [gcd_den_mul_digitSum_le a b ha hb,
+      Nat.mul_comm (gcdDigitSum a b) (((5 ^ (a * b)) ^ a - 1) * ((5 ^ (a * b)) ^ b - 1))]
+  · linarith [gcd_num_lt_den_mul_digitSum_succ a b ha hb,
+      Nat.mul_comm (((5 ^ (a * b)) ^ a - 1) * ((5 ^ (a * b)) ^ b - 1)) (gcdDigitSum a b + 1)]
+
+/-- Prunescu–Shunia base-5 floor extraction: the units base-`5^(a·b)`
+digit of `⌊5^(a·b·(a·b+a+b)) / ((5^(a²·b)−1)(5^(a·b²)−1))⌋` is the
+linear-Diophantine count `solCount a b (a·b)`, for `1 ≤ a, 1 ≤ b`
+(arXiv:2411.06430, Theorem 4.1). -/
+theorem solCount_eq_floor_mod (a b : ℕ) (ha : 1 ≤ a) (hb : 1 ≤ b) :
+    (5 ^ (a * b * (a * b + a + b))
+        / ((5 ^ (a ^ 2 * b) - 1) * (5 ^ (a * b ^ 2) - 1)))
+        % 5 ^ (a * b)
+      = solCount a b (a * b) := by
+  rw [gcd_num_pow, gcd_dena_pow, gcd_denb_pow]
+  rw [gcd_div_eq_digitSum a b ha hb]
+  exact gcdDigitSum_mod a b ha hb
 
 end GebLean

--- a/geb-lean/GebLean/Utilities/ArithClosedForms.lean
+++ b/geb-lean/GebLean/Utilities/ArithClosedForms.lean
@@ -1,0 +1,116 @@
+import GebLean.LawvereER
+import Mathlib.NumberTheory.Padics.PadicVal.Basic
+import Mathlib.Data.Nat.Choose.Central
+import Mathlib.Data.Nat.Choose.Factorization
+import Mathlib.Data.Nat.Choose.Bounds
+import Mathlib.Data.Nat.Choose.Sum
+import Mathlib.Data.Nat.Digits.Lemmas
+
+/-!
+# Search-free closed forms for number-theoretic functions
+
+`ℕ`-level closed-form identities supporting the Era bounded-sum engine
+(`GebLean/EraCompleteness.lean`): the slow `2`-adic valuation, the
+central binomial coefficient, the binary Hamming weight, and the
+digit-block indicator, each equated to a Mathlib reference function.
+
+## Main definitions
+
+* `nu2Closed` — the slow, log-free `2`-adic valuation closed form.
+
+## Main statements
+
+* `nu2Closed_eq` — `nu2Closed n = padicValNat 2 n` for `n ≥ 1`.
+
+## References
+
+* Prunescu, Sauras-Altuzarra, arXiv:2407.12928 (the method; `ν_p`
+  Theorem 2.1).
+
+## Tags
+
+elementary recursive, closed form, p-adic valuation
+-/
+
+namespace GebLean
+
+/-- The slow (log-free) `2`-adic valuation closed form
+(arXiv:2407.12928, Theorem 2.1). `Nat.gcd n (2^n) = 2^(v₂ n)`, so the
+binomial-mod read-off recovers `v₂ n`. Realised as an `Era` term later;
+not numerically evaluable on large inputs, but its `eval` lemma is
+proved, not computed. -/
+def nu2Closed (n : ℕ) : ℕ :=
+  let base := 2 ^ (n + 1) - 1
+  (Nat.gcd n (2 ^ n) ^ (n + 1) % base ^ 2) / base
+
+private theorem gcd_pow_eq (n : ℕ) (hn : 1 ≤ n) :
+    Nat.gcd n (2 ^ n) = 2 ^ padicValNat 2 n := by
+  have hn0 : n ≠ 0 := Nat.one_le_iff_ne_zero.mp hn
+  set x := padicValNat 2 n with hx
+  have hxn : x ≤ n := by
+    have := padicValNat_le_nat_log (p := 2) n
+    exact this.trans (Nat.log_le_self 2 n)
+  apply Nat.dvd_antisymm
+  · -- gcd ∣ 2^x : gcd ∣ n and gcd ∣ 2^n, so gcd = 2^k, and k ≤ x
+    obtain ⟨k, hk, hgcd⟩ :=
+      (Nat.dvd_prime_pow Nat.prime_two).mp (Nat.gcd_dvd_right n (2 ^ n))
+    rw [hgcd]
+    have hdn : (2 : ℕ) ^ k ∣ n := hgcd ▸ Nat.gcd_dvd_left n (2 ^ n)
+    have hkx : k ≤ x := (padicValNat_dvd_iff_le hn0).mp hdn
+    exact pow_dvd_pow 2 hkx
+  · -- 2^x ∣ gcd : 2^x ∣ n and 2^x ∣ 2^n
+    apply Nat.dvd_gcd
+    · exact pow_padicValNat_dvd
+    · exact pow_dvd_pow 2 hxn
+
+private theorem pow_succ_mod_sq (a x : ℕ) :
+    (a + 1) ^ x % a ^ 2 = (1 + x * a) % a ^ 2 := by
+  induction x with
+  | zero => simp
+  | succ k ih =>
+    rw [pow_succ, Nat.mul_mod, ih, ← Nat.mul_mod]
+    have hexp : (1 + k * a) * (a + 1) = 1 + (k + 1) * a + k * a ^ 2 := by ring
+    rw [hexp, Nat.add_mul_mod_self_right]
+
+/-- The slow `ν₂` closed form computes the `2`-adic valuation: for
+`n ≥ 1`, `nu2Closed n = padicValNat 2 n`. -/
+theorem nu2Closed_eq (n : ℕ) (hn : 1 ≤ n) :
+    nu2Closed n = padicValNat 2 n := by
+  set x := padicValNat 2 n with hx
+  set base := 2 ^ (n + 1) - 1 with hbase
+  have hxn : x ≤ n := by
+    have := padicValNat_le_nat_log (p := 2) n
+    exact this.trans (Nat.log_le_self 2 n)
+  -- `2 ^ (n + 1) = base + 1`
+  have hpow1 : (1 : ℕ) ≤ 2 ^ (n + 1) := Nat.one_le_two_pow
+  have hbb : base + 1 = 2 ^ (n + 1) := by omega
+  -- rewrite the gcd power as `(base + 1) ^ x`
+  have hgcd : Nat.gcd n (2 ^ n) ^ (n + 1) = (base + 1) ^ x := by
+    rw [gcd_pow_eq n hn, ← pow_mul, Nat.mul_comm, pow_mul, hbb]
+  -- numeric bounds on `base`
+  have hbase2 : 2 ≤ n + 1 := by omega
+  have hbge : 2 ^ 2 ≤ 2 ^ (n + 1) := Nat.pow_le_pow_right (by norm_num) hbase2
+  have hbase3 : 3 ≤ base := by omega
+  -- `x < base` (since `x ≤ n < 2 ^ (n + 1) - 1 = base`)
+  have hnlt : n < 2 ^ (n + 1) - 1 := by
+    have h1 : n < 2 ^ n := Nat.lt_two_pow_self
+    have h2 : 2 ^ n + 2 ^ n = 2 ^ (n + 1) := by rw [pow_succ]; ring
+    have h3 : (1 : ℕ) ≤ 2 ^ n := Nat.one_le_two_pow
+    omega
+  have hxb : x < base := lt_of_le_of_lt hxn hnlt
+  -- `1 + x * base < base ^ 2`
+  have hlt : 1 + x * base < base ^ 2 := by
+    have : x * base + base ≤ base * base := by
+      have := Nat.mul_le_mul_right base (Nat.succ_le_of_lt hxb)
+      simpa [Nat.succ_mul, Nat.mul_comm] using this
+    have hsq : base ^ 2 = base * base := by ring
+    omega
+  -- assemble
+  unfold nu2Closed
+  simp only [← hbase]
+  rw [hgcd, pow_succ_mod_sq, Nat.mod_eq_of_lt hlt]
+  rw [Nat.add_mul_div_right _ _ (by omega : 0 < base)]
+  have h1div : (1 : ℕ) / base = 0 := Nat.div_eq_of_lt (by omega)
+  omega
+
+end GebLean

--- a/geb-lean/GebLean/Utilities/ArithClosedForms.lean
+++ b/geb-lean/GebLean/Utilities/ArithClosedForms.lean
@@ -447,4 +447,153 @@ theorem solCount_mul_eq_gcd_succ (a b : ℕ) (ha : 1 ≤ a) (hb : 1 ≤ b) :
     · simp only; rw [← hx]
     · simp only; rw [← hy]
 
+/-- Inclusion–exclusion recurrence for the linear-Diophantine count:
+for `1 ≤ a, 1 ≤ b` and `a + b ≤ m`,
+`solCount a b m + solCount a b (m − a − b)
+  = solCount a b (m − a) + solCount a b (m − b)`. The coefficientwise
+content of `(1 − tᵃ)(1 − tᵇ)·Σ solCount a b m · tᵐ = 1`. -/
+private theorem solCount_recurrence (a b m : ℕ) (ha : 1 ≤ a) (hb : 1 ≤ b)
+    (hm : a + b ≤ m) :
+    solCount a b m + solCount a b (m - a - b)
+      = solCount a b (m - a) + solCount a b (m - b) := by
+  set S := (Finset.range (m + 1) ×ˢ Finset.range (m + 1)).filter
+    (fun p => a * p.1 + b * p.2 = m) with hS
+  set Sx := S.filter (fun p => 1 ≤ p.1) with hSx
+  set Sy := S.filter (fun p => 1 ≤ p.2) with hSy
+  have hmemS : ∀ p : ℕ × ℕ, p ∈ S ↔
+      (p.1 < m + 1 ∧ p.2 < m + 1) ∧ a * p.1 + b * p.2 = m := by
+    intro p
+    rw [hS, Finset.mem_filter, Finset.mem_product, Finset.mem_range,
+      Finset.mem_range]
+  have hmemSx : ∀ p : ℕ × ℕ, p ∈ Sx ↔ p ∈ S ∧ 1 ≤ p.1 := by
+    intro p; rw [hSx, Finset.mem_filter]
+  have hmemSy : ∀ p : ℕ × ℕ, p ∈ Sy ↔ p ∈ S ∧ 1 ≤ p.2 := by
+    intro p; rw [hSy, Finset.mem_filter]
+  -- `Sx ∪ Sy = S`: no solution has `x = 0 ∧ y = 0` for `m ≥ a + b > 0`.
+  have hunion : Sx ∪ Sy = S := by
+    apply Finset.Subset.antisymm
+    · intro p hp
+      rw [Finset.mem_union, hmemSx, hmemSy] at hp
+      rcases hp with h | h
+      · exact h.1
+      · exact h.1
+    · intro p hp
+      rw [Finset.mem_union, hmemSx, hmemSy]
+      have heq := ((hmemS p).mp hp).2
+      rcases Nat.eq_zero_or_pos p.1 with hx0 | hx0
+      · rcases Nat.eq_zero_or_pos p.2 with hy0 | hy0
+        · exfalso; rw [hx0, hy0] at heq; omega
+        · exact Or.inr ⟨hp, hy0⟩
+      · exact Or.inl ⟨hp, hx0⟩
+  -- card identity from `card_union_add_card_inter`.
+  have hincl : S.card + (Sx ∩ Sy).card = Sx.card + Sy.card := by
+    rw [← hunion]; exact Finset.card_union_add_card_inter Sx Sy
+  -- `card Sx = solCount a b (m - a)`.
+  have hSxcard : Sx.card = solCount a b (m - a) := by
+    rw [solCount]
+    apply Finset.card_nbij' (fun p => (p.1 - 1, p.2)) (fun p => (p.1 + 1, p.2))
+    · intro p hp
+      simp only [Finset.mem_coe, hmemSx, hmemS] at hp
+      simp only [Finset.mem_coe, Finset.mem_filter, Finset.mem_product,
+        Finset.mem_range]
+      obtain ⟨⟨-, heq⟩, hx1⟩ := hp
+      have hax : a ≤ a * p.1 := Nat.le_mul_of_pos_right a hx1
+      have heq' : a * (p.1 - 1) + b * p.2 = m - a := by
+        have : a * (p.1 - 1) = a * p.1 - a := by rw [Nat.mul_sub, Nat.mul_one]
+        omega
+      exact ⟨mem_solCount_box a b (m - a) (p.1 - 1) p.2 ha hb heq', heq'⟩
+    · intro p hp
+      simp only [Finset.mem_coe, Finset.mem_filter, Finset.mem_product,
+        Finset.mem_range] at hp
+      simp only [Finset.mem_coe, hmemSx, hmemS]
+      obtain ⟨-, heq⟩ := hp
+      have heq' : a * (p.1 + 1) + b * p.2 = m := by rw [Nat.mul_add, Nat.mul_one]; omega
+      exact ⟨⟨mem_solCount_box a b m (p.1 + 1) p.2 ha hb heq', heq'⟩, by omega⟩
+    · intro p hp
+      simp only [Finset.mem_coe, hmemSx, hmemS] at hp
+      obtain ⟨-, hx1⟩ := hp
+      apply Prod.ext
+      · simp only; omega
+      · simp only
+    · intro p _
+      apply Prod.ext
+      · simp only; omega
+      · simp only
+  -- `card Sy = solCount a b (m - b)`.
+  have hSycard : Sy.card = solCount a b (m - b) := by
+    rw [solCount]
+    apply Finset.card_nbij' (fun p => (p.1, p.2 - 1)) (fun p => (p.1, p.2 + 1))
+    · intro p hp
+      simp only [Finset.mem_coe, hmemSy, hmemS] at hp
+      simp only [Finset.mem_coe, Finset.mem_filter, Finset.mem_product,
+        Finset.mem_range]
+      obtain ⟨⟨-, heq⟩, hy1⟩ := hp
+      have hby : b ≤ b * p.2 := Nat.le_mul_of_pos_right b hy1
+      have heq' : a * p.1 + b * (p.2 - 1) = m - b := by
+        have : b * (p.2 - 1) = b * p.2 - b := by rw [Nat.mul_sub, Nat.mul_one]
+        omega
+      exact ⟨mem_solCount_box a b (m - b) p.1 (p.2 - 1) ha hb heq', heq'⟩
+    · intro p hp
+      simp only [Finset.mem_coe, Finset.mem_filter, Finset.mem_product,
+        Finset.mem_range] at hp
+      simp only [Finset.mem_coe, hmemSy, hmemS]
+      obtain ⟨-, heq⟩ := hp
+      have heq' : a * p.1 + b * (p.2 + 1) = m := by rw [Nat.mul_add, Nat.mul_one]; omega
+      exact ⟨⟨mem_solCount_box a b m p.1 (p.2 + 1) ha hb heq', heq'⟩, by omega⟩
+    · intro p hp
+      simp only [Finset.mem_coe, hmemSy, hmemS] at hp
+      obtain ⟨-, hy1⟩ := hp
+      apply Prod.ext
+      · simp only
+      · simp only; omega
+    · intro p _
+      apply Prod.ext
+      · simp only
+      · simp only; omega
+  -- `card (Sx ∩ Sy) = solCount a b (m - a - b)`.
+  have hmemInter : ∀ p : ℕ × ℕ, p ∈ Sx ∩ Sy ↔
+      ((p.1 < m + 1 ∧ p.2 < m + 1) ∧ a * p.1 + b * p.2 = m)
+        ∧ 1 ≤ p.1 ∧ 1 ≤ p.2 := by
+    intro p
+    rw [Finset.mem_inter, hmemSx, hmemSy, hmemS]
+    tauto
+  have hintercard : (Sx ∩ Sy).card = solCount a b (m - a - b) := by
+    rw [solCount]
+    apply Finset.card_nbij' (fun p => (p.1 - 1, p.2 - 1))
+      (fun p => (p.1 + 1, p.2 + 1))
+    · intro p hp
+      simp only [Finset.mem_coe, hmemInter] at hp
+      simp only [Finset.mem_coe, Finset.mem_filter, Finset.mem_product,
+        Finset.mem_range]
+      obtain ⟨⟨-, heq⟩, hx1, hy1⟩ := hp
+      have hax0 : a ≤ a * p.1 := Nat.le_mul_of_pos_right a hx1
+      have hby0 : b ≤ b * p.2 := Nat.le_mul_of_pos_right b hy1
+      have heq' : a * (p.1 - 1) + b * (p.2 - 1) = m - a - b := by
+        have hax : a * (p.1 - 1) = a * p.1 - a := by rw [Nat.mul_sub, Nat.mul_one]
+        have hby : b * (p.2 - 1) = b * p.2 - b := by rw [Nat.mul_sub, Nat.mul_one]
+        omega
+      exact ⟨mem_solCount_box a b (m - a - b) (p.1 - 1) (p.2 - 1) ha hb heq', heq'⟩
+    · intro p hp
+      simp only [Finset.mem_coe, Finset.mem_filter, Finset.mem_product,
+        Finset.mem_range] at hp
+      simp only [Finset.mem_coe, hmemInter]
+      obtain ⟨-, heq⟩ := hp
+      have heq' : a * (p.1 + 1) + b * (p.2 + 1) = m := by
+        rw [Nat.mul_add, Nat.mul_one, Nat.mul_add, Nat.mul_one]; omega
+      exact ⟨⟨mem_solCount_box a b m (p.1 + 1) (p.2 + 1) ha hb heq', heq'⟩,
+        by omega, by omega⟩
+    · intro p hp
+      simp only [Finset.mem_coe, hmemInter] at hp
+      obtain ⟨-, hx1, hy1⟩ := hp
+      apply Prod.ext
+      · simp only; omega
+      · simp only; omega
+    · intro p _
+      apply Prod.ext
+      · simp only; omega
+      · simp only; omega
+  have hScard : S.card = solCount a b m := by rw [hS, solCount]
+  rw [hSxcard, hSycard, hintercard, hScard] at hincl
+  exact hincl
+
 end GebLean

--- a/geb-lean/GebLean/Utilities/ArithClosedForms.lean
+++ b/geb-lean/GebLean/Utilities/ArithClosedForms.lean
@@ -17,10 +17,14 @@ digit-block indicator, each equated to a Mathlib reference function.
 ## Main definitions
 
 * `nu2Closed` — the slow, log-free `2`-adic valuation closed form.
+* `centralBinomClosed` — the central binomial coefficient as a
+  base-`2^(2n)` digit read-off of `(1 + 2^(2n))^(2n)`.
 
 ## Main statements
 
 * `nu2Closed_eq` — `nu2Closed n = padicValNat 2 n` for `n ≥ 1`.
+* `centralBinomClosed_eq` — `centralBinomClosed n = Nat.centralBinom n`
+  for `n ≥ 1`.
 
 ## References
 
@@ -112,5 +116,66 @@ theorem nu2Closed_eq (n : ℕ) (hn : 1 ≤ n) :
   rw [Nat.add_mul_div_right _ _ (by omega : 0 < base)]
   have h1div : (1 : ℕ) / base = 0 := Nat.div_eq_of_lt (by omega)
   omega
+
+private theorem ofDigits_ofFn (b : ℕ) (m : ℕ) (f : ℕ → ℕ) :
+    Nat.ofDigits b (List.ofFn (fun i : Fin m => f i)) =
+      ∑ i ∈ Finset.range m, f i * b ^ i := by
+  induction m with
+  | zero => simp
+  | succ k ih =>
+    rw [List.ofFn_succ', List.concat_eq_append, Nat.ofDigits_append]
+    simp only [Fin.val_castSucc, List.length_ofFn]
+    rw [ih, Finset.sum_range_succ]
+    simp [Nat.ofDigits_singleton, Fin.last, Nat.mul_comm]
+
+private theorem choose_two_mul_lt (n j : ℕ) (hn : 1 ≤ n) :
+    (2 * n).choose j < 2 ^ (2 * n) := by
+  have hk : 2 * n = (2 * n - 1) + 1 := by omega
+  have hle : (2 * n).choose j ≤ 2 ^ (2 * n - 1) := by
+    rw [hk]; exact Nat.choose_succ_le_two_pow (2 * n - 1) j
+  have hlt : 2 ^ (2 * n - 1) < 2 ^ (2 * n) :=
+    Nat.pow_lt_pow_right (by norm_num) (by omega)
+  exact lt_of_le_of_lt hle hlt
+
+/-- `C(2n,n)` as the arithmetic-term closed form
+`⌊(1+2^(2n))^(2n) / 2^(2n²)⌋ mod 2^(2n)` (arXiv:2407.12928). Agrees with
+`Nat.centralBinom` for `n ≥ 1`; degenerates to `0` at `n = 0`
+(`Nat.centralBinom 0 = 1`), handled separately. -/
+def centralBinomClosed (n : ℕ) : ℕ :=
+  ((1 + 2 ^ (2 * n)) ^ (2 * n) / 2 ^ (2 * n ^ 2)) % 2 ^ (2 * n)
+
+/-- The central-binomial closed form computes `Nat.centralBinom`: for
+`n ≥ 1`, `centralBinomClosed n = Nat.centralBinom n`. -/
+theorem centralBinomClosed_eq (n : ℕ) (hn : 1 ≤ n) :
+    centralBinomClosed n = Nat.centralBinom n := by
+  set b := 2 ^ (2 * n) with hb
+  set L := List.ofFn (fun j : Fin (2 * n + 1) => (2 * n).choose j) with hL
+  have hbpos : 0 < b := by rw [hb]; positivity
+  -- digits are all `< b`
+  have hdig : ∀ l ∈ L, l < b := by
+    intro l hmem
+    rw [hL, List.mem_ofFn] at hmem
+    obtain ⟨j, rfl⟩ := hmem
+    exact choose_two_mul_lt n j hn
+  -- expansion: `(1 + b) ^ (2n) = ofDigits b L`
+  have hexp : (1 + b) ^ (2 * n) = Nat.ofDigits b L := by
+    rw [hL, ofDigits_ofFn, add_comm 1 b, add_pow]
+    apply Finset.sum_congr rfl
+    intro j _
+    rw [one_pow, mul_one, Nat.cast_id, Nat.mul_comm]
+  -- `2 ^ (2 n²) = b ^ n`
+  have hpow : (2 : ℕ) ^ (2 * n ^ 2) = b ^ n := by
+    rw [hb, ← pow_mul]; ring_nf
+  rw [Nat.centralBinom_eq_two_mul_choose, centralBinomClosed, ← hb, hexp, hpow,
+    Nat.ofDigits_div_pow_eq_ofDigits_drop n hbpos L hdig,
+    Nat.ofDigits_mod_eq_head!]
+  -- the leading digit of `drop n L` is `C(2n, n)`
+  have hgE : L[n]? = some ((2 * n).choose n) := by
+    rw [hL, List.getElem?_ofFn, dif_pos (by omega)]
+  have hhead : (List.drop n L).head! = (2 * n).choose n := by
+    have h2 := List.head?_drop (l := L) (i := n)
+    rw [hgE] at h2
+    exact List.head!_of_head? h2
+  rw [hhead, Nat.mod_eq_of_lt (choose_two_mul_lt n n hn)]
 
 end GebLean

--- a/geb-lean/GebLean/Utilities/ArithClosedForms.lean
+++ b/geb-lean/GebLean/Utilities/ArithClosedForms.lean
@@ -862,4 +862,288 @@ private theorem gcd_tooth_count (a b e : ℕ) (ha : 1 ≤ a) (hb : 1 ≤ b)
     change q - 1 - (q - 1 - i) = i
     omega
 
+/-- The comb quotient `G = Σ_{i<q} B^((r+a·i) mod b)·Σ_{l<(r+a·i)/b} B^(b·l)`,
+the exact quotient of `gcdPComb a b` by `(5^(a·b))^b − 1` in base `5^(a·b)`. -/
+private def gcdGSum (a b : ℕ) : ℕ :=
+  ∑ i ∈ Finset.range ((a * b + a + b) / a),
+    (5 ^ (a * b)) ^ (((a * b + a + b) % a + a * i) % b) *
+      ∑ l ∈ Finset.range (((a * b + a + b) % a + a * i) / b),
+        (5 ^ (a * b)) ^ (b * l)
+
+/-- The carry-free residue `W = Σ_{i<q} B^((r+a·i) mod b)`. -/
+private def gcdWSum (a b : ℕ) : ℕ :=
+  ∑ i ∈ Finset.range ((a * b + a + b) / a),
+    (5 ^ (a * b)) ^ (((a * b + a + b) % a + a * i) % b)
+
+/-- Per-tooth base-`B` expansion: `B^c = (B^b − 1)·(B^(c%b)·Σ_{l<c/b} B^(b·l)) + B^(c%b)`. -/
+private theorem gcd_tooth_split (B b c : ℕ) (hB : 1 ≤ B) :
+    B ^ c = (B ^ b - 1) * (B ^ (c % b) * ∑ l ∈ Finset.range (c / b), B ^ (b * l))
+      + B ^ (c % b) := by
+  have hBb : 1 ≤ B ^ b := Nat.one_le_pow _ _ hB
+  have hstep : ∀ l : ℕ, B ^ (b * l) = (B ^ b) ^ l := fun l => pow_mul B b l
+  simp_rw [hstep]
+  have hg : (B ^ b - 1) * ∑ l ∈ Finset.range (c / b), (B ^ b) ^ l = (B ^ b) ^ (c / b) - 1 := by
+    have h := natGeomSum_mul (B ^ b) (c / b) hBb
+    linarith [Nat.mul_comm (∑ l ∈ Finset.range (c / b), (B ^ b) ^ l) (B ^ b - 1)]
+  have hcdiv : (B ^ b) ^ (c / b) = B ^ (b * (c / b)) := (pow_mul B b (c / b)).symm
+  have hsum : c % b + b * (c / b) = c := Nat.mod_add_div c b
+  have hBcb : 1 ≤ (B ^ b) ^ (c / b) := Nat.one_le_pow _ _ hBb
+  rw [show (B ^ b - 1) * (B ^ (c % b) * ∑ l ∈ Finset.range (c / b), (B ^ b) ^ l) =
+      B ^ (c % b) * ((B ^ b - 1) * ∑ l ∈ Finset.range (c / b), (B ^ b) ^ l) from by ring,
+    hg, Nat.mul_sub_one, hcdiv, ← pow_add, hsum]
+  have hBc : B ^ (c % b) ≤ B ^ c := Nat.pow_le_pow_right hB (by omega)
+  omega
+
+/-- Comb split: `P = (B^b − 1)·G + W`, where `B := 5^(a·b)`,
+`G := gcdGSum a b`, `W := gcdWSum a b`. -/
+private theorem gcd_pComb_split (a b : ℕ) (_ha : 1 ≤ a) (_hb : 1 ≤ b) :
+    gcdPComb a b
+      = ((5 ^ (a * b)) ^ b - 1) * gcdGSum a b + gcdWSum a b := by
+  set B := 5 ^ (a * b) with hBdef
+  set E := a * b + a + b with hEdef
+  set q := E / a with hqdef
+  set r := E % a with hrdef
+  have hB1 : 1 ≤ B := Nat.one_le_pow _ _ (by omega)
+  -- Rewrite P as Σ_{i<q} B^(r + a*i)
+  have hP : gcdPComb a b = ∑ i ∈ Finset.range q, B ^ (r + a * i) := by
+    simp only [gcdPComb, ← hBdef, ← hEdef, ← hqdef, ← hrdef, Finset.mul_sum]
+    exact Finset.sum_congr rfl (fun i _ => by rw [pow_add])
+  rw [hP, gcdGSum, gcdWSum]
+  simp only [← hBdef, ← hEdef, ← hqdef, ← hrdef]
+  rw [Finset.mul_sum, ← Finset.sum_add_distrib]
+  exact Finset.sum_congr rfl (fun i _ => gcd_tooth_split B b (r + a * i) hB1)
+
+/-- `2·b + 2 < 5^b` for `1 ≤ b`. -/
+private theorem two_mul_add_two_lt_five_pow (b : ℕ) (hb : 1 ≤ b) :
+    2 * b + 2 < 5 ^ b := by
+  induction b with
+  | zero => omega
+  | succ m ih =>
+    rcases Nat.eq_zero_or_pos m with hm | hm
+    · subst hm; norm_num
+    · have := ih hm
+      have h5m : 1 ≤ (5 : ℕ) ^ m := Nat.one_le_pow _ _ (by omega)
+      rw [pow_succ]; nlinarith
+
+/-- Arithmetic core of the no-carry bound: from `W ≤ q·P`, `q ≤ B − 2`,
+`1 ≤ P`, and `Bb = P·B`, conclude `W < Bb − 1`. -/
+private theorem wSum_bound_arith (W q P B Bb : ℕ) (hW : W ≤ q * P) (hq : q ≤ B - 2)
+    (hP : 1 ≤ P) (hBb : Bb = P * B) (hB : 2 ≤ B) : W < Bb - 1 := by
+  have h1 : q * P ≤ (B - 2) * P := Nat.mul_le_mul_right _ hq
+  have h2 : (B - 2) * P = P * B - 2 * P := by rw [Nat.sub_mul]; ring_nf
+  have h3 : 2 * P ≤ P * B := by nlinarith
+  have h4 : 2 ≤ 2 * P := by omega
+  omega
+
+/-- No-carry bound: `W < (5^(a·b))^b − 1`. -/
+private theorem gcd_wSum_lt_denb (a b : ℕ) (ha : 1 ≤ a) (hb : 1 ≤ b) :
+    gcdWSum a b < (5 ^ (a * b)) ^ b - 1 := by
+  set B := 5 ^ (a * b) with hBdef
+  set q := (a * b + a + b) / a with hqdef
+  set r := (a * b + a + b) % a with hrdef
+  have hB1 : 1 ≤ B := Nat.one_le_pow _ _ (by omega)
+  -- each summand ≤ B^(b-1)
+  have hterm : ∀ i ∈ Finset.range q, B ^ ((r + a * i) % b) ≤ B ^ (b - 1) := by
+    intro i _
+    exact Nat.pow_le_pow_right hB1 (by have := Nat.mod_lt (r + a * i) hb; omega)
+  -- W ≤ q * B^(b-1)
+  have hWle : gcdWSum a b ≤ q * B ^ (b - 1) := by
+    rw [gcdWSum, ← hBdef, ← hqdef, ← hrdef]
+    calc ∑ i ∈ Finset.range q, B ^ ((r + a * i) % b)
+        ≤ ∑ _i ∈ Finset.range q, B ^ (b - 1) := Finset.sum_le_sum hterm
+      _ = q * B ^ (b - 1) := by rw [Finset.sum_const, Finset.card_range, smul_eq_mul]
+  -- q ≤ 2*b+1
+  have hq_le : q ≤ 2 * b + 1 := by
+    rw [hqdef]
+    apply Nat.div_le_of_le_mul
+    nlinarith [ha, hb]
+  -- B ≥ 5^b and 2*b+2 < 5^b ≤ B, so q ≤ B - 2
+  have h5b : (5 : ℕ) ^ b ≤ B := by
+    rw [hBdef]; exact Nat.pow_le_pow_right (by omega) (by nlinarith [ha, hb])
+  have hlt5b : 2 * b + 2 < 5 ^ b := two_mul_add_two_lt_five_pow b hb
+  have hqB : q ≤ B - 2 := by omega
+  have hBb_eq : B ^ b = B ^ (b - 1) * B := by
+    conv_lhs => rw [show b = b - 1 + 1 by omega]
+    rw [pow_succ]
+  have hB2 : 2 ≤ B := by omega
+  exact wSum_bound_arith _ q (B ^ (b - 1)) B (B ^ b) hWle hqB
+    (Nat.one_le_pow _ _ hB1) hBb_eq hB2
+
+/-- Flattened comb quotient: `G = Σ_{(i,l)} B^((r+a·i)%b + b·l)` over the
+sigma `Σ_{i<q} (range ((r+a·i)/b))`. -/
+private theorem gcdGSum_flat (a b : ℕ) :
+    gcdGSum a b
+      = ∑ x ∈ (Finset.range ((a * b + a + b) / a)).sigma
+          (fun i => Finset.range (((a * b + a + b) % a + a * i) / b)),
+        (5 ^ (a * b)) ^ (((a * b + a + b) % a + a * x.1) % b + b * x.2) := by
+  rw [gcdGSum]
+  have hnest : ∀ i, (5 ^ (a * b)) ^ (((a * b + a + b) % a + a * i) % b) *
+      ∑ l ∈ Finset.range (((a * b + a + b) % a + a * i) / b), (5 ^ (a * b)) ^ (b * l)
+      = ∑ l ∈ Finset.range (((a * b + a + b) % a + a * i) / b),
+          (5 ^ (a * b)) ^ (((a * b + a + b) % a + a * i) % b + b * l) := by
+    intro i
+    rw [Finset.mul_sum]
+    exact Finset.sum_congr rfl (fun l _ => by rw [← pow_add])
+  simp_rw [hnest]
+  rw [Finset.sum_sigma']
+
+/-- The reindex: `gcdDigitSum a b = gcdGSum a b`. -/
+private theorem gcd_digitSum_eq_gSum (a b : ℕ) (ha : 1 ≤ a) (hb : 1 ≤ b) :
+    gcdDigitSum a b = gcdGSum a b := by
+  rw [gcdGSum_flat, gcdDigitSum]
+  set E := a * b + a + b with hEdef
+  set n := a * b with hndef
+  set q := E / a with hqdef
+  set r := E % a with hrdef
+  set B := 5 ^ (a * b) with hBdef
+  set s := (Finset.range q).sigma (fun i => Finset.range ((r + a * i) / b)) with hsdef
+  set g : (_ : ℕ) × ℕ → ℕ := fun x => (r + a * x.1) % b + b * x.2 with hgdef
+  -- r + a*q = E
+  have hEqr : r + a * q = E := by
+    have hdm : a * q + r = E := by
+      rw [hqdef, hrdef]; exact Nat.div_add_mod E a
+    omega
+  -- maps_to: each exponent lands in range (n+1)
+  have hmaps : ∀ x ∈ s, g x ∈ Finset.range (n + 1) := by
+    intro x hx
+    rw [hsdef, Finset.mem_sigma, Finset.mem_range, Finset.mem_range] at hx
+    obtain ⟨hi, hl⟩ := hx
+    rw [Finset.mem_range, hgdef]
+    change (r + a * x.1) % b + b * x.2 < n + 1
+    set t := r + a * x.1 with htdef
+    set m := t / b with hmdef
+    -- g x ≤ t - b
+    have hmod : t % b + b * m = t := Nat.mod_add_div t b
+    have hbl : b * x.2 + b ≤ b * m := by
+      have hx2 : x.2 + 1 ≤ m := by omega
+      calc b * x.2 + b = b * (x.2 + 1) := by ring
+        _ ≤ b * m := Nat.mul_le_mul_left b hx2
+    have hgle : t % b + b * x.2 ≤ t - b := by omega
+    -- t ≤ n + b via a*x.1 ≤ a*q - a and r + a*q = n + a + b
+    have hile : x.1 + 1 ≤ q := by omega
+    have haiq : a * x.1 + a ≤ a * q := by
+      calc a * x.1 + a = a * (x.1 + 1) := by ring
+        _ ≤ a * q := Nat.mul_le_mul_left a hile
+    have hEqr' : r + a * q = n + a + b := by rw [hEqr, hEdef]
+    have htn : t ≤ n + b := by rw [htdef]; omega
+    omega
+  -- fiberwise regrouping
+  have hfib := Finset.sum_fiberwise_of_maps_to (s := s) (t := Finset.range (n + 1))
+    hmaps (f := fun x => B ^ (g x))
+  rw [← hfib]
+  apply Finset.sum_congr rfl
+  intro e he
+  simp only [Finset.mem_range] at he
+  -- inner fiber sum: B^(g x) = B^e on the fiber, so sum = card * B^e
+  have hinner : ∑ x ∈ s with g x = e, B ^ (g x)
+      = (s.filter (fun x => g x = e)).card * B ^ e := by
+    rw [Finset.sum_congr rfl (fun x hx => by
+      simp only [Finset.mem_filter] at hx; rw [hx.2])]
+    rw [Finset.sum_const, smul_eq_mul]
+  rw [hinner]
+  -- fiber card = solCount a b (n - e)
+  have hcard : (s.filter (fun x => g x = e)).card = solCount a b (n - e) := by
+    rw [← gcd_tooth_count a b e ha hb (by omega)]
+    rw [← hqdef, ← hrdef]
+    apply Finset.card_nbij' (fun x => x.1)
+      (fun i => (⟨i, (e - (r + a * i) % b) / b⟩ : (_ : ℕ) × ℕ))
+    · -- forward maps into tooth-index set
+      intro x hx
+      rw [hsdef, Finset.coe_filter, Set.mem_setOf_eq, Finset.mem_sigma, Finset.mem_range,
+        Finset.mem_range] at hx
+      obtain ⟨⟨hi, hl⟩, hge⟩ := hx
+      rw [Finset.coe_filter, Set.mem_setOf_eq, Finset.mem_range]
+      rw [hgdef] at hge
+      simp only at hge
+      set t := r + a * x.1 with htdef
+      -- e = t%b + b*x.2, so e ≡ t (mod b) and e < t
+      have hmod : t % b + b * (t / b) = t := Nat.mod_add_div t b
+      have hx2 : x.2 + 1 ≤ t / b := by omega
+      have hebmod : e % b = t % b := by
+        rw [← hge, Nat.add_mul_mod_self_left, Nat.mod_mod]
+      refine ⟨hi, hebmod.symm, ?_⟩
+      have : b * (x.2 + 1) ≤ b * (t / b) := Nat.mul_le_mul_left b hx2
+      rw [Nat.mul_add, Nat.mul_one] at this
+      omega
+    · -- inverse maps into fiber
+      intro i hi
+      rw [Finset.coe_filter, Set.mem_setOf_eq, Finset.mem_range] at hi
+      obtain ⟨hiq, hmod, hge⟩ := hi
+      rw [hsdef, Finset.coe_filter, Set.mem_setOf_eq, Finset.mem_sigma, Finset.mem_range,
+        Finset.mem_range]
+      set t := r + a * i with htdef
+      -- l = (e - t%b)/b; t%b ≤ e and b ∣ (e - t%b)
+      have htmod : t % b + b * (t / b) = t := Nat.mod_add_div t b
+      have he_split : e % b + b * (e / b) = e := Nat.mod_add_div e b
+      have hle : t % b ≤ e := by omega
+      have hb_dvd : b ∣ (e - t % b) := by
+        rw [hmod]; exact Dvd.intro (e / b) (by omega)
+      have hetm : e = t % b + b * ((e - t % b) / b) := by
+        rw [Nat.mul_div_cancel' hb_dvd]; omega
+      refine ⟨⟨hiq, ?_⟩, ?_⟩
+      · -- (e - t%b)/b < t/b
+        have : b * ((e - t % b) / b) < b * (t / b) := by omega
+        exact Nat.lt_of_mul_lt_mul_left this
+      · rw [hgdef]; simp only [← htdef]; omega
+    · -- left inverse on fiber
+      intro x hx
+      rw [hsdef, Finset.coe_filter, Set.mem_setOf_eq, Finset.mem_sigma, Finset.mem_range,
+        Finset.mem_range] at hx
+      obtain ⟨⟨hi, hl⟩, hge⟩ := hx
+      rw [hgdef] at hge
+      simp only at hge
+      set t := r + a * x.1 with htdef
+      -- recover x.2 = (e - t%b)/b
+      apply Sigma.ext
+      · rfl
+      · have hval : (e - t % b) / b = x.2 := by
+          rw [← hge, Nat.add_sub_cancel_left, Nat.mul_div_cancel_left _ hb]
+        simp only
+        exact heq_of_eq hval
+    · -- right inverse on tooth-index set
+      intro i _
+      rfl
+  rw [hcard]
+
+/-- Combined identity: `B^(a·b+a+b) = dena·(denb·S + W) + B^r`, where
+`B := 5^(a·b)`, `dena := B^a − 1`, `denb := B^b − 1`, `S := gcdDigitSum a b`,
+`W := gcdWSum a b`, `r := (a·b+a+b) % a`. -/
+private theorem gcd_num_eq_den_digitSum (a b : ℕ) (ha : 1 ≤ a) (hb : 1 ≤ b) :
+    (5 ^ (a * b)) ^ (a * b + a + b)
+      = ((5 ^ (a * b)) ^ a - 1)
+          * (((5 ^ (a * b)) ^ b - 1) * gcdDigitSum a b + gcdWSum a b)
+        + (5 ^ (a * b)) ^ ((a * b + a + b) % a) := by
+  rw [gcd_num_split a b ha hb, gcd_pComb_split a b ha hb, gcd_digitSum_eq_gSum a b ha hb]
+
+/-- Lower Euclidean bound: `dena·denb·S ≤ B^(a·b+a+b)`. -/
+private theorem gcd_den_mul_digitSum_le (a b : ℕ) (ha : 1 ≤ a) (hb : 1 ≤ b) :
+    ((5 ^ (a * b)) ^ a - 1) * ((5 ^ (a * b)) ^ b - 1) * gcdDigitSum a b
+      ≤ (5 ^ (a * b)) ^ (a * b + a + b) := by
+  rw [gcd_num_eq_den_digitSum a b ha hb, Nat.mul_assoc, Nat.mul_add]
+  omega
+
+/-- Upper Euclidean bound: `B^(a·b+a+b) < dena·denb·(S+1)`. -/
+private theorem gcd_num_lt_den_mul_digitSum_succ (a b : ℕ) (ha : 1 ≤ a)
+    (hb : 1 ≤ b) :
+    (5 ^ (a * b)) ^ (a * b + a + b)
+      < ((5 ^ (a * b)) ^ a - 1) * ((5 ^ (a * b)) ^ b - 1)
+          * (gcdDigitSum a b + 1) := by
+  rw [gcd_num_eq_den_digitSum a b ha hb]
+  set dena := (5 ^ (a * b)) ^ a - 1 with hdena
+  set denb := (5 ^ (a * b)) ^ b - 1 with hdenb
+  set S := gcdDigitSum a b with hS
+  have hbr : (5 ^ (a * b)) ^ ((a * b + a + b) % a) < dena := gcd_rem_lt_dena a b ha hb
+  have hW : gcdWSum a b < denb := gcd_wSum_lt_denb a b ha hb
+  -- dena·(denb·S + W) + B^r < dena·(denb·S + denb) = dena·denb·(S+1)
+  have hWdvd : dena * gcdWSum a b + dena ≤ dena * denb := by
+    rw [← Nat.mul_succ]
+    exact Nat.mul_le_mul_left dena (by omega)
+  have hexpand : dena * (denb * S + gcdWSum a b)
+      + (5 ^ (a * b)) ^ ((a * b + a + b) % a)
+      < dena * (denb * (S + 1)) := by
+    rw [Nat.mul_add, Nat.mul_add, Nat.mul_one, Nat.mul_add]
+    omega
+  rw [Nat.mul_assoc]
+  exact hexpand
+
 end GebLean

--- a/geb-lean/GebLean/Utilities/EraBoundedSum.lean
+++ b/geb-lean/GebLean/Utilities/EraBoundedSum.lean
@@ -1,6 +1,8 @@
 import GebLean.LawvereER
 import Mathlib.Algebra.BigOperators.Group.Finset.Basic
 import Mathlib.Algebra.Ring.GeomSum
+import Mathlib.Tactic.Linarith
+import Mathlib.Tactic.Ring
 
 /-!
 # `natBSum` bridge and geometric closed form
@@ -14,6 +16,10 @@ geometric closed form `Σ_{i<n} q^i = (q^n − 1)/(q − 1)`.
 
 * `natBSum_eq_sum` — `natBSum bound f = ∑ i ∈ Finset.range bound, f i`.
 * `natGeomSum_eq` — the geometric closed form for `2 ≤ q`.
+* `natLinGeomSum_mul` — the linear-weighted geometric progression
+  identity, cleared of division.
+* `natLinGeomSum_eq` — the linear-weighted geometric closed form for
+  `2 ≤ q` and `2 ≤ n`.
 
 ## References
 
@@ -58,5 +64,102 @@ theorem natGeomSum_eq (q n : ℕ) (hq : 2 ≤ q) :
 theorem natBSum_geom (q bound : ℕ) (hq : 2 ≤ q) :
     natBSum bound (fun i => q ^ i) = (q ^ bound - 1) / (q - 1) := by
   rw [natBSum_eq_sum]; exact natGeomSum_eq q bound hq
+
+/-- Linear-weighted geometric sum `Σ_{i<n} i·qⁱ`, cleared of division
+and stated additively (no `ℕ` truncation, valid for all `n`), for
+`2 ≤ q`. `G₁` re-indexed to `Finset.range n`. -/
+theorem natLinGeomSum_mul (q n : ℕ) (hq : 2 ≤ q) :
+    (∑ i ∈ Finset.range n, i * q ^ i) * (q - 1) ^ 2 + q ^ (n + 1)
+        + n * q ^ n =
+      n * q ^ (n + 1) + q := by
+  induction n with
+  | zero => simp
+  | succ m ih =>
+    rw [Finset.sum_range_succ, Nat.add_mul, pow_succ]
+    -- normalize pow expansions so q^{m+k} appears as iterated *q
+    simp only [pow_succ, pow_zero, one_mul] at *
+    have hqm : 1 ≤ q ^ m := Nat.one_le_pow _ _ (by omega)
+    -- q^m*(q-1) = q^m*q - q^m
+    have ha : q ^ m * (q - 1) = q ^ m * q - q ^ m := Nat.mul_sub_one _ _
+    -- q^m ≤ q^m*q
+    have hle : q ^ m ≤ q ^ m * q := Nat.le_mul_of_pos_right _ (by omega)
+    -- q^m*q ≤ q^m*q*q
+    have hle2 : q ^ m * q ≤ q ^ m * q * q := Nat.le_mul_of_pos_right _ (by omega)
+    -- (q^m*q - q^m)*q = q^m*q*q - q^m*q
+    have hd : (q ^ m * q - q ^ m) * q = q ^ m * q * q - q ^ m * q :=
+      Nat.sub_mul _ _ _
+    -- additive expansion: q^m*(q-1)*(q-1) + 2*(q^m*q) = q^m*q*q + q^m
+    have hexp : q ^ m * (q - 1) * (q - 1) + 2 * (q ^ m * q) = q ^ m * q * q + q ^ m := by
+      -- key: q^m*q*(q-1) = q^m*q*q - q^m*q (Nat.mul_sub_one)
+      have hpqd : q ^ m * q * (q - 1) = q ^ m * q * q - q ^ m * q := Nat.mul_sub_one _ _
+      -- additive: q^m*q*(q-1) + q^m*q = q^m*q*q  (with hle2 for the subtraction)
+      have hpqd2 : q ^ m * q * (q - 1) + q ^ m * q = q ^ m * q * q := by omega
+      -- q^m*(q-1)*(q-1) + q^m*(q-1) = q^m*(q-1)*q  (dist law, additive)
+      have hpd2 : q ^ m * (q - 1) * (q - 1) + q ^ m * (q - 1) = q ^ m * (q - 1) * q := by
+        have hle3 : q ^ m * (q - 1) ≤ q ^ m * (q - 1) * q :=
+          Nat.le_mul_of_pos_right _ (by omega)
+        have := Nat.mul_sub_one (q ^ m * (q - 1)) q
+        omega
+      -- q^m*(q-1)*q = q^m*q*(q-1)  (mul_comm in the middle)
+      have hcomm : q ^ m * (q - 1) * q = q ^ m * q * (q - 1) := by ring
+      omega
+    -- key atoms omega needs: (m+1)*R = m*R + R for R = q^m*q*q and R = q^m*q
+    have hm1R : (m + 1) * (q ^ m * q * q) = m * (q ^ m * q * q) + q ^ m * q * q :=
+      Nat.succ_mul m (q ^ m * q * q)
+    have hm1Q : (m + 1) * (q ^ m * q) = m * (q ^ m * q) + q ^ m * q :=
+      Nat.succ_mul m (q ^ m * q)
+    -- m-scaled version: m*q^m*((q-1)*(q-1)) + 2*m*(q^m*q) = m*(q^m*q*q) + m*q^m
+    -- derived by multiplying hexp by m and reassociating
+    have hmexp : m * q ^ m * ((q - 1) * (q - 1)) + 2 * m * (q ^ m * q) =
+        m * (q ^ m * q * q) + m * q ^ m := by
+      -- m * (hexp) using Nat.mul_add on both sides
+      have hscale : m * (q ^ m * (q - 1) * (q - 1) + 2 * (q ^ m * q)) =
+          m * (q ^ m * q * q + q ^ m) := congrArg (m * ·) hexp
+      -- left: m * (A + B) = m*A + m*B
+      rw [Nat.mul_add, Nat.mul_add] at hscale
+      -- reassociate: m * (q^m*(q-1)*(q-1)) = m*q^m*((q-1)*(q-1))
+      have hl1 : m * (q ^ m * (q - 1) * (q - 1)) = m * q ^ m * ((q - 1) * (q - 1)) := by
+        rw [Nat.mul_assoc, Nat.mul_assoc]
+      -- m*(2*(q^m*q)) = 2*m*(q^m*q)
+      have hl2 : m * (2 * (q ^ m * q)) = 2 * m * (q ^ m * q) := by
+        rw [← Nat.mul_assoc, Nat.mul_comm m 2, Nat.mul_assoc]
+      linarith [hl1, hl2, hscale]
+    linarith
+
+/-- Linear-weighted geometric closed form:
+`Σ_{i<n} i·qⁱ = ((n−1)·q^{n+1} − n·qⁿ + q)/(q−1)²` for `2 ≤ q` and `2 ≤ n`.
+The hypothesis `2 ≤ n` ensures `n·qⁿ ≤ (n−1)·q^{n+1}` so the ℕ subtraction is exact;
+the formula reduces to a division of `S·(q−1)²` by `(q−1)²`.
+Derived from `natLinGeomSum_mul` by clearing denominators. -/
+theorem natLinGeomSum_eq (q n : ℕ) (hq : 2 ≤ q) (hn : 2 ≤ n) :
+    ∑ i ∈ Finset.range n, i * q ^ i =
+      ((n - 1) * q ^ (n + 1) - n * q ^ n + q) / (q - 1) ^ 2 := by
+  have hpos : 0 < (q - 1) ^ 2 := Nat.pow_pos (by omega)
+  have hmul := natLinGeomSum_mul q n hq
+  -- (n-1)*q^{n+1} + q^{n+1} = n*q^{n+1}
+  have hn1_eq : (n - 1) * q ^ (n + 1) + q ^ (n + 1) = n * q ^ (n + 1) := by
+    have hpred : n - 1 + 1 = n := by omega
+    calc (n - 1) * q ^ (n + 1) + q ^ (n + 1)
+        = (n - 1 + 1) * q ^ (n + 1) := by rw [Nat.add_mul, one_mul]
+      _ = n * q ^ (n + 1) := by rw [hpred]
+  -- n*q^n ≤ (n-1)*q^{n+1}: needed for exact ℕ subtraction
+  -- equivalent to n ≤ (n-1)*q, which holds for n ≥ 2, q ≥ 2
+  have hle_sub : n * q ^ n ≤ (n - 1) * q ^ (n + 1) := by
+    -- rewrite as (n-1)*q*q^n ≥ n*q^n, i.e., (n-1)*q ≥ n (for n≥2, q≥2)
+    have hpow : (n - 1) * q ^ (n + 1) = (n - 1) * q * q ^ n := by
+      rw [pow_succ]; ring
+    rw [hpow]
+    apply Nat.mul_le_mul_right
+    -- n ≤ (n-1)*q: use 2*(n-1) ≥ n (from n≥2) and q*(n-1) ≥ 2*(n-1)
+    calc n ≤ 2 * (n - 1) := by omega
+      _ ≤ q * (n - 1) := Nat.mul_le_mul_right _ hq
+      _ = (n - 1) * q := by ring
+  -- from hmul and hn1_eq: (Σ i·qⁱ)*(q-1)² + n·qⁿ = (n-1)·q^{n+1} + q
+  have hadd : (∑ i ∈ Finset.range n, i * q ^ i) * (q - 1) ^ 2 + n * q ^ n =
+      (n - 1) * q ^ (n + 1) + q := by linarith
+  -- exact ℕ subtraction: (n-1)*q^{n+1} - n*q^n + q = (Σ i·qⁱ)*(q-1)²
+  have hclear : (n - 1) * q ^ (n + 1) - n * q ^ n + q =
+      (∑ i ∈ Finset.range n, i * q ^ i) * (q - 1) ^ 2 := by omega
+  rw [hclear, Nat.mul_div_cancel _ hpos]
 
 end GebLean

--- a/geb-lean/GebLean/Utilities/EraBoundedSum.lean
+++ b/geb-lean/GebLean/Utilities/EraBoundedSum.lean
@@ -3,6 +3,7 @@ import Mathlib.Algebra.BigOperators.Group.Finset.Basic
 import Mathlib.Algebra.Ring.GeomSum
 import Mathlib.Tactic.Linarith
 import Mathlib.Tactic.Ring
+import Mathlib.Tactic.Zify
 
 /-!
 # `natBSum` bridge and geometric closed form
@@ -20,6 +21,9 @@ geometric closed form `Σ_{i<n} q^i = (q^n − 1)/(q − 1)`.
   identity, cleared of division.
 * `natLinGeomSum_eq` — the linear-weighted geometric closed form for
   `2 ≤ q` and `2 ≤ n`.
+* `natSqGeomSum_mul` — the square-weighted geometric progression
+  identity, cleared of division, for `2 ≤ q` and `2 ≤ n`.
+* `natSqGeomSum_zero`, `natSqGeomSum_one` — base cases at `n = 0` and `n = 1`.
 
 ## References
 
@@ -161,5 +165,66 @@ theorem natLinGeomSum_eq (q n : ℕ) (hq : 2 ≤ q) (hn : 2 ≤ n) :
   have hclear : (n - 1) * q ^ (n + 1) - n * q ^ n + q =
       (∑ i ∈ Finset.range n, i * q ^ i) * (q - 1) ^ 2 := by omega
   rw [hclear, Nat.mul_div_cancel _ hpos]
+
+-- Private helpers: convert ℕ-truncated-subtraction coefficients to ℤ.
+private lemma cast_coeff_sq (m : ℕ) (hm : 2 ≤ m) :
+    ((2 * m ^ 2 - 2 * m - 1 : ℕ) : ℤ) = 2 * (m : ℤ) ^ 2 - 2 * m - 1 := by
+  have h1 : 2 * m ≤ 2 * m ^ 2 := by nlinarith
+  have h2 : 1 ≤ 2 * m ^ 2 - 2 * m := Nat.le_sub_of_add_le (by nlinarith)
+  rw [show 2 * m ^ 2 - 2 * m - 1 = (2 * m ^ 2 - 2 * m) - 1 from by omega,
+      Nat.cast_sub h2, Nat.cast_sub h1]
+  push_cast; ring
+
+private lemma cast_coeff_sq_succ (m : ℕ) (hm : 2 ≤ m) :
+    ((2 * (m + 1) ^ 2 - 2 * (m + 1) - 1 : ℕ) : ℤ) = 2 * (m : ℤ) ^ 2 + 2 * m - 1 := by
+  have h1 : 2 * (m + 1) ≤ 2 * (m + 1) ^ 2 := by nlinarith
+  have h2 : 1 ≤ 2 * (m + 1) ^ 2 - 2 * (m + 1) := Nat.le_sub_of_add_le (by nlinarith)
+  rw [show 2 * (m + 1) ^ 2 - 2 * (m + 1) - 1 = (2 * (m + 1) ^ 2 - 2 * (m + 1)) - 1 from by omega,
+      Nat.cast_sub h2, Nat.cast_sub h1]
+  push_cast; ring
+
+/-- Square-weighted geometric sum at `n = 0`: the empty sum is `0`. -/
+theorem natSqGeomSum_zero (q : ℕ) :
+    ∑ i ∈ Finset.range 0, i ^ 2 * q ^ i = 0 := by simp
+
+/-- Square-weighted geometric sum at `n = 1`: the only term `0² · q⁰ = 0`. -/
+theorem natSqGeomSum_one (q : ℕ) :
+    ∑ i ∈ Finset.range 1, i ^ 2 * q ^ i = 0 := by simp
+
+/-- Square-weighted geometric sum `Σ_{i<n} i²·qⁱ`, cleared and additive,
+for `2 ≤ q` and `2 ≤ n`. `G₂` re-indexed to `Finset.range n`. -/
+theorem natSqGeomSum_mul (q n : ℕ) (hq : 2 ≤ q) (hn : 2 ≤ n) :
+    (∑ i ∈ Finset.range n, i ^ 2 * q ^ i) * (q - 1) ^ 3
+        + (2 * n ^ 2 - 2 * n - 1) * q ^ (n + 1) + q ^ 2 + q =
+      (n - 1) ^ 2 * q ^ (n + 2) + n ^ 2 * q ^ n := by
+  induction n with
+  | zero => omega
+  | succ m ih =>
+    by_cases hm2 : 2 ≤ m
+    · -- inductive step: m ≥ 2
+      have ihm := ih hm2
+      rw [Finset.sum_range_succ, show m + 1 - 1 = m from by omega]
+      -- lift to ℤ; `zify` handles `(q-1)^3` and `(m-1)^2` given positivity bounds,
+      -- but not the ℕ-truncated-subtraction coefficients; those are rewritten separately
+      zify [show 1 ≤ q from by omega, show 1 ≤ m from by omega,
+            Nat.one_le_pow m q (by omega),
+            Nat.one_le_pow (m + 1) q (by omega),
+            Nat.one_le_pow (m + 2) q (by omega),
+            Nat.one_le_pow (m + 3) q (by omega)] at ihm ⊢
+      rw [cast_coeff_sq m hm2] at ihm
+      rw [cast_coeff_sq_succ m hm2]
+      -- Expand the new degree-3 term and match against the IH
+      have hcube : (m : ℤ) ^ 2 * (q : ℤ) ^ m * ((q : ℤ) - 1) ^ 3 =
+          (m : ℤ) ^ 2 * ((q : ℤ) ^ (m + 1 + 2) - 3 * (q : ℤ) ^ (m + 1 + 1) +
+            3 * (q : ℤ) ^ (m + 1) - (q : ℤ) ^ m) := by ring
+      have hpow_eq : (q : ℤ) ^ (m + 2) = (q : ℤ) ^ (m + 1 + 1) := by ring_nf
+      rw [show ((m : ℤ) - 1) ^ 2 = (m : ℤ) ^ 2 - 2 * m + 1 from by ring, hpow_eq] at ihm
+      linarith [hcube]
+    · -- base case: m < 2 and m + 1 ≥ 2, so m = 1
+      have hm1 : m = 1 := by omega
+      subst hm1
+      simp only [Finset.sum_range_succ, Finset.sum_range_zero, zero_add]
+      zify [show 1 ≤ q from by omega]
+      push_cast; ring
 
 end GebLean

--- a/geb-lean/docs/superpowers/notes/2026-06-14-erabsum-m3b-construction-decision.md
+++ b/geb-lean/docs/superpowers/notes/2026-06-14-erabsum-m3b-construction-decision.md
@@ -1,0 +1,319 @@
+# eraBSum / eraBProd construction — M3b re-gate decision
+
+<!-- START doctoc generated TOC please keep comment here to allow auto update -->
+<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
+
+- [1 Purpose and decision](#1-purpose-and-decision)
+- [2 Relationship to the Task-4 decision and the spec](#2-relationship-to-the-task-4-decision-and-the-spec)
+- [3 The construction problem (recalled)](#3-the-construction-problem-recalled)
+- [4 The chosen construction](#4-the-chosen-construction)
+  - [4.1 Ingredient closed forms](#41-ingredient-closed-forms)
+  - [4.2 The hypercube counting engine](#42-the-hypercube-counting-engine)
+  - [4.3 The recurrence-to-term engine and bsum/bprod](#43-the-recurrence-to-term-engine-and-bsumbprod)
+- [5 Numeric validation](#5-numeric-validation)
+- [6 Lean formalisation obligations](#6-lean-formalisation-obligations)
+- [7 The majorant prerequisite](#7-the-majorant-prerequisite)
+- [8 Recommended M3b staging](#8-recommended-m3b-staging)
+- [9 Transcription versus novel](#9-transcription-versus-novel)
+- [10 References](#10-references)
+
+<!-- END doctoc -->
+
+## 1 Purpose and decision
+
+This note records the M3b re-gate decision for the bounded-sum and
+bounded-product term formers `eraBSum` and `eraBProd`, the engines of
+the Era-basis completeness direction (spec
+`docs/superpowers/specs/2026-06-14-era-completeness-bounded-sum-design.md`,
+§ 5, § 6, § 13; M2/M3 gate). It refines the Task-4 decision note
+(`2026-06-14-erabsum-construction-decision.md`), which selected route 3
+(the Marchenkov 2007 § 5 digit-sum `σ` method) but left the construction
+of the `σ`-packing and the `exp₂` term as an open question entangled
+with bounded search.
+
+Decision. The construction is the Prunescu–Sauras-Altuzarra hypercube
+counting method (the constructive realisation of route 3 in the Era
+basis), packaged for `eraBSum` and `eraBProd` by the Istrate–Prunescu–
+Shunia recurrence-to-term metatheorem. Concretely:
+
+- The `σ` / `exp₂` crux is resolved: the `2`-adic valuation, the
+  central binomial coefficient, the binary digit sum, and the
+  generalised geometric progressions are all explicit closed-form
+  arithmetic terms over the basis `{add, tsub, mul, div, mod, pow}`
+  (equivalently `{add, mod, pow2}`), with literature references and
+  numeric validation (§ 5).
+- `eraBSum` and `eraBProd` are obtained as the `k = 1` instances of the
+  general recurrence-to-term engine (`a(m+1) = a(m) + f(m)` and
+  `a(m+1) = a(m) · f(m)`), each requiring only an arithmetic-term
+  majorant of the summand. This eliminates the dependency on the
+  untranslated Marchenkov 2003 monograph (Statement 2.13) that the spec
+  flagged for `eraBProd` (§ 6, § 13).
+
+Source. The construction is transcribed from peer-reviewed and arXiv
+sources in the identical operation set, superseding a raw transcription
+of Marchenkov 2007 § 5 (a Springer article leaning on the untranslated
+2003 monograph). The chosen sources are the same research lineage that
+the Era basis paper (arXiv:2505.23787) belongs to, and the project
+already transcribes from it (`Era.lean`'s `esq` is that paper's
+Theorem 1).
+
+## 2 Relationship to the Task-4 decision and the spec
+
+The Task-4 note rejected routes 1 (Mathlib `Dioph`, `Prop`-only) and 2
+(direct `mod (β − 1)` digit-extraction, which cannot itself produce the
+packing) and selected route 3. It identified the open question as
+whether the directly-computable Era summand lets the counting reduction
+be encoded without the full exponential-Diophantine `R`-class.
+
+This re-gate answers that question and the spec's two M2/M3 gate items
+(§ 13: "search-free simplification" and "exp-diophantine magnitude"):
+
+- The directly-computable summand does not remove the need for a
+  Diophantine encoding of the summand's graph. Forming the digit
+  packing `Σ_{i<y} f(i) · βⁱ` is itself a bounded sum over an arbitrary
+  sequence and has no closed form; structural recursion on the summand
+  term fails for the `Σ (g · h)`, `Σ 2^g`, `Σ (g mod h)` cases (Task-4
+  note § 2). The unique escape is the hypercube counting method, which
+  re-expresses the packing as a count of Diophantine solutions that
+  factors into the generalised geometric progressions (the only
+  closed-form sums).
+- The full Davis–Putnam–Robinson–Matiyasevich apparatus is not needed.
+  The encoding required is the elementary term-to-Diophantine reduction
+  of the recurrence paper's Lemma 2 (a sum-of-squares, simple,
+  unique-witness, explicitly bounded system), by induction on term
+  structure. This is the dominant formalisation cost (§ 6).
+
+## 3 The construction problem (recalled)
+
+The completeness induction (spec § 4) requires
+
+```text
+eval (eraBSum  t) ctx = natBSum  (ctx 0) (fun i => eval t (Fin.cons i (Fin.tail ctx)))
+eval (eraBProd t) ctx = natBProd (ctx 0) (fun i => eval t (Fin.cons i (Fin.tail ctx)))
+```
+
+with variable `0` of `t` the loop index and `ctx 0` the bound
+(`GebLean/LawvereER.lean`: `natBSum`, `natBProd`, `interp_bsum`,
+`interp_bprod`). The Era basis carries no recursion or search scheme —
+only composition — so each must be a closed composition term.
+
+## 4 The chosen construction
+
+### 4.1 Ingredient closed forms
+
+Each is a closed-form arithmetic term over the basis. `Era` term
+realisations compose the existing formers
+`eadd`/`etsub`/`emul`/`ediv`/`emod`/`epow`/`epow2` (`Era.lean`).
+`G₀` is already delivered as `eraGeomSum` / `natGeomSum_eq` (M3a). All
+formulas were validated numerically (§ 5).
+
+```text
+G_r(q,t) = Σ_{k=0}^{t} k^r q^k        (generalised geometric progression)
+  G0(q,t) = (q^(t+1) − 1) / (q − 1)
+  G1(q,t) = (t·q^(t+2) − (t+1)·q^(t+1) + q) / (q − 1)^2
+  G2(q,t) = (t^2·q^(t+3) − (2t^2+2t−1)·q^(t+2) + (t+1)^2·q^(t+1)
+             − q^2 − q) / (q − 1)^3
+
+gcd(m,n)  : Mazzanti base-2 closed form (method paper, Lemma 3.3);
+            an alternative base-5 form appears in the recurrence
+            paper § 3.
+
+ν2(m)     = floor( ( gcd(m, 2^m)^(m+1) mod (2^(m+1) − 1)^2 )
+                   / (2^(m+1) − 1) )
+            (method paper, Theorem 2.1: the SLOW, log-free form — the
+            one realised as an Era term; see the de-cycling note below.
+            A faster log-bounded form (Theorem 9.4, exponent ⌊log₂ m⌋+3)
+            exists but is used only for numeric probes, never in terms.).
+
+C(2n,n)   = ( floor( (1 + 2^(2n))^(2n) / 2^(2n^2) ) ) mod 2^(2n)
+            (central binomial coefficient).
+
+HW(n)     = ν2( C(2n,n) )            (Hamming weight = binary digit sum
+            σ; Kummer's theorem; method paper via Mazzanti Lemma 4.2).
+
+δ(a,w)    = (2^w − 1)(2^w − a + 1)    for 0 ≤ a < 2^w; the indicator:
+            HW(δ(a,w)) = 2w if a = 0, else w   (method paper Lemma 3.1).
+```
+
+### 4.2 The hypercube counting engine
+
+Method paper (arXiv:2407.12928) Lemma 3.1–3.3, Theorem 3.4,
+Corollary 3.6. To count the zeros of a simple exponential polynomial
+`P` over a cube `{0,…,t−1}^k`, given an arithmetic-term width `w` with
+`0 ≤ P(ā) < 2^w` on the whole cube:
+
+```text
+M = Σ_{ā ∈ cube} 2^(2 w · v(ā)) · δ( P(ā), w ),   v(ā) = mixed-radix index
+#{ ā : P(ā) = 0 } = HW(M) / w − t^k
+```
+
+`M` is a closed-form term because the cube-sum factorises (Lemma 3.2):
+
+```text
+Σ_{ā ∈ cube} Πᵢ aᵢ^(uᵢ) vᵢ^(aᵢ) = Πᵢ G_{uᵢ}(vᵢ, t − 1)
+```
+
+so each monomial of `δ(P, w)` becomes a product of `G`-terms (Eqs (7),
+(8)). Corollary 3.6: only `{HW, G₀, G₁, G₂}` are needed, since a chain
+of auxiliary variables reduces every non-exponential occurrence to
+degree ≤ 2.
+
+### 4.3 The recurrence-to-term engine and bsum/bprod
+
+Recurrence paper (arXiv:2606.09336) Theorem 2 / Corollary 2: a sequence
+`a(m+k) = F(m, a(m),…,a(m+k−1))` with `F` an arithmetic term and an
+arithmetic-term majorant `A` with `a(j) < A(j, ā)` for all `j ≤ n` has a
+closed-form term
+
+```text
+a(n) = floor( H(n, ȳ) / A(n, ȳ)^n )
+```
+
+where `H` codes the whole value-history in base `A` (positional coding,
+Lemma 3) and the read-off extracts the last digit; `H` is built by the
+hypercube count of § 4.2 applied to the Diophantine encoding of the
+recurrence step (Lemma 2). Specialisations (`k = 1`):
+
+```text
+eraBSum  :  s(0)=0, s(m+1) = s(m) + f(m)   ⇒  Σ_{i<y} f(i)  = floor(H/A^y)
+eraBProd :  p(0)=1, p(m+1) = p(m) · f(m)   ⇒  Π_{i<y} f(i)  = floor(H/A^y)
+```
+
+`eraBSum` also admits the direct 2-D form
+`Σ_{i<y} f(i) = #{ (i,w) : i<y, w<f(i) }` via § 4.2 (Theorem 3.4)
+without the positional-coding layer; `eraBProd` is not naturally a count
+and uses the recurrence engine. Building the general engine once yields
+both and positions Route-B `simrec` (a `k`-ary recurrence) for any later
+work, without committing to it here.
+
+## 5 Numeric validation
+
+A throwaway probe (pure-`ℕ` integer arithmetic, outside the repository;
+the project's `#eval` hazard concerns symbolic `Tm.eval` reduction, not
+plain `ℕ`) validated every ingredient closed form against a reference
+implementation:
+
+- `gcd` (base-2 and base-5), `C(2n,n)`, `ν2` (both the slow Theorem 2.1
+  form and the fast Theorem 9.4 form), `HW = ν2(C(2n,n))` against
+  population count, the `δ` indicator, and `G₀/G₁/G₂`: all agree.
+- Two findings the probe surfaced, incorporated above:
+  - `G₁`'s constant term is `+ q`, not `+ 1` (a transcription slip from
+    the source's notation); corrected in § 4.1.
+  - De-cycling (corrected by the M3b plan's adversarial review;
+    supersedes an earlier conclusion in this note). The term-level `HW`
+    must use the SLOW, log-free `ν2` (Theorem 2.1), NOT the fast one:
+    the fast `ν2` (Theorem 9.4) depends on `⌊log₂⌋` (Theorem 9.3), which
+    is realised through the count engine via `HW`, which uses `ν2` — a
+    def/proof cycle `count → HW → ν2(fast) → ⌊log₂⌋ → count`. The slow
+    `ν2` carries no logarithm and breaks the cycle. Its term forms
+    `2^m`-sized numbers internally, so it is not numerically evaluable
+    on large arguments such as `C(2n,n)` — but that is irrelevant: the
+    term's `eval` lemma is proved, never computed. The fast `ν2` is
+    correct only as a throwaway numeric probe (where evaluability is the
+    concern), never in a committed term.
+
+## 6 Lean formalisation obligations
+
+The Lean obligation is the `eval` identity for each former (§ 3); the
+closed term is the witness. Correctness rests on:
+
+- the ingredient `ℕ`-identities of § 4.1 (each an induction or algebra
+  proof; Mathlib supplies `geom_sum_eq`, `Nat.centralBinom`,
+  `padicValNat`, the Kummer/Legendre lemma
+  `sub_one_mul_padicValNat_choose_eq_sub_sum_digits`, `Nat.gcd`);
+- `HW`-additivity over non-overlapping base-`2^(2w)` blocks (Lemma 3.3);
+- the cube-sum factorisation (Lemma 3.2) and the positional read-off
+  (Lemma 3 / `floor(H/A^n)`);
+- the dominant cost: Lemma 2, the induction on `ETm` producing a
+  bounded, unique-witness, sum-of-squares Diophantine system for the
+  recurrence step, carrying the four invariants (sum-of-squares, simple,
+  unique witness, explicit bounds) through every term constructor.
+
+All ingredients are closed terms with no `Classical.choice` in
+computational content, so the `noncomputable` ban and axiom-clean
+discipline (`propext`, `Quot.sound`, `Classical.choice` only) are
+preserved; `Era.lean` retains its no-Mathlib property and the new
+content lives in the bridge module and `Utilities/`.
+
+## 7 The majorant prerequisite
+
+The engine requires an arithmetic-term majorant `A(y, x̄)` with
+`f(i) < A` for all `i < y` (and analogously a product majorant). It is
+constructible by induction on the summand term `f` — the monotone
+elementary majorant that the spec flagged as a likely first sub-task
+(handoff) — or mechanically by the recurrence paper's Claim 2 recipe
+(replace every `tsub` by `add` and substitute the range bound for each
+unknown). The majorant fixes the packing width `w` and is independent of
+the rest of the construction; it is the recommended first M3b sub-task.
+
+## 8 Recommended M3b staging
+
+For the follow-on plan (`superpowers:writing-plans`), in dependency
+order:
+
+1. Monotone arithmetic-term majorant for an `ETm` summand, with its
+   `ℕ`-bound lemma.
+2. Ingredient terms and `ℕ`-identities: `G₁`, `G₂` (extend M3a's `G₀`);
+   `2^(v₂ n)` (gcd-light); the slow log-free `ν2` (Theorem 2.1);
+   `C(2n,n)`; `HW`; the `δ` indicator with its `HW`-value lemma. (No
+   `⌊log₂⌋`/fast-`ν2` term — see the de-cycling note in § 5.)
+3. The hypercube engine: cube-sum factorisation, the packed number `M`,
+   the count read-off `HW(M)/w − t^k` (Theorem 3.4 / Corollary 3.6).
+4. Lemma 2: `ETm`-to-Diophantine reduction (the dominant task; consider
+   isolating the four invariants as a structure carried by the
+   induction).
+5. The recurrence read-off (positional coding, `floor(H/A^n)`) and
+   Theorem 2.
+6. `eraBSum`, `eraBProd` as the `k = 1` instances, each with its `eval`
+   lemma against `natBSum` / `natBProd`.
+7. Assemble `era_complete` (spec § 4) and the K-sim-2 corollary
+   (spec § 8); the soundness direction `era_sound_er` already exists
+   (`EraCompleteness.lean`).
+
+Stage 2 is partly Mathlib-citation work; stage 4 is the principal
+schedule risk and the natural re-checkpoint.
+
+## 9 Transcription versus novel
+
+- The ingredient closed forms (§ 4.1), the hypercube counting engine
+  (§ 4.2), and the recurrence-to-term metatheorem (§ 4.3): transcription
+  of arXiv:2407.12928 and arXiv:2606.09336 (themselves building on
+  Mazzanti 2002, Marchenkov 2007, Matiyasevich, Kummer/Legendre).
+- The `Era`-term realisations, the `eval` lemmas against `natBSum` /
+  `natBProd`, the `ETm`-to-Diophantine reduction specialised to the Era
+  term language, and the structural-induction completeness assembly:
+  novel artifacts bridging the cited results to the Era basis.
+
+## 10 References
+
+- M. Prunescu, L. Sauras-Altuzarra, "On the representation of
+  number-theoretic functions by arithmetic terms", arXiv:2407.12928.
+  (The method: `δ` indicator, cube-sum factorisation, packed number,
+  Theorem 3.4 count, Corollary 3.6; `ν_p` Theorems 2.1 / 9.4; integer
+  logarithm Theorem 9.3; central binomial; `HW`; `G_r`.)
+- G. Istrate, M. Prunescu, J. M. Shunia, "Undecidability, Chaos and
+  Universality in Arithmetic Terms", arXiv:2606.09336. (Theorem 2 /
+  Corollary 2 recurrence-to-term; Lemma 2 term-to-Diophantine; Lemma 3
+  positional coding.)
+- M. Prunescu, L. Sauras-Altuzarra, J. M. Shunia, "A Minimal
+  Substitution Basis for the Kalmár Elementary Functions",
+  arXiv:2505.23787. (The Era basis; Theorem 1, transcribed as
+  `Era.lean`'s `esq`.)
+- J. M. Shunia, L. Sauras-Altuzarra, "Arithmetic Terms for Multinomial
+  Coefficient Sums", arXiv:2312.00301. (Partial sums of binomial
+  coefficients; an alternative source for the layer-2 sums.)
+- S. S. Marchenkov, "Superpositions of Elementary Arithmetic Functions",
+  J. Appl. Ind. Math. 1(3) (2007) 351–360. (Route 3, the digit-sum `σ`
+  method that the above realise constructively.)
+- S. Mazzanti, "Plain Bases for Classes of Primitive Recursive
+  Functions", MLQ 48:1 (2002) 93–104. (`σ(x) = exp₂ C(2x, x)`; the
+  base-2 `gcd` term.)
+- Companion spec:
+  `docs/superpowers/specs/2026-06-14-era-completeness-bounded-sum-design.md`.
+- Task-4 decision:
+  `docs/superpowers/notes/2026-06-14-erabsum-construction-decision.md`.
+- Repository: `GebLean/Era.lean` (`ETm`, `Tm.eval`, `eraInterp`, term
+  formers, `esq`); `GebLean/LawvereER.lean` (`ERMor1`, `natBSum`,
+  `natBProd`, `interp_bsum`, `interp_bprod`);
+  `GebLean/Utilities/EraBoundedSum.lean` (`natGeomSum_eq`, `natBSum_geom`
+  — `G₀`); `GebLean/EraCompleteness.lean` (`era_sound_er`, `eraGeomSum`).

--- a/geb-lean/docs/superpowers/plans/2026-06-14-era-completeness-m3b-plan.md
+++ b/geb-lean/docs/superpowers/plans/2026-06-14-era-completeness-m3b-plan.md
@@ -1,0 +1,983 @@
+# Era completeness M3b implementation plan
+
+<!-- START doctoc generated TOC please keep comment here to allow auto update -->
+<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
+**Table of Contents**  *generated with [DocToc](https://github.com/thlorenz/doctoc)*
+
+- [How to work this plan](#how-to-work-this-plan)
+- [De-cycling: term-level `HW` uses the slow, log-free `ν₂`](#de-cycling-term-level-hw-uses-the-slow-log-free-%CE%BD%E2%82%82)
+- [File structure](#file-structure)
+- [Phase map and the Phase-4 re-checkpoint](#phase-map-and-the-phase-4-re-checkpoint)
+- [Phase 1 — Generalised geometric progressions (`G₁`, `G₂`)](#phase-1--generalised-geometric-progressions-g%E2%82%81-g%E2%82%82)
+  - [Task 1.1: `natLinGeomSum` — the `G₁` identity over ℕ](#task-11-natlingeomsum--the-g%E2%82%81-identity-over-%E2%84%95)
+  - [Task 1.2: `natSqGeomSum` — the `G₂` identity over ℕ](#task-12-natsqgeomsum--the-g%E2%82%82-identity-over-%E2%84%95)
+- [Phase 2 — Number-theoretic ingredient closed forms](#phase-2--number-theoretic-ingredient-closed-forms)
+  - [Task 2.1: the slow `2`-adic valuation `nu2Closed`](#task-21-the-slow-2-adic-valuation-nu2closed)
+  - [Task 2.2: central binomial closed form `centralBinomClosed`](#task-22-central-binomial-closed-form-centralbinomclosed)
+  - [Task 2.3: Hamming weight `hwClosed`](#task-23-hamming-weight-hwclosed)
+  - [Task 2.4: the digit-block indicator `δ`](#task-24-the-digit-block-indicator-%CE%B4)
+- [Phase 3 — `Era`-term realisations of the ingredients](#phase-3--era-term-realisations-of-the-ingredients)
+  - [Task 3.1: the largest-power-of-two-divisor term (gcd-light)](#task-31-the-largest-power-of-two-divisor-term-gcd-light)
+  - [Task 3.2: `eraNu2`, `eraCentralBinom`, `eraSigma`](#task-32-eranu2-eracentralbinom-erasigma)
+  - [Task 3.3: `eraDelta` (the indicator term)](#task-33-eradelta-the-indicator-term)
+- [Phase 3.5 — The monotone `ETm` majorant (gates Phases 4–5)](#phase-35--the-monotone-etm-majorant-gates-phases-45)
+- [Phase 4 — Lemma 2: `ETm`-to-Diophantine reduction (RE-CHECKPOINT)](#phase-4--lemma-2-etm-to-diophantine-reduction-re-checkpoint)
+- [Phase 5 — The counting engine and the recurrence read-off](#phase-5--the-counting-engine-and-the-recurrence-read-off)
+- [Phase 6 — `eraBSum` and `eraBProd`](#phase-6--erabsum-and-erabprod)
+  - [Task 6.1: `eraBSum`](#task-61-erabsum)
+  - [Task 6.2: `eraBProd`](#task-62-erabprod)
+- [Phase 7 — Capstones: `era_complete` and the K-sim-2 corollary](#phase-7--capstones-era_complete-and-the-k-sim-2-corollary)
+  - [Task 7.1: `era_complete`](#task-71-era_complete)
+  - [Task 7.2: the K-sim-2 corollary](#task-72-the-k-sim-2-corollary)
+- [Self-review checklist (run before execution)](#self-review-checklist-run-before-execution)
+
+<!-- END doctoc generated TOC please keep comment here to allow auto update -->
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use
+> superpowers:subagent-driven-development (recommended) or
+> superpowers:executing-plans to implement this plan task-by-task. Steps
+> use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Build the `eraBSum` and `eraBProd` term formers with their
+`eval` lemmas, then assemble `era_complete` (every `ERMor1` function is
+an `Era` term) and the K-sim-2 corollary.
+
+**Architecture:** Transcribe the Prunescu–Sauras-Altuzarra hypercube
+counting method and the Istrate–Prunescu–Shunia recurrence-to-term
+metatheorem (decision note
+`docs/superpowers/notes/2026-06-14-erabsum-m3b-construction-decision.md`).
+Ingredient closed forms (generalised geometric progressions, `gcd`,
+`2`-adic valuation, central binomial, Hamming weight, the digit-block
+indicator) are proved as `ℕ`-identities against Mathlib reference
+functions, realised as `Era` terms, then composed by the counting
+engine into `eraBSum`/`eraBProd`. `era_complete` is a structural
+induction on `ERMor1` whose only non-routine cases are `bsum`/`bprod`.
+The decision note is the binding construction source; the companion
+spec's construction narrative (spec § 5, § 6) describes the superseded
+Marchenkov-2007/2003 route and is stale, but the spec's `eval`-lemma
+statements, completeness statement, soundness reuse, corollary, and
+acceptance criteria (§ 3, § 4, § 7, § 8, § 11, § 12) remain binding and
+are matched verbatim here.
+
+**Tech stack:** Lean 4, Mathlib (pin `v4.29.0-rc6`), `lake build` /
+`lake test` / `lake lint`, `scripts/check-axioms.sh`. Constructive-only
+(no `noncomputable`); axiom-clean (`propext`, `Quot.sound`,
+`Classical.choice` only).
+
+---
+
+## How to work this plan
+
+- **One declaration at a time** (`.claude/rules/lean-coding.md`): write a
+  `def`/`theorem`, get it building with no `sorry`/underscore, then move
+  on. `sorry` is an audited stand-in *between* steps only; never in a
+  commit.
+
+- **Numeric sanity checks** use `#eval` on plain-`ℕ` closed forms (fast
+  and safe). Do **not** `#guard`/`#eval` symbolic `Tm.eval`/`ERMor1.interp`
+  reductions — they expand the Gödel-style composite and hang (memory:
+  "ER / Gödel-numbering interp not safe for `#guard`"). Test `Era` terms
+  only through proven `@[simp]`/`eval` lemmas. Numeric checks are
+  throwaway: delete every `#eval` line before committing.
+
+- **Slow vs fast `ν₂`** (a load-bearing distinction, see the de-cycling
+  note below): the **slow**, log-free `ν₂` (Theorem 2.1,
+  `gcd(n, 2ⁿ)`, exponent `n+1`) is the one realised as an `Era` *term*;
+  its term is not numerically evaluable on large inputs, but its `eval`
+  lemma is *proved*, never computed. The **fast** `ν₂` (Theorem 9.4,
+  log-bounded) is used **only** in throwaway numeric probes for
+  validation; it never appears in committed terms, because it depends on
+  `⌊log₂⌋`, which the count engine realises via `HW`, which uses `ν₂` —
+  a cycle (see "De-cycling" below).
+
+- **Per-commit**: `bash scripts/pre-commit.sh` (runs `lake test` +
+  `lake lint`) before every `.lean` commit. Commit messages: imperative,
+  lowercase subject, no trailing period; end with the
+  `Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>`
+  trailer.
+
+- **VCS**: `jj` only; no raw mutating `git`. Each task is one or more
+  `jj` commits authored by the controller (subagent-driven: implementers
+  edit and verify, controller commits and reviews).
+
+- **`ℕ`-truncated-subtraction proofs**: prefer an additive
+  (subtraction-free) statement so `omega` closes the inductive step;
+  feed it the nonlinear facts as hypotheses (`Nat.one_le_pow`,
+  `Nat.mul_sub_one`, `Nat.le_mul_of_pos_right`); it treats
+  products/powers as opaque atoms otherwise (memory).
+
+- **Mathlib search** before each from-scratch proof: `lean_leansearch`,
+  `lean_loogle`, `lean_local_search` (do not assume a lemma name).
+
+## De-cycling: term-level `HW` uses the slow, log-free `ν₂`
+
+The count engine read-off is `d = HW(M)/w − tᵏ`. If the term-level `HW`
+used the fast `ν₂` (Theorem 9.4), it would need `⌊log₂⌋`, which Theorem
+9.3 realises *through the count engine* (`HW` again) — a def/proof cycle
+`count → HW → ν₂(fast) → ⌊log₂⌋ → count`. The source avoids this by
+realising the count-engine `HW` with the **slow** `ν₂` (Theorem 2.1,
+log-free). This plan does the same: the committed `HW`/`ν₂` *terms* use
+the slow form; `⌊log₂⌋` and the fast `ν₂` are **not** on the term
+critical path (no `eraIlog2` term is built). The `ℕ`-level `ilog2`
+(`Nat.log 2`) is used only for magnitude bounds in proofs.
+
+This **supersedes** the decision note's earlier fast-`ν₂`/`⌊log₂⌋`
+layering (note § 4.1, § 5, § 8 item 2), which the plan's adversarial
+review found to be circular for the term construction; the decision
+note is corrected to match. The fast `ν₂` is correct only as a numeric
+probe, where "infeasible to evaluate the slow form" — not "unusable as a
+term" — is the operative concern.
+
+## File structure
+
+- `GebLean/Utilities/EraBoundedSum.lean` (exists; has `G₀` as
+  `natGeomSum_eq`/`natBSum_geom`): extend with the generalised geometric
+  progressions `G₁`, `G₂` (`ℕ`-identities, additive forms).
+  Responsibility: bounded sums with closed forms.
+
+- `GebLean/Utilities/ArithClosedForms.lean` (new): the number-theoretic
+  ingredient `ℕ`-identities — the slow `2`-adic valuation, the central
+  binomial closed form, the Hamming weight, and the `δ` digit-block
+  indicator — each equated to a Mathlib reference function.
+  Responsibility: search-free closed forms for number theory.
+
+- `GebLean/Utilities/EraHypercube.lean` (new): the `ℕ`-level hypercube
+  counting identity (`count = HW(M)/w − tᵏ`), the packed-number `M`
+  closed form via the cube-sum factorisation, the mixed-radix
+  enumeration bijection, and the positional-coding read-off
+  `a(n) = ⌊H/Aⁿ⌋`. Responsibility: the counting engine at `ℕ` level.
+
+- `GebLean/Utilities/EraDiophantine.lean` (new): Lemma 2 — the recursion
+  on `ETm` producing a bounded, unique-witness, sum-of-squares
+  Diophantine system for a term's graph; the monotone `ETm` majorant;
+  the Identity-(4) exponent reduction. Responsibility: the
+  term-to-Diophantine reduction (the dominant cost).
+
+- `GebLean/EraCompleteness.lean` (exists; has `era_sound_er`,
+  `eraGeomSum`): the `Era`-term realisations (`eraNu2`,
+  `eraCentralBinom`, `eraSigma`, `eraDelta`, the count term, `eraBSum`,
+  `eraBProd`) and the capstones (`era_complete`, the K-sim-2 corollary).
+
+## Phase map and the Phase-4 re-checkpoint
+
+Phases 1–3 plus the majorant (Phase 3.5) are concretely specified below.
+Phase 4 (`EraDiophantine`) and Phase 5 (the counting read-off and
+Theorem 2) are the discovery-heavy core; they are decomposed into
+sub-lemma signatures with strategy here, and the decision note (§ 8)
+designates the **start of Phase 4 as the re-checkpoint**: when Phases
+1–3.5 land, write a detailed Phase-4/5 sub-plan against the then-exact
+`ℕ`-shapes before executing. Phases 6–7 assemble the formers and the
+capstones. Dependency order: 1, 2, 3, **3.5 (majorant)**, 4, 5, 6, 7 —
+the majorant gates Phases 4 and 5 (it fixes the witness bounds and the
+packing width), so it precedes them.
+
+---
+
+## Phase 1 — Generalised geometric progressions (`G₁`, `G₂`)
+
+Extends M3a's `G₀`. These are the bounded sums `Σ_{i<n} iʳ qⁱ` used by
+the counting engine (Phase 5). The decision note § 4.1 gives the
+`Σ_{k≤t}` forms; re-indexed to `Finset.range n` (`t = n−1`) the
+**verified** cleared constants are, for `G₁`,
+`(Σ_{i<n} i·qⁱ)·(q−1)² = (n−1)·q^{n+1} − n·qⁿ + q`, and for `G₂`,
+`(Σ_{i<n} i²·qⁱ)·(q−1)³ = (n−1)²·q^{n+2} − (2n²−2n−1)·q^{n+1} + n²·qⁿ − q² − q`.
+These have interior `ℕ` truncation at small `n`, so state them additively
+(subtraction-free) and numeric-check over `range 8` (including
+`n = 0, 1`) before proving.
+
+### Task 1.1: `natLinGeomSum` — the `G₁` identity over ℕ
+
+**Files:**
+
+- Modify: `GebLean/Utilities/EraBoundedSum.lean`
+
+- [ ] **Step 1: State the additive (ℕ-safe) identity**
+
+```lean
+/-- Linear-weighted geometric sum `Σ_{i<n} i·qⁱ`, cleared of division
+and stated additively (no `ℕ` truncation, valid for all `n`), for
+`2 ≤ q`. `G₁` re-indexed to `Finset.range n` (decision note § 4.1). -/
+theorem natLinGeomSum_mul (q n : ℕ) (hq : 2 ≤ q) :
+    (∑ i ∈ Finset.range n, i * q ^ i) * (q - 1) ^ 2 + q ^ (n + 1)
+        + n * q ^ n =
+      n * q ^ (n + 1) + q := by
+  sorry
+```
+
+Note: the additive form `LHS·(q−1)² + q^{n+1} + n·qⁿ = n·q^{n+1} + q`
+is equivalent over `ℤ` to `(n−1)·q^{n+1} − n·qⁿ + q` but avoids every
+`ℕ` subtraction, so it holds for all `n ≥ 0` and `omega` can close the
+step.
+
+- [ ] **Step 2: Numeric check FIRST (over `range 8`, incl. `n=0,1`)**
+
+```lean
+#eval (List.range 8).all (fun n =>
+  ((List.range n).foldl (fun s i => s + i * 3 ^ i) 0) * (3 - 1) ^ 2
+      + 3 ^ (n + 1) + n * 3 ^ n
+    = n * 3 ^ (n + 1) + 3)
+```
+
+Expected: `true`. Remove before commit.
+
+- [ ] **Step 3: Build to confirm the statement elaborates**
+
+Run: `lake build GebLean.Utilities.EraBoundedSum`
+Expected: builds with a `declaration uses 'sorry'` warning, no
+elaboration errors.
+
+- [ ] **Step 4: Prove by induction on `n`**
+
+Strategy: `induction n`; base `simp`. Step: `Finset.sum_range_succ`,
+`pow_succ`, the IH, then `omega` fed `Nat.one_le_pow` and the product
+facts. The additive form keeps every term non-negative, so `omega`
+closes after the nonlinear atoms are supplied. Mirror
+`natGeomSum_mul`'s structure.
+
+- [ ] **Step 5: `/`-form corollary (for `n ≥ 1`, optional consumer
+convenience)**
+
+```lean
+theorem natLinGeomSum_eq (q n : ℕ) (hq : 2 ≤ q) (hn : 1 ≤ n) :
+    ∑ i ∈ Finset.range n, i * q ^ i =
+      ((n - 1) * q ^ (n + 1) - n * q ^ n + q) / (q - 1) ^ 2 := by
+  sorry
+```
+
+Strategy: derive from `natLinGeomSum_mul` by clearing; only stated for
+`n ≥ 1` so `(n − 1)` is exact. If the engine consumes the `_mul` form
+directly, this corollary may be dropped.
+
+- [ ] **Step 6: Verify axiom-clean and commit**
+
+Run: `bash scripts/pre-commit.sh`
+Run: `bash scripts/check-axioms.sh` (expect `propext`, `Quot.sound`,
+`Classical.choice` only)
+
+```bash
+jj describe -m "feat(era): prove the linear-weighted geometric sum over naturals
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+jj new
+```
+
+### Task 1.2: `natSqGeomSum` — the `G₂` identity over ℕ
+
+Higher-effort than Task 1.1: degree-3 in the cleared bracket, and the
+middle coefficient `2n²−2n−1` is negative for `n ≤ 1`, so the cleared
+`ℕ` identity is meaningful only for `n ≥ 2`. Prove the additive form for
+`n ≥ 2` and discharge `n = 0, 1` as trivial base cases (the sum is `0`).
+
+**Files:**
+
+- Modify: `GebLean/Utilities/EraBoundedSum.lean`
+
+- [ ] **Step 1: Numeric check FIRST (pin the constants, incl. small n)**
+
+```lean
+#eval (List.range 8).all (fun n =>
+  ((List.range n).foldl (fun s i => s + i ^ 2 * 3 ^ i) 0) * (3 - 1) ^ 3
+      + (2 * n ^ 2 - 2 * n - 1) * 3 ^ (n + 1) + 3 ^ 2 + 3
+    = (n - 1) ^ 2 * 3 ^ (n + 2) + n ^ 2 * 3 ^ n)
+```
+
+Expected: `true` for `n ≥ 2`; inspect `n = 0, 1` separately (the
+`2n²−2n−1` underflows in `ℕ` there). Adjust until the `n ≥ 2` cases all
+pass; remove before commit.
+
+- [ ] **Step 2: State the additive identity for `n ≥ 2`**
+
+```lean
+/-- Square-weighted geometric sum `Σ_{i<n} i²·qⁱ`, cleared and additive,
+for `2 ≤ q` and `2 ≤ n`. `G₂` re-indexed to `Finset.range n`
+(decision note § 4.1). -/
+theorem natSqGeomSum_mul (q n : ℕ) (hq : 2 ≤ q) (hn : 2 ≤ n) :
+    (∑ i ∈ Finset.range n, i ^ 2 * q ^ i) * (q - 1) ^ 3
+        + (2 * n ^ 2 - 2 * n - 1) * q ^ (n + 1) + q ^ 2 + q =
+      (n - 1) ^ 2 * q ^ (n + 2) + n ^ 2 * q ^ n := by
+  sorry
+```
+
+- [ ] **Step 3: Base cases `n = 0, 1`**
+
+```lean
+theorem natSqGeomSum_zero (q : ℕ) :
+    ∑ i ∈ Finset.range 0, i ^ 2 * q ^ i = 0 := by simp
+theorem natSqGeomSum_one (q : ℕ) :
+    ∑ i ∈ Finset.range 1, i ^ 2 * q ^ i = 0 := by simp
+```
+
+- [ ] **Step 4: Prove Step 2 by induction on `n` from `2`**
+
+Strategy: induct with the base at `n = 2` (compute directly) and the
+step via `Finset.sum_range_succ`, `pow_succ`, IH, `omega` with the
+nonlinear atoms. The additive form keeps coefficients non-negative for
+`n ≥ 2`. Budget a `lean4:sorry-filler-deep` pass — this is materially
+harder than `G₁`.
+
+- [ ] **Step 5: build, axiom-check, commit**
+
+```bash
+jj describe -m "feat(era): prove the square-weighted geometric sum over naturals
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+jj new
+```
+
+---
+
+## Phase 2 — Number-theoretic ingredient closed forms
+
+Each ingredient: a closed-form `ℕ` `def`, an identity equating it to a
+Mathlib reference function (for `n ≥ 1`, with explicit `n = 0` handling
+where the closed form degenerates), and (Phase 3) an `Era` term. The
+`ν₂` realised here is the **slow, log-free** form (see De-cycling).
+
+### Task 2.1: the slow `2`-adic valuation `nu2Closed`
+
+**Files:**
+
+- Create: `GebLean/Utilities/ArithClosedForms.lean`
+
+- [ ] **Step 1: Module docstring + imports**
+
+```lean
+import GebLean.LawvereER
+import Mathlib.NumberTheory.Padics.PadicVal.Basic
+import Mathlib.Data.Nat.Choose.Central
+import Mathlib.Data.Nat.Choose.Factorization
+import Mathlib.Data.Nat.Choose.Bounds
+import Mathlib.Data.Nat.Choose.Sum
+import Mathlib.Data.Nat.Digits.Lemmas
+
+/-!
+# Search-free closed forms for number-theoretic functions
+
+`ℕ`-level closed-form identities supporting the Era bounded-sum engine
+(`GebLean/EraCompleteness.lean`): the slow `2`-adic valuation, the
+central binomial coefficient, the binary Hamming weight, and the
+digit-block indicator, each equated to a Mathlib reference function.
+
+## Main definitions
+
+* `nu2Closed` — the slow, log-free `2`-adic valuation closed form.
+* `centralBinomClosed` — `C(2n,n)` as an arithmetic-term closed form.
+* `hwClosed` — the binary Hamming weight via `ν₂(C(2n,n))`.
+* `deltaBlock` — the digit-block indicator.
+
+## Main statements
+
+* `nu2Closed_eq` — `nu2Closed n = padicValNat 2 n` for `n ≥ 1`.
+* `centralBinomClosed_eq` — `= Nat.centralBinom n` for `n ≥ 1`.
+* `hwClosed_eq` — `= (Nat.digits 2 n).sum` for `n ≥ 1`.
+* `hwClosed_deltaBlock` — the indicator's Hamming weight.
+
+## References
+
+* Prunescu, Sauras-Altuzarra, arXiv:2407.12928 (the method; `ν_p`
+  Theorem 2.1; central binomial; Hamming weight; `δ` Lemma 3.1).
+
+## Tags
+
+elementary recursive, closed form, p-adic valuation, Hamming weight
+-/
+
+namespace GebLean
+```
+
+- [ ] **Step 2: define the slow `ν₂`**
+
+```lean
+/-- The slow (log-free) `2`-adic valuation closed form
+(arXiv:2407.12928, Theorem 2.1). `Nat.gcd n (2^n) = 2^(v₂ n)`, so the
+binomial-mod read-off recovers `v₂ n`. Realised as an `Era` term
+(Phase 3); not numerically evaluable on large inputs, but its `eval`
+lemma is proved, not computed. -/
+def nu2Closed (n : ℕ) : ℕ :=
+  let base := 2 ^ (n + 1) - 1
+  (Nat.gcd n (2 ^ n) ^ (n + 1) % base ^ 2) / base
+```
+
+- [ ] **Step 3: numeric check (small `n` only — the slow form forms
+`2ⁿ`)**
+
+```lean
+#eval (List.range 60).all (fun n => n = 0 || nu2Closed n = padicValNat 2 n)
+```
+
+Expected: `true`. (`padicValNat 2` needs the `Fact (Nat.Prime 2)`
+instance `fact_prime_two`, available in Mathlib.) Remove before commit.
+
+- [ ] **Step 4: prove `nu2Closed n = padicValNat 2 n` for `n ≥ 1`**
+
+```lean
+theorem nu2Closed_eq (n : ℕ) (hn : 1 ≤ n) :
+    nu2Closed n = padicValNat 2 n := by
+  sorry
+```
+
+Strategy (method paper Theorem 2.1): set `x = padicValNat 2 n`. Facts:
+`Nat.gcd n (2^n) = 2^x` (from `pow_padicValNat_dvd : 2^x ∣ n` and
+`x ≤ n`); `x < base := 2^(n+1) − 1`. Then
+`(2^x)^(n+1) = (2^(n+1))^x = (base+1)^x ≡ 1 + x·base (mod base²)` by the
+binomial theorem, using `x < base` so `mod base²` isolates
+`1 + x·base`; dividing by `base` gives `x`. Factor the binomial-mod step
+as a generic lemma `pow_succ_mod_sq (a x : ℕ) (h : x < a + 1) :
+(a + 1) ^ x % a ^ 2 = (1 + x * a) % a ^ 2` then specialise.
+
+- [ ] **Step 5: build, axiom-check, commit**
+
+```bash
+jj describe -m "feat(era): prove the slow 2-adic valuation closed form
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+jj new
+```
+
+### Task 2.2: central binomial closed form `centralBinomClosed`
+
+**Files:**
+
+- Modify: `GebLean/Utilities/ArithClosedForms.lean`
+
+- [ ] **Step 1: define**
+
+```lean
+/-- `C(2n,n)` as the arithmetic-term closed form
+`⌊(1+2^(2n))^(2n) / 2^(2n²)⌋ mod 2^(2n)` (arXiv:2407.12928). Agrees with
+`Nat.centralBinom` for `n ≥ 1`; degenerates to `0` at `n = 0`
+(`Nat.centralBinom 0 = 1`), handled separately. -/
+def centralBinomClosed (n : ℕ) : ℕ :=
+  ((1 + 2 ^ (2 * n)) ^ (2 * n) / 2 ^ (2 * n ^ 2)) % 2 ^ (2 * n)
+```
+
+- [ ] **Step 2: numeric check** for `n` in `1 .. 14`:
+`centralBinomClosed n = Nat.centralBinom n`. Confirm separately that
+`centralBinomClosed 0 = 0 ≠ 1 = Nat.centralBinom 0`. Remove before
+commit.
+
+- [ ] **Step 3: prove `centralBinomClosed n = Nat.centralBinom n` for
+`n ≥ 1`**
+
+```lean
+theorem centralBinomClosed_eq (n : ℕ) (hn : 1 ≤ n) :
+    centralBinomClosed n = Nat.centralBinom n := by
+  sorry
+```
+
+Strategy: `(1 + 2^(2n))^(2n) = Σ_j C(2n,j) · 2^(2n·j)` (binomial
+theorem, `add_pow` / `Commute.add_pow`). The base-`2^(2n)` digits are
+`C(2n,j)`, which fit strictly (`C(2n,j) < 2^(2n)` for `n ≥ 1`: from
+`Nat.choose_le_two_pow : C(m,k) ≤ 2^m` plus strictness via
+`Nat.sum_range_choose : Σ_j C(2n,j) = 2^(2n)` having more than one
+positive term), so `⌊·/2^(2n²)⌋ mod 2^(2n)` extracts the `j = n` digit
+`C(2n,n)`. Factor a base-`b` digit-extraction lemma
+`digit_extract (d : ℕ → ℕ) (b k : ℕ) (hfit : ∀ j, d j < b) :
+(Σ_j d j · b^j) / b^k % b = d k`.
+
+- [ ] **Step 4: build, axiom-check, commit**
+
+```bash
+jj describe -m "feat(era): prove the central binomial coefficient closed form
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+jj new
+```
+
+### Task 2.3: Hamming weight `hwClosed`
+
+**Files:**
+
+- Modify: `GebLean/Utilities/ArithClosedForms.lean`
+
+- [ ] **Step 1: define (slow `ν₂` ∘ central binomial)**
+
+```lean
+/-- Binary Hamming weight (digit sum) `σ`, as `ν₂(C(2n,n))` (Kummer),
+using the slow log-free `ν₂`. -/
+def hwClosed (n : ℕ) : ℕ := nu2Closed (centralBinomClosed n)
+```
+
+- [ ] **Step 2: numeric check** `hwClosed n = (Nat.digits 2 n).sum` for
+`n` in `1 .. 10` (the slow `ν₂` on `C(2n,n)` is feasible only for small
+`n` — it forms a `~2·C(2n,n)`-bit number and stalls past `n ≈ 12`, so
+keep the probe range small; confirm `n = 0`
+gives digit sum `0`). Remove before commit.
+
+- [ ] **Step 3: prove `hwClosed n = (Nat.digits 2 n).sum` for `n ≥ 1`,
+plus `n = 0`**
+
+```lean
+theorem hwClosed_eq (n : ℕ) (hn : 1 ≤ n) :
+    hwClosed n = (Nat.digits 2 n).sum := by
+  sorry
+```
+
+Strategy: chain `nu2Closed_eq` (needs `centralBinomClosed n ≥ 1`, from
+`centralBinomClosed_eq` and `Nat.centralBinom_pos`) and
+`centralBinomClosed_eq` to reduce to
+`padicValNat 2 (Nat.centralBinom n) = (Nat.digits 2 n).sum`. Factor the
+Kummer step as a named, moderate-effort sub-lemma
+`padicValNat_centralBinom_two (n : ℕ) :
+padicValNat 2 (Nat.centralBinom n) = (Nat.digits 2 n).sum`, assembled
+from `sub_one_mul_padicValNat_choose_eq_sub_sum_digits` at `p = 2`,
+`k = n`, `m = 2n` (giving `(2−1)·v₂ = S₂(n) + S₂(n) − S₂(2n)`), with
+`Nat.centralBinom_eq_two_mul_choose` and the `digits 2 (2n)` shift
+`S₂(2n) = S₂(n)`. Handle `n = 0` directly (`hwClosed 0` and digit sum
+both `0`).
+
+- [ ] **Step 4: build, axiom-check, commit**
+
+```bash
+jj describe -m "feat(era): prove the Hamming weight closed form via Kummer
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+jj new
+```
+
+### Task 2.4: the digit-block indicator `δ`
+
+**Files:**
+
+- Modify: `GebLean/Utilities/ArithClosedForms.lean`
+
+- [ ] **Step 1: define and state the indicator lemma**
+
+```lean
+/-- The digit-block indicator (arXiv:2407.12928, Lemma 3.1):
+`δ a w = (2^w - 1)(2^w - a + 1)`. -/
+def deltaBlock (a w : ℕ) : ℕ := (2 ^ w - 1) * (2 ^ w - a + 1)
+
+/-- `HW(δ a w) = 2w` when `a = 0`, else `w`, for `0 ≤ a < 2^w`. -/
+theorem hwClosed_deltaBlock {a w : ℕ} (ha : a < 2 ^ w) :
+    hwClosed (deltaBlock a w) = if a = 0 then 2 * w else w := by
+  sorry
+```
+
+- [ ] **Step 2: numeric check** over `w ∈ 1 .. 6`, `a ∈ 0 .. 2^w − 1`
+(confirm `deltaBlock a w ≥ 1` so `hwClosed` is in its proven range, and
+`< 2^(2w)`). Remove before commit.
+
+- [ ] **Step 3: prove**
+
+Strategy: via `hwClosed_eq` reduce to `(Nat.digits 2 (δ a w)).sum`. For
+`a = 0`: `δ = (2^w−1)(2^w+1) = 2^(2w)−1`, digit sum `2w`. For
+`1 ≤ a < 2^w`: a direct base-`2`/base-`2^w` block computation showing
+the `2w` bits split into two complementary runs summing to `w`. Fiddly;
+budget a `lean4:sorry-filler-deep` pass.
+
+- [ ] **Step 4: build, axiom-check, commit**
+
+```bash
+jj describe -m "feat(era): prove the digit-block indicator Hamming weight
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+jj new
+```
+
+---
+
+## Phase 3 — `Era`-term realisations of the ingredients
+
+For each `ℕ` closed form, build the `Era` term mirroring its arithmetic
+composition and prove `eval` equals the `ℕ` closed form. Realisations
+compose `eadd`/`etsub`/`emul`/`ediv`/`emod`/`epow`/`epow2`. Test only
+through the `eval` lemma (never `#eval` on `Tm.eval`). All terms use the
+slow `ν₂`, so there is no back-dependency on Phase 5: every Phase-3
+`eval` lemma is committable here.
+
+### Task 3.1: the largest-power-of-two-divisor term (gcd-light)
+
+**Files:**
+
+- Modify: `GebLean/EraCompleteness.lean`
+
+The slow `ν₂` needs only `Nat.gcd n (2^n)`, which equals `2^(v₂ n)` — a
+power of two, not a general gcd. Realise this directly rather than
+transcribing the full Mazzanti gcd term (record the choice in a comment;
+this is the from-scratch ingredient, weighted toward the simpler
+option).
+
+- [ ] **Step 1: choose and define**
+
+```lean
+/-- `2^(v₂ n)`, the largest power of two dividing `n` (= `gcd n (2^n)`),
+as an `Era` term in variable `0`. -/
+def eraPow2Val : ETm 1 := sorry  -- e.g. n / oddPart, or a closed form
+
+theorem eraPow2Val_eval (n : ℕ) :
+    Tm.eval eraInterp eraPow2Val ![n] = Nat.gcd n (2 ^ n) := by
+  sorry
+```
+
+Strategy: option A — realise the largest power of two dividing `n` as
+`n / odd(n)` where `odd(n)` is built search-free; option B — transcribe
+Mazzanti's base-2 gcd term specialised to `gcd n (2^n)`. Search Mathlib
+for an existing `gcd`-as-arithmetic-term first (`lean_leansearch`); none
+is expected. The `ℕ` identity `Nat.gcd n (2^n) = 2^(padicValNat 2 n)` is
+the correctness target — search for it
+(`Nat.gcd_pow`, `Nat.Coprime`, `pow_padicValNat_dvd`).
+
+- [ ] **Step 2:** build (with `sorry`), prove, numeric `eval` check via
+the lemma, axiom-check, commit.
+
+```bash
+jj describe -m "feat(era): realise the largest power-of-two divisor as an Era term
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+jj new
+```
+
+### Task 3.2: `eraNu2`, `eraCentralBinom`, `eraSigma`
+
+**Files:**
+
+- Modify: `GebLean/EraCompleteness.lean`
+
+Identical pattern each: a `def` mirroring the `ℕ` closed form, then an
+`eval` lemma reducing to the Phase-2 identity. One commit each. No
+`⌊log₂⌋` / `eraIlog2` is built (De-cycling).
+
+- [ ] **Step 1: `eraNu2 : ETm 1`** composing `eraPow2Val`, `epow`,
+`emod`, `ediv`, `etsub`, `epow2`; prove `eval eraNu2 ![n] = nu2Closed n`
+by reduction to `nu2Closed`'s definition (using `eraPow2Val_eval`).
+
+- [ ] **Step 2: `eraCentralBinom : ETm 1`** mirroring
+`centralBinomClosed`; `eval = centralBinomClosed n`.
+
+- [ ] **Step 3: `eraSigma : ETm 1`** as `eraNu2 ∘ eraCentralBinom`
+(substitution via `Tm.subst`/`sub0`); prove
+`eval eraSigma ![n] = hwClosed n` by `Tm.eval_subst` + the two `eval`
+lemmas. (The bridge to the digit sum is `hwClosed_eq`, used by
+consumers; `eraSigma`'s own `eval` lemma targets `hwClosed n`.)
+
+- [ ] **Step 4: per sub-task** build, axiom-check, commit (three
+commits, e.g. `feat(era): realise the 2-adic valuation as an Era term`).
+
+### Task 3.3: `eraDelta` (the indicator term)
+
+**Files:**
+
+- Modify: `GebLean/EraCompleteness.lean`
+
+- [ ] `eraDelta : ETm 2` (variable `0` = `a`, `1` = `w`) mirroring
+`deltaBlock`; `eval eraDelta ![a,w] = deltaBlock a w`. Build, prove
+(direct reduction), axiom-check, commit.
+
+---
+
+## Phase 3.5 — The monotone `ETm` majorant (gates Phases 4–5)
+
+The engine needs an arithmetic-term majorant `A(y, x̄)` with `f(i) < A`
+for `i < y` (and a product majorant): it fixes the packing width `w`
+(Phase 5) and the witness bounds `DiophEnc.bound` (Phase 4). This is the
+first dependency-critical sub-task after the ingredients (decision note
+§ 7, § 8 item 1) — it precedes Phase 4.
+
+**Files:**
+
+- Create/extend: `GebLean/Utilities/EraDiophantine.lean`
+
+- [ ] **Step 1: reuse assessment.** `GebLean/Utilities/ERAMajorants.lean`
+provides the Tourlakis `A_one`/`A_one_iter`/`A_two_iter`/`towerER`
+majorant family, but typed for `ERMor1`, not `ETm` — so it does not
+directly give an `ETm`-summand majorant. Record (one line) that
+`ERAMajorants` is `ERMor1`-typed and that the `ETm` majorant is built
+fresh; note whether the `PolyBound`/`towerER` magnitude bounds can be
+reused for the width estimate.
+
+- [ ] **Step 2: choose construction and define.** Two routes (record the
+choice, as in Task 3.1): (A) structural recursion on `ETm` building a
+monotone majorant term; (B) the recurrence-paper Claim-2 recipe (replace
+every `tsub` by `add`, substitute the range bound for the loop index).
+
+```lean
+/-- A monotone arithmetic-term majorant: `eval (eraMajorant t) ctx`
+strictly bounds `eval t ctx'` for all `ctx'` agreeing with `ctx` off the
+loop index, over the loop range. -/
+def eraMajorant {n : ℕ} (t : ETm n) : ETm n := sorry
+
+theorem eraMajorant_spec {n : ℕ} (t : ETm n) (ctx : Fin n → ℕ) :
+    Tm.eval eraInterp t ctx < Tm.eval eraInterp (eraMajorant t) ctx := by
+  sorry
+```
+
+- [ ] **Step 3:** build, prove, axiom-check, commit.
+
+```bash
+jj describe -m "feat(era): build the monotone ETm majorant for the engine
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+jj new
+```
+
+---
+
+## Phase 4 — Lemma 2: `ETm`-to-Diophantine reduction (RE-CHECKPOINT)
+
+> **Re-checkpoint (decision note § 8).** Before executing Phase 4, with
+> Phases 1–3.5 landed and the exact `ℕ`-shapes known, write a detailed
+> Phase-4/5 sub-plan (`superpowers:writing-plans`) and adversarially
+> review it. Phase 4 is the dominant cost and principal schedule risk.
+> The decomposition below is the architecture that sub-plan refines; the
+> `DiophEnc` field types must be finalised there (the skeleton below is
+> illustrative — a field type cannot literally be `sorry`).
+
+**Files:**
+
+- Modify: `GebLean/Utilities/EraDiophantine.lean`
+
+Goal: a recursion on `ETm` producing, for a term `t : ETm n`, a
+Diophantine system with the four invariants (arXiv:2606.09336, Lemma 2):
+sum-of-squares; simple (a simple exponential polynomial); unique
+witness; explicit arithmetic-term witness bounds.
+
+- [ ] **Sub-lemma 4.1: the carrier structure (all four invariants as
+fields).** Finalise the field types in the sub-plan; the four invariants
+are:
+
+```lean
+/-- A bounded, unique-witness, sum-of-squares Diophantine encoding of a
+term's graph `t.eval ρ = y`. Variables: `n` inputs, the output `y`, and
+`witArity` witnesses. -/
+structure DiophEnc (n : ℕ) where
+  witArity : ℕ
+  /-- the sum-of-squares predicate term (vars: inputs, `y`, witnesses) -/
+  sos : ETm (n + 1 + witArity)
+  /-- per-witness bound terms (vars: inputs and `y`) -/
+  bound : Fin witArity → ETm (n + 1)
+  /-- correctness: `sos = 0` exactly characterises the graph -/
+  sos_zero_iff : Prop        -- finalise: ∀ ρ y w, eval sos … = 0 ↔ …
+  /-- uniqueness of the witness tuple when the graph holds -/
+  uniq : Prop                -- finalise: ∀ ρ y, graph → ∃! w, …
+  /-- the witnesses respect their bounds -/
+  bound_spec : Prop          -- finalise: solution witnesses < bound
+```
+
+- [ ] **Sub-lemma 4.2: the Identity-(4) exponent reduction.** The
+device reducing variable-exponent cases (`mul`, `div`, `tsub`, `pow`) to
+base `2`:
+
+```lean
+/-- `a^b = 2^((ab+a+1)·b) mod (2^(ab+a+1) − a)` (arXiv:2407.12928,
+Identity (4)), valid including `0^0 = 1`. -/
+theorem pow_eq_two_pow_mod (a b : ℕ) :
+    a ^ b = 2 ^ ((a * b + a + 1) * b) % (2 ^ (a * b + a + 1) - a) := by
+  sorry
+```
+
+Numeric-check first over `a ∈ 0..29`, `b ∈ 0..14` (validated in the
+gate probe), then prove.
+
+- [ ] **Sub-lemmas 4.3–4.6: the induction cases** (one per `ETm`
+constructor: `var`, `zero`, `succ`, and `app b` for each `b : EraB`).
+Build the `DiophEnc` from sub-encodings following the paper's Cases 1–3
+(projection; `2^B`; `B₁ + B₂`; `B₁ mod B₂`), extended to the full Era
+basis (`tsub`, `mul`, `div`, `pow` via Sub-lemma 4.2). Each case
+preserves the four invariants; the witness bounds compose via
+`eraMajorant` (Phase 3.5).
+
+- [ ] **Sub-lemma 4.7: the top-level reduction** assembling
+`diophOf : ETm n → DiophEnc n` and its correctness theorem.
+
+Strategy notes for the sub-plan: this mirrors `Tm.eval_subst`'s
+structural induction but tracks the invariant bundle; expect heavy use
+of `lean4:sorry-filler-deep` and factoring per constructor. Budget this
+as the largest phase. Commit per sub-lemma.
+
+---
+
+## Phase 5 — The counting engine and the recurrence read-off
+
+**Files:**
+
+- Create: `GebLean/Utilities/EraHypercube.lean`
+
+- [ ] **Sub-lemma 5.1: `HW`-additivity over non-overlapping blocks.**
+`(Nat.digits 2 (Σ blocks)).sum = Σ (Nat.digits 2 block).sum` when blocks
+occupy disjoint base-`2^(2w)` positions (recurrence paper Lemma 3.3); a
+base-`2^(2w)` place-value / no-carry argument.
+
+- [ ] **Sub-lemma 5.2: the mixed-radix enumeration bijection.** The map
+`v(ā) = a₁ + a₂·t + ⋯ + a_k·t^(k−1)` is a bijection
+`{0,…,t−1}^k ≅ {0,…,t^k−1}` (a `Finset`/`Fin`-product digit expansion);
+isolate it, as the cube-sum factorisation depends on it.
+
+- [ ] **Sub-lemma 5.3: the packed number `M` and the cube-sum
+factorisation** (method paper Lemma 3.2):
+`Σ_{ā∈cube} Πᵢ aᵢ^{uᵢ} vᵢ^{aᵢ} = Πᵢ G_{uᵢ}(vᵢ, t−1)`, reusing
+`natGeomSum_eq` (`G₀`), `natLinGeomSum_mul` (`G₁`), `natSqGeomSum_mul`
+(`G₂`).
+
+- [ ] **Sub-lemma 5.4: the count read-off**
+`#{ā : P ā = 0} = (Nat.digits 2 (M …)).sum / w − t^k` (method paper
+Theorem 3.4 / Corollary 3.6), composing 5.1–5.3 and
+`hwClosed_deltaBlock`. The `HW` here is the slow-`ν₂` term — state the
+well-foundedness explicitly (no `⌊log₂⌋` dependency; no cycle).
+
+- [ ] **Sub-lemma 5.5: positional coding read-off**
+`a(n) = ⌊H/Aⁿ⌋` and the recurrence metatheorem specialisation
+(recurrence paper Lemma 3, Theorem 2) for `k = 1`, consuming the Phase-4
+`DiophEnc` and the Phase-3.5 majorant `A`.
+
+Strategy: 5.1 is a place-value argument; 5.2 a digit-expansion bijection;
+5.3 reduces to the `G_r` closed forms (Phase 1); 5.4 is arithmetic from
+5.1–5.3. Re-checkpoint review applies (Phase 4 header). Commit per
+sub-lemma.
+
+---
+
+## Phase 6 — `eraBSum` and `eraBProd`
+
+**Files:**
+
+- Modify: `GebLean/EraCompleteness.lean`
+
+### Task 6.1: `eraBSum`
+
+- [ ] **Step 1: define**
+
+```lean
+/-- Bounded summation as an `Era` term: variable `0` is the bound;
+`eval (eraBSum t)` sums `t` over the loop index. Built from the count
+read-off (Phase 5) applied to the Diophantine encoding (Phase 4) of the
+summand `t`, via `Σ_{i<y} f i = #{(i,w) : i<y, w<f i}`, with the width
+fixed by `eraMajorant` (Phase 3.5). -/
+def eraBSum {k : ℕ} (t : ETm (k + 1)) : ETm (k + 1) := sorry
+```
+
+- [ ] **Step 2: the `eval` lemma (the deliverable)**
+
+```lean
+theorem eraBSum_eval {k : ℕ} (t : ETm (k + 1)) (ctx : Fin (k + 1) → ℕ) :
+    Tm.eval eraInterp (eraBSum t) ctx =
+      natBSum (ctx 0) (fun i =>
+        Tm.eval eraInterp t (Fin.cons i (Fin.tail ctx))) := by
+  sorry
+```
+
+Strategy: `natBSum (ctx 0) f = ∑ i ∈ Finset.range (ctx 0), f i`
+(`natBSum_eq_sum`, M3a) `= #{(i,w) : i<ctx 0 ∧ w<f i}` (a
+`Finset.card`/double-count identity `sum_eq_card_lt`) `=` the count
+read-off (Sub-lemma 5.4) applied to the `DiophEnc` of `t` (Phase 4),
+with the majorant fixing `w` (Phase 3.5). Reduce `eval (eraBSum t)` to
+that count via the Phase-5 `eval` lemmas.
+
+- [ ] **Step 3:** build, axiom-check, commit.
+
+### Task 6.2: `eraBProd`
+
+- [ ] **Step 1: define** `eraBProd` via the recurrence engine
+(Sub-lemma 5.5) with step `·` (`p(m+1) = p(m) · f(m)`), product majorant
+(Phase 3.5).
+
+- [ ] **Step 2: the `eval` lemma**
+
+```lean
+theorem eraBProd_eval {k : ℕ} (t : ETm (k + 1)) (ctx : Fin (k + 1) → ℕ) :
+    Tm.eval eraInterp (eraBProd t) ctx =
+      natBProd (ctx 0) (fun i =>
+        Tm.eval eraInterp t (Fin.cons i (Fin.tail ctx))) := by
+  sorry
+```
+
+- [ ] **Step 3:** build, axiom-check, commit.
+
+---
+
+## Phase 7 — Capstones: `era_complete` and the K-sim-2 corollary
+
+**Files:**
+
+- Modify: `GebLean/EraCompleteness.lean`
+
+### Task 7.1: `era_complete`
+
+- [ ] **Step 1: state**
+
+```lean
+/-- Completeness: every `ERMor1` (elementary) function is the denotation
+of some `Era` term. -/
+theorem era_complete {n : ℕ} (f : ERMor1 n) :
+    ∃ t : ETm n, ∀ ctx : Fin n → ℕ,
+      Tm.eval eraInterp t ctx = f.interp ctx := by
+  sorry
+```
+
+- [ ] **Step 2: prove by structural induction on `f`**
+
+```text
+zero      → ⟨Tm.zero, …⟩                       (ERMor1.interp_zero, eraInterp)
+succ      → ⟨Tm.succ (Tm.var 0), …⟩            (interp_succ)
+proj i    → ⟨Tm.var i, …⟩                      (interp_proj)
+sub       → ⟨Tm.var 0 ∸ᵉ Tm.var 1, …⟩          (interp_sub, etsub_eval)
+comp f g  → substitute g-witnesses into f-witness   (Tm.eval_subst + IHs)
+bsum f    → ⟨eraBSum (IH-witness of f), …⟩      (eraBSum_eval + IH)
+bprod f   → ⟨eraBProd (IH-witness of f), …⟩     (eraBProd_eval + IH)
+```
+
+Strategy: `induction f` with the seven cases; the five routine cases are
+immediate from the `interp_*` and `*_eval` lemmas; `comp` uses
+`Tm.eval_subst` with the `Fin.cons`/`Fin.tail` context juggling matching
+`interp_comp`; `bsum`/`bprod` apply the Phase-6 `eval` lemmas to the
+inductive witness. The `Fin.cons i (Fin.tail ctx)` shape is identical in
+`ERMor1.interp_bsum` and `eraBSum_eval`, so the IH applies directly.
+
+- [ ] **Step 3:** build, axiom-check, commit.
+
+### Task 7.2: the K-sim-2 corollary
+
+The function-class equality comes from the existing **term-level
+interp-faithfulness** lemmas, not the categorical `erKSimEquiv`
+(`erKSimEquiv` has no semantic readout). The forward bridge is
+`erToK_interp` (`GebLean/LawvereERKSim/ErToK.lean`,
+`(erToK e).interp v = e.interp v`); the reverse is `kToER_interp`
+(`GebLean/LawvereKSimER.lean`, carrying an `f.level ≤ 2` premise that is
+load-bearing for the K-sim-2 statement).
+
+- [ ] **Step 1: pin the extraction.** Confirm `erToK_interp` and
+`kToER_interp` (with its `level ≤ 2` premise) give the
+`ERMor1` ↔ `K-sim-2` function-class equality directly; assess whether
+`erKSimEquiv` is needed at all (likely not). State the exact corollary
+signature in terms of the K-sim-2 morphism `interp`.
+
+- [ ] **Step 2: state and prove the corollary** by composing
+`era_complete` + `era_sound_er` (giving `Era ≃ E³` as denoted functions)
+with the `ERMor1 ↔ K-sim-2` interp faithfulness. Keep it a thin
+composition; implement no `K-sim` scheme over the basis (spec § 12).
+
+- [ ] **Step 3:** build, axiom-check, commit. This commit closes M3b.
+
+---
+
+## Self-review checklist (run before execution)
+
+- [ ] **Spec coverage.** Spec § 5 (bounded-sum engine) → Phases 1–6;
+  § 6 (bounded product via the engine, no separate `2^x`-elimination) →
+  Task 6.2; § 4/§ 3 (the induction, the two `eval` lemmas) → Phases 6–7;
+  § 7 (soundness) → already `era_sound_er` (not redone); § 8 (K-sim-2
+  corollary) → Task 7.2. Acceptance criteria § 11 (no
+  `sorry`/`admit`/underscore in commits, 100-char, axiom-clean,
+  `Era.lean` unmodified) → the per-task pre-commit + axiom-check gates
+  and the file structure.
+
+- [ ] **`Era.lean` untouched** (spec § 12): all new content lives in
+  `Utilities/*` and `EraCompleteness.lean`.
+
+- [ ] **Type consistency.** `eraBSum`/`eraBProd : ETm (k+1) → ETm (k+1)`;
+  the `eval`-lemma RHS `natBSum (ctx 0) (fun i => Tm.eval … (Fin.cons i
+  (Fin.tail ctx)))` matches `ERMor1.interp_bsum` verbatim. Ingredient
+  names consistent across phases (`nu2Closed`/`eraNu2`,
+  `centralBinomClosed`/`eraCentralBinom`, `hwClosed`/`eraSigma`,
+  `deltaBlock`/`eraDelta`, `natLinGeomSum_mul`/`natSqGeomSum_mul`).
+
+- [ ] **Mathlib name sweep (Phase-0 of execution).** Confirmed present
+  in the pin: `Nat.pow_log_le_self` (arg `x ≠ 0`),
+  `Nat.lt_pow_succ_log_self`, `Nat.centralBinom`, `Nat.centralBinom_pos`,
+  `Nat.centralBinom_eq_two_mul_choose`, `padicValNat` (needs
+  `Fact (Nat.Prime 2)` = `fact_prime_two`), `pow_padicValNat_dvd`,
+  `sub_one_mul_padicValNat_choose_eq_sub_sum_digits`,
+  `Nat.choose_le_two_pow`, `Nat.sum_range_choose`, `Nat.digits`,
+  `Nat.mul_div_cancel`, `Nat.log`. Note: `geom_sum_eq` lives at the
+  Field path (`Mathlib/Algebra/Field/GeomSum.lean`) and is **not** used
+  for the `ℕ`-level inductions (G₁/G₂ are proved by `ℕ` induction).

--- a/geb-lean/docs/superpowers/plans/2026-06-14-era-completeness-m3b-plan.md
+++ b/geb-lean/docs/superpowers/plans/2026-06-14-era-completeness-m3b-plan.md
@@ -592,41 +592,23 @@ slow `ν₂`, so there is no back-dependency on Phase 5: every Phase-3
 
 - Modify: `GebLean/EraCompleteness.lean`
 
-The slow `ν₂` needs only `Nat.gcd n (2^n)`, which equals `2^(v₂ n)` — a
-power of two, not a general gcd. Realise this directly rather than
-transcribing the full Mazzanti gcd term (record the choice in a comment;
-this is the from-scratch ingredient, weighted toward the simpler
-option).
+SUPERSEDED — see the sub-plan
+`docs/superpowers/plans/2026-06-15-era-gcd-term-subplan.md`.
 
-- [ ] **Step 1: choose and define**
+Investigation (committed) disproved this task's original premise.
+Realising `2^(v₂ n) = gcd(n, 2^n)` as an `Era` *term* needs a
+basis-composition `gcd`: "option A" (`n / oddPart`, search-free) is
+PROVABLY unrealisable (exhaustive depth-≤3 basis search found no closed
+form for `2^(v₂ n)` or `oddPart`), and no power-of-2 shortcut exists. The
+only route is the general Prunescu–Shunia base-5 `gcd`-as-arithmetic-term
+(arXiv:2411.06430, Thm 4.1), a multi-hundred-line `ℕ` development. Note
+the *value* `gcd(n,2^n) = 2^(padicValNat 2 n)` is already proved
+(`gcd_pow_eq`, private in `ArithClosedForms.lean`); only the TERM needs
+the closed form.
 
-```lean
-/-- `2^(v₂ n)`, the largest power of two dividing `n` (= `gcd n (2^n)`),
-as an `Era` term in variable `0`. -/
-def eraPow2Val : ETm 1 := sorry  -- e.g. n / oddPart, or a closed form
-
-theorem eraPow2Val_eval (n : ℕ) :
-    Tm.eval eraInterp eraPow2Val ![n] = Nat.gcd n (2 ^ n) := by
-  sorry
-```
-
-Strategy: option A — realise the largest power of two dividing `n` as
-`n / odd(n)` where `odd(n)` is built search-free; option B — transcribe
-Mazzanti's base-2 gcd term specialised to `gcd n (2^n)`. Search Mathlib
-for an existing `gcd`-as-arithmetic-term first (`lean_leansearch`); none
-is expected. The `ℕ` identity `Nat.gcd n (2^n) = 2^(padicValNat 2 n)` is
-the correctness target — search for it
-(`Nat.gcd_pow`, `Nat.Coprime`, `pow_padicValNat_dvd`).
-
-- [ ] **Step 2:** build (with `sorry`), prove, numeric `eval` check via
-the lemma, axiom-check, commit.
-
-```bash
-jj describe -m "feat(era): realise the largest power-of-two divisor as an Era term
-
-Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
-jj new
-```
+`eraPow2Val` (and `eraGcd`) are built in the sub-plan (phases G1–G4),
+which delivers `eraPow2Val_eval : Tm.eval eraInterp eraPow2Val ![n] =
+Nat.gcd n (2^n)`. After the sub-plan lands, resume at Task 3.2.
 
 ### Task 3.2: `eraNu2`, `eraCentralBinom`, `eraSigma`
 

--- a/geb-lean/docs/superpowers/plans/2026-06-15-era-gcd-g2-floor-extraction-plan.md
+++ b/geb-lean/docs/superpowers/plans/2026-06-15-era-gcd-g2-floor-extraction-plan.md
@@ -287,6 +287,46 @@ into 2–4 private `ℤ`-valued helper lemmas discovered during execution
 `R_nonneg` and `R_lt_den`). Re-checkpoint with the controller if the
 helper set grows beyond ~4 or the `ℤ` identity resists `ring`.
 
+### EXECUTION UPDATE (2026-06-15): verified two-step decomposition
+
+The direct 2D approach above stalls on the bound `0 ≤ R < den`: `R` is
+mixed-sign and the triangle-inequality bound `Σ |coef|·Bᵖ` strictly
+EXCEEDS `den = B^{a+b} − B^a − B^b + 1` (it equals `B^{a+b} − 1`), so
+`R < den` holds only by cancellation, not termwise. The viable route is
+the two-step (single-factor) reduction, NUMERICALLY VERIFIED end-to-end
+for `1 ≤ a,b ≤ 4` (incl. `a=1`, `b=1`, `a≠b`). Write `B := 5^(a·b)`,
+`E := a·b+a+b`, `dena := Bᵃ−1`, `denb := Bᵇ−1`, `r := E % a`,
+`q := E / a`, `P := gcdPComb a b = Bʳ·Σ_{i<q} B^{a·i}`, `S := gcdDigitSum a b`.
+
+Verified facts (all `true` on the grid): `num = dena·P + Bʳ`;
+`Bʳ < dena`; `denb·S ≤ P`; `P < denb·(S+1)`; `P / denb = S`;
+`num / den = S`.
+
+Decomposition (replaces the single Task 4 with 4a/4b/4c):
+
+- 4a (DONE, commit `84fd0f17…`): `gcdPComb` def, `gcd_num_split`
+  (`num = dena·P + Bʳ`, via `natGeomSum_mul` and `r + a·q = E`),
+  `gcd_rem_lt_dena` (`Bʳ < dena`). Clean geometric identities.
+- 4b (CRUX, remaining): `gcd_denb_mul_digitSum_le_pComb`
+  (`denb·S ≤ gcdPComb a b`) and `gcd_pComb_lt_denb_mul_digitSum_succ`
+  (`gcdPComb a b < denb·(S+1)`). Equivalent to `P / denb = S`. The comb
+  `P` (digits 0/1, spaced `a`) divided by `Bᵇ−1`: `P = denb·G + W` with
+  `W = Σ_{i<q} B^{(r+a·i) mod b}` (since `Bᵇ ≡ 1 mod denb`), so
+  `P/denb = G + ⌊W/denb⌋`; the residue `Rb = P − denb·S` is genuinely
+  NONNEGATIVE with base-`B` digits `< B` at positions `< b`. Connecting
+  `P/denb`'s digits to `s(n−k) = solCount a b (n−k)` uses the boundary-
+  complete (guarded) recurrence `s(m) = [a≤m]s(m−a) + [b≤m]s(m−b) −
+  [a+b≤m]s(m−a−b)` for `1 ≤ m` (extends `solCount_recurrence`, which
+  needs `a+b ≤ m`), equivalently the difference-invariance
+  `s(m) − [b≤m]s(m−b) = [a≤m]s(m−a) − [a+b≤m]s(m−a−b)`, telescoped over
+  `a`-steps. This is the Prunescu–Shunia combinatorial core (~150–200
+  lines); the dominant remaining cost.
+- 4c (remaining, mechanical): the two Task-4 target theorems
+  `gcd_den_mul_digitSum_le`, `gcd_num_lt_den_mul_digitSum_succ` from
+  4a+4b. `num = dena·P + Bʳ < dena·(P+1) ≤ dena·denb·(S+1)` (using
+  `Bʳ < dena` and `P+1 ≤ denb·(S+1)`); and
+  `den·S = dena·denb·S ≤ dena·P ≤ num` (using `denb·S ≤ P`).
+
 - [ ] **Step 3: numeric guard.**
 
 Temporary `#eval` (then delete) over `1 ≤ a,b ≤ 4` re-confirming

--- a/geb-lean/docs/superpowers/plans/2026-06-15-era-gcd-g2-floor-extraction-plan.md
+++ b/geb-lean/docs/superpowers/plans/2026-06-15-era-gcd-g2-floor-extraction-plan.md
@@ -1,0 +1,398 @@
+# Era gcd-term G2 micro-plan: floor digit extraction
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use
+> superpowers:subagent-driven-development (recommended) or
+> superpowers:executing-plans to implement this plan task-by-task.
+> Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** prove the Prunescu–Shunia base-5 floor identity
+`⌊Bᴱ / ((Bᵃ−1)(Bᵇ−1))⌋ % B = solCount a b (a·b)` (with `B = 5^(a·b)`),
+the remaining hard core of the gcd sub-plan
+(`2026-06-15-era-gcd-term-subplan.md`, Phase G2).
+
+**Architecture:** read the integer division `F := num / den` as the
+truncated base-`B` positional encoding of the generating function
+`1/((1−tᵃ)(1−tᵇ)) = Σ s(m) tᵐ`. The single content is the exact
+identity `F = S`, where `S = Σ_{k=0}^{n} s(n−k)·Bᵏ` and
+`s = solCount a b`. Prove `F = S` by the two-sided Euclidean bound
+`den·S ≤ num < den·(S+1)`; then `F % B = S % B = s(n) = gcd a b + 1`
+follows from the window bound `s(n) < B` and G1. This reorganises the
+parent sub-plan's G2.1 (`ModEq`) and G2.2 (`%`) around the stronger,
+cleaner `num/den = S`.
+
+**Tech Stack:** Lean 4, Mathlib (pin `v4.29.0-rc6`),
+`lake build`/`lake test`/`lake lint`, `scripts/check-axioms.sh`.
+Constructive-only; axiom-clean (`propext`/`Quot.sound`/`Classical.choice`).
+
+---
+
+## Validated mathematics (numeric evidence)
+
+With `n := a·b`, `B := 5ⁿ`, `E := n+a+b`, `num := Bᴱ`,
+`den := (Bᵃ−1)(Bᵇ−1)`, `s(m) := solCount a b m`,
+`S := Σ_{k=0}^{n} s(n−k)·Bᵏ`:
+
+- `num = den·S + R` with `0 ≤ R < den` (so `num/den = S`), and
+  `S % B = s(n) = gcd a b + 1`. Verified by `#eval` for all
+  `1 ≤ a,b ≤ 4` (including asymmetric `a≠b` and the `a=1`/`b=1`
+  boundary): `F == S`, `num == den·S + R ∧ R < den`, and
+  `F % B == gcd a b + 1` all `true`.
+
+Coefficient structure of `den·S` in base `B` (write `m = E−p` for the
+coefficient of `Bᵖ`): it is `s(m) − s(m−a) − s(m−b) + s(m−a−b)` with
+each summand gated to `0` when its `solCount` argument leaves `[0,n]`.
+For `1 ≤ m ≤ n` the defining recurrence
+`s(m) − s(m−a) − s(m−b) + s(m−a−b) = 0` makes every coefficient vanish;
+`m = 0` (i.e. `p = E`) contributes the single `Bᴱ`. Hence the remainder
+`R = num − den·S` is supported only on the high-`m` band
+`m ∈ [n+1, E]` (low powers `Bᵖ`, `p ∈ [0, a+b−1]`):
+
+```text
+R = Σ_{m=n+1}^{n+a+b} (gated removed terms)(m) · B^{E−m}
+  = Σ_{m=n+1}^{n+a+b}
+      ( [m ≤ n+b]·s(m−b) + [m ≤ n+a]·s(m−a) − s(m−a−b) ) · B^{E−m}
+```
+
+`R` is a `ℤ` quantity: its base-`B` coefficients are MIXED-SIGN — the
+units coefficient (`m = n+a+b`, `B⁰`) is always `−s(n) < 0`, and the
+higher-power coefficients carry the positive `s(m−a)`/`s(m−b)` terms.
+So `0 ≤ R < den` is a GLOBAL fact (the negative units are dominated by
+the `B^{≥1}`-scaled positive band terms), NOT a per-digit/no-carry one.
+Numerically (`a,b ≤ 6`): `R = num − den·S` as a `ℤ` value matches this
+formula exactly, and `0 ≤ R < B^{a+b} ≤ den`. The bound must therefore
+be argued over `ℤ` (Task 4), not as a nonnegative `ℕ` digit sum.
+
+## The solution-count recurrence (prerequisite, Task 1)
+
+The inclusion–exclusion recurrence is the engine of the telescoping:
+
+```text
+solCount a b m
+  = solCount a b (m−a) + solCount a b (m−b) − solCount a b (m−a−b)   (m ≥ 1)
+solCount a b 0 = 1
+```
+
+read off from `(1 − tᵃ)(1 − tᵇ)·Σ s(m) tᵐ = 1`. It must be proved as a
+finite `ℕ` identity over `solCount` (Finset.card), not via series.
+
+## File structure
+
+- `GebLean/Utilities/ArithClosedForms.lean` (extend, after
+  `solCount_mul_eq_gcd_succ` at line ~449, before `end GebLean`): the
+  recurrence, `gcdDigitSum`, the two Euclidean bounds, `num/den = S`,
+  the mod extraction, and the public `solCount_eq_floor_mod`. Reuses
+  this file's `solCount`, `solCount_le_succ`, `solCount_mul_eq_gcd_succ`,
+  `mem_solCount_box`, and `natGeomSum_mul` (namespace `GebLean`, file
+  `EraBoundedSum.lean`).
+
+No change to `GebLean/EraCompleteness.lean` (that is sub-plan G3/G4).
+`Era.lean` untouched.
+
+---
+
+### Task 1: the solution-count recurrence
+
+**Files:**
+
+- Modify: `GebLean/Utilities/ArithClosedForms.lean` (after line ~449)
+
+- [ ] **Step 1: state and prove `solCount_recurrence`.**
+
+```lean
+/-- Inclusion–exclusion recurrence for the linear-Diophantine count:
+for `1 ≤ a, 1 ≤ b` and `a + b ≤ m`,
+`solCount a b m = solCount a b (m−a) + solCount a b (m−b)
+  − solCount a b (m−a−b)`. The coefficientwise content of
+`(1 − tᵃ)(1 − tᵇ)·Σ solCount a b m · tᵐ = 1`. -/
+private theorem solCount_recurrence (a b m : ℕ) (ha : 1 ≤ a) (hb : 1 ≤ b)
+    (hm : a + b ≤ m) :
+    solCount a b m + solCount a b (m - a - b)
+      = solCount a b (m - a) + solCount a b (m - b)
+```
+
+Strategy: phrase additively (`x + z = y + w`) to stay in `ℕ`. Prove by
+a bijection / `Finset.card` identity on the four solution finsets.
+Inclusion–exclusion: the solutions of `a·x+b·y=m` with `x ≥ 1` biject
+(via `x ↦ x−1`) with solutions of `a·x+b·y = m−a`; with `y ≥ 1` to
+`m−b`; the `x ≥ 1 ∧ y ≥ 1` ones to `m−a−b`. Every `a·x+b·y=m` solution
+has `x ≥ 1 ∨ y ≥ 1` (else `m = 0 < a+b`). Reuse `mem_solCount_box`,
+`Finset.card_union_add_card_inter` (or `Finset.filter` split on
+`x = 0`), `Nat.sub_add_cancel`. Difficulty: medium-hard; budget
+`lean4:sorry-filler-deep`. Numeric guard first (temporary `#eval`).
+
+- [ ] **Step 2: verify.**
+
+Run: `lake build GebLean.Utilities.ArithClosedForms`
+Expected: builds; no `sorry`/underscore.
+Then `bash scripts/check-axioms.sh` clean.
+
+- [ ] **Step 3: commit.**
+
+`feat(era): prove the linear-Diophantine count recurrence`
+
+---
+
+### Task 2: the digit sum `gcdDigitSum` and the window bound
+
+**Files:**
+
+- Modify: `GebLean/Utilities/ArithClosedForms.lean`
+
+- [ ] **Step 1: define `gcdDigitSum` (the value `S`).**
+
+```lean
+/-- Base-`5^(a·b)` digit sum encoding the linear-Diophantine counts:
+`S = Σ_{k=0}^{a·b} solCount a b (a·b − k) · (5^(a·b))^k`. Equals
+`⌊5^(a·b·(a·b+a+b)) / ((5^(a²·b)−1)(5^(a·b²)−1))⌋` (Task 5). -/
+private def gcdDigitSum (a b : ℕ) : ℕ :=
+  ∑ k ∈ Finset.range (a * b + 1),
+    solCount a b (a * b - k) * (5 ^ (a * b)) ^ k
+```
+
+- [ ] **Step 2: window bound `solCount a b (a·b) < 5^(a·b)`.**
+
+```lean
+private theorem solCount_mul_lt_base (a b : ℕ) (ha : 1 ≤ a) (hb : 1 ≤ b) :
+    solCount a b (a * b) < 5 ^ (a * b)
+```
+
+Strategy: `solCount a b (a·b) ≤ a·b + 1` by `solCount_le_succ`; then
+`a·b + 1 < 5^(a·b)`. `Nat.lt_pow_self (1 < 5)` gives only `a·b < 5^(a·b)`
+(`≤`, not the needed strict `+1`). Use the chain
+`a·b < 2^(a·b)` (`Nat.lt_two_pow_self`; `Nat.lt_two_pow` is absent from
+the pin — it is already used at `ArithClosedForms.lean:109`) so
+`a·b + 1 ≤ 2^(a·b)`, then `2^(a·b) < 5^(a·b)`
+(`Nat.pow_lt_pow_left`, exponent `a·b ≥ 1` from `ha`,`hb`); chain with
+`omega`. Easy.
+
+- [ ] **Step 3: `gcdDigitSum_mod`.**
+
+```lean
+private theorem gcdDigitSum_mod (a b : ℕ) (ha : 1 ≤ a) (hb : 1 ≤ b) :
+    gcdDigitSum a b % 5 ^ (a * b) = solCount a b (a * b)
+```
+
+Strategy: split `gcdDigitSum` at `k = 0`: the `k = 0` term is
+`solCount a b (a·b) · 1`; every `k ≥ 1` term is divisible by
+`5^(a·b)`. So `gcdDigitSum a b = solCount a b (a·b) + 5^(a·b)·T`. Then
+`Nat.add_mul_mod_self_left` + `Nat.mod_eq_of_lt` with Step 2's window
+bound. Reuse `Finset.sum_range_succ'` (peel `k = 0`) or
+`Finset.range_eq_Ico` + factor `5^(a·b)` from `(5^(a·b))^k = 5^(a·b)·(…)`
+for `k ≥ 1`. Medium.
+
+- [ ] **Step 4: verify + commit.**
+
+`lake build`, `check-axioms.sh`. Commit:
+`feat(era): define the gcd base-5 digit sum and window bound`.
+
+---
+
+### Task 3: exponent bridging to base `B = 5^(a·b)`
+
+**Files:**
+
+- Modify: `GebLean/Utilities/ArithClosedForms.lean`
+
+- [ ] **Step 1: the three exponent rewrites.**
+
+```lean
+private theorem gcd_num_pow (a b : ℕ) :
+    5 ^ (a * b * (a * b + a + b)) = (5 ^ (a * b)) ^ (a * b + a + b)
+private theorem gcd_dena_pow (a b : ℕ) :
+    5 ^ (a ^ 2 * b) = (5 ^ (a * b)) ^ a
+private theorem gcd_denb_pow (a b : ℕ) :
+    5 ^ (a * b ^ 2) = (5 ^ (a * b)) ^ b
+```
+
+Strategy: each is `← pow_mul` after a `ring_nf`/`Nat.mul_comm` on the
+exponent (`a·b·(a·b+a+b) = (a·b)·(a·b+a+b)`, `a²·b = (a·b)·a`,
+`a·b² = (a·b)·b`). Trivial; bundle in one commit.
+
+- [ ] **Step 2: verify + commit.**
+
+`feat(era): bridge gcd closed-form exponents to base 5^(ab)`.
+
+---
+
+### Task 4: the Euclidean bounds (HARD CORE)
+
+**Files:**
+
+- Modify: `GebLean/Utilities/ArithClosedForms.lean`
+
+The single hard piece. After Task 3, all statements use `B := 5^(a·b)`,
+`num := B^(a·b+a+b)`, `den := (B^a−1)(B^b−1)` (introduced by `set` over
+the bridged forms).
+
+- [ ] **Step 1: lower bound `den·S ≤ num`.**
+
+```lean
+private theorem gcd_den_mul_digitSum_le (a b : ℕ) (ha : 1 ≤ a)
+    (hb : 1 ≤ b) :
+    ((5 ^ (a * b)) ^ a - 1) * ((5 ^ (a * b)) ^ b - 1) * gcdDigitSum a b
+      ≤ (5 ^ (a * b)) ^ (a * b + a + b)
+```
+
+- [ ] **Step 2: upper bound `num < den·(S+1)`.**
+
+```lean
+private theorem gcd_num_lt_den_mul_digitSum_succ (a b : ℕ) (ha : 1 ≤ a)
+    (hb : 1 ≤ b) :
+    (5 ^ (a * b)) ^ (a * b + a + b)
+      < ((5 ^ (a * b)) ^ a - 1) * ((5 ^ (a * b)) ^ b - 1)
+          * (gcdDigitSum a b + 1)
+```
+
+Strategy (both). Work over `ℤ` throughout (these are theorems, so the
+`ℤ` detour costs no computability): cast the goals via `Int.toNat`/
+`Int.ofNat` and `Int.natCast` monotonicity (`Int.lt_iff_add_one_le`,
+`Int.toNat_lt`, `Nat.cast_le`/`Nat.cast_lt`). Establish the exact `ℤ`
+identity
+
+```text
+(num : ℤ) = (den : ℤ) * (S : ℤ) + R,
+R = Σ_{m=n+1}^{n+a+b}
+      ( [m ≤ n+b]·s(m−b) + [m ≤ n+a]·s(m−a) − s(m−a−b) ) · B^{E−m}
+```
+
+then prove `0 ≤ R` (⇒ `den·S ≤ num`, lower bound) and `R < den` (⇒
+`num < den·(S+1)`, upper bound). `R` is MIXED-SIGN — do NOT model it as
+a nonnegative `ℕ` digit sum or an `ℕ` `gcdRemainder` def; the units
+coefficient `−s(n)` is negative and cancels only globally.
+
+Derivation of the identity: over `ℤ`, expand
+`den·S = (B^{a+b} − B^a − B^b + 1)·Σ_{k} s(n−k)Bᵏ` into four shifted
+sums; collect by power of `B`; for each interior power apply
+`solCount_recurrence` (Task 1, cast to `ℤ` so the alternating sum is
+literally `0` — no truncation) so the coefficient telescopes to `0`;
+the leading power gives `Bᴱ`; the surviving boundary terms are `R`. The
+`ℤ` identity itself should fall to `ring`/`Finset.sum` manipulation once
+the recurrence rewrites the interior; `linear_combination` over the
+recurrence instances is a candidate.
+
+Bounds over `ℤ`. `R < den`: `R ≤ Σ_{p=0}^{a+b−1} s_max·Bᵖ` with
+`s_max ≤ n+b` (≤ `solCount_le_succ` on the largest argument), so
+`R < B·(B^{a+b}−1)/(B−1) ≤ B^{a+b}`, while
+`den = (B^a−1)(B^b−1) ≥ B^{a+b−1}·(…)`; compare with `natGeomSum_mul`.
+`0 ≤ R`: the highest band power dominates the lone negative units term
+(`s(n) < B ≤ B^{a+b−1}`). Reuse `natGeomSum_mul` (for
+`(B^c−1) = (B−1)·Σ Bⁱ` and the shift identities), `Finset.sum_range_succ`
+/`sum_range_succ'`, `Finset.mul_sum`, `Int`-arith lemmas. Boundary cases
+`a = 1`, `b = 1` (empty interior band) handled by the same telescoping
+with degenerate ranges; verify no off-by-one in `Finset.range` bounds
+(the Task 4.3 numeric guard covers `(1,1)`,`(1,k)`,`(k,1)`). This is the
+dominant cost; budget `lean4:sorry-filler-deep` and expect decomposition
+into 2–4 private `ℤ`-valued helper lemmas discovered during execution
+(e.g. `gcd_num_sub_den_mul_digitSum_eq : (num:ℤ) − den·S = R` plus
+`R_nonneg` and `R_lt_den`). Re-checkpoint with the controller if the
+helper set grows beyond ~4 or the `ℤ` identity resists `ring`.
+
+- [ ] **Step 3: numeric guard.**
+
+Temporary `#eval` (then delete) over `1 ≤ a,b ≤ 4` re-confirming
+`den·S ≤ num` and `num < den·(S+1)` before trusting the proof shape.
+
+- [ ] **Step 4: verify + commit per helper.**
+
+`lake build`, `check-axioms.sh`. Commit(s):
+`feat(era): bound the gcd base-5 floor between consecutive multiples`.
+
+---
+
+### Task 5: `num/den = S` and the floor extraction (G2.1 + G2.2)
+
+**Files:**
+
+- Modify: `GebLean/Utilities/ArithClosedForms.lean`
+
+- [ ] **Step 1: the division identity.**
+
+```lean
+private theorem gcd_div_eq_digitSum (a b : ℕ) (ha : 1 ≤ a) (hb : 1 ≤ b) :
+    (5 ^ (a * b)) ^ (a * b + a + b)
+        / (((5 ^ (a * b)) ^ a - 1) * ((5 ^ (a * b)) ^ b - 1))
+      = gcdDigitSum a b
+```
+
+Strategy: `Nat.div_eq_of_lt_le {k n m} : k * n ≤ m → m < (k+1) * n →
+m / n = k` (confirmed in the pin) with `k := gcdDigitSum a b`,
+`n := den`, `m := num`; feed Tasks 4.1/4.2 after `mul_comm` to match
+the `k * n` (i.e. `S * den`) order. Then rewrite the bridged exponents
+(Task 3) so the goal matches the closed form's `5^(a²·b)` /
+`5^(a·b²)` / `5^(a·b·(a·b+a+b))` shapes.
+
+- [ ] **Step 2: the public extraction (supersedes G2.1+G2.2).**
+
+```lean
+/-- Prunescu–Shunia base-5 floor extraction: the units base-`5^(a·b)`
+digit of `⌊5^(a·b·(a·b+a+b)) / ((5^(a²·b)−1)(5^(a·b²)−1))⌋` is the
+linear-Diophantine count `solCount a b (a·b)`. -/
+theorem solCount_eq_floor_mod (a b : ℕ) (ha : 1 ≤ a) (hb : 1 ≤ b) :
+    (5 ^ (a * b * (a * b + a + b))
+        / ((5 ^ (a ^ 2 * b) - 1) * (5 ^ (a * b ^ 2) - 1)))
+        % 5 ^ (a * b)
+      = solCount a b (a * b)
+```
+
+Strategy: rewrite via Task 3 to base `B`, apply `gcd_div_eq_digitSum`
+(Step 1), then `gcdDigitSum_mod` (Task 2.3). One `rw` chain.
+
+- [ ] **Step 3: update the module docstring.**
+
+Add to `ArithClosedForms.lean`'s `## Main statements` section:
+
+```text
+* `solCount_eq_floor_mod` — the Prunescu–Shunia base-5 floor read-off
+  `⌊5^(a·b·(a·b+a+b)) / ((5^(a²·b)−1)(5^(a·b²)−1))⌋ % 5^(a·b)
+  = solCount a b (a·b)` for `1 ≤ a, 1 ≤ b`.
+```
+
+Add to `## References` (the gcd content — G1 and G2 — is from this
+source, currently absent; required by the "cite the literature" rule):
+
+```text
+* Prunescu, Shunia, arXiv:2411.06430 (the base-5 gcd closed form;
+  Theorem 4.1).
+```
+
+`gcdDigitSum` is `private`, so `## Main definitions` needs no change.
+
+- [ ] **Step 4: verify + commit.**
+
+`lake build`, `lake lint`, `check-axioms.sh`. Commit:
+`feat(era): extract the gcd count as a base-5 floor digit`.
+
+RE-CHECKPOINT: with G2 complete, return to the parent sub-plan and
+confirm G3 (`gcdClosed5`/`gcdClosed5_eq`) and G4 (`eraGcd`/`eraPow2Val`)
+shapes against the now-exact `solCount_eq_floor_mod`. `gcdClosed5_eq`
+chains this with `solCount_mul_eq_gcd_succ` (G1.3) and a `Nat.add_sub`.
+
+---
+
+## Self-review checklist (run before execution)
+
+- [ ] `solCount_recurrence` is stated additively (no `ℕ`-subtraction
+  underflow) and its hypothesis `a + b ≤ m` matches every call site in
+  Task 4. (It is FALSE for `m < a+b`, e.g. `(a,b,m)=(1,1,1)`.)
+- [ ] Task 4's `R` is treated as a MIXED-SIGN `ℤ` quantity; the bounds
+  `0 ≤ R` and `R < den` are proved over `ℤ`. No `ℕ`-valued
+  `gcdRemainder` def, no per-digit/no-carry nonnegativity claim (the
+  `B⁰` coefficient `−s(n)` is negative).
+- [ ] `gcdDigitSum`, the bounds, and `gcd_div_eq_digitSum` all use the
+  identical `den` expression `((5^(a·b))^a − 1)·((5^(a·b))^b − 1)`.
+- [ ] No fabricated mathlib names: Phase-0 sweep DONE — all present in
+  the pin with assumed signatures: `Nat.div_eq_of_lt_le`,
+  `Nat.lt_pow_self`, `Nat.lt_two_pow_self`, `Nat.pow_lt_pow_left`,
+  `Finset.sum_range_succ'`, `Finset.mul_sum`, `Nat.add_mul_mod_self_left`,
+  `Nat.mul_sub`, `Nat.sub_mul`, `Finset.card_union_add_card_inter`,
+  `Nat.div_div_eq_div_mul`, `Nat.mod_eq_of_lt`. (`Nat.lt_two_pow` is
+  ABSENT — do not use it.)
+- [ ] Boundary cases `a = 1`, `b = 1` exercised by the Task 4.3 numeric
+  guard and produce no `Finset.range` off-by-one.
+- [ ] `Era.lean` untouched; all new content in `ArithClosedForms.lean`.
+- [ ] Each commit: no `sorry`/`admit`/underscore; axiom-clean; ≤ 100
+  char lines; docstrings on `solCount_recurrence` and the public
+  `solCount_eq_floor_mod`; pre-commit green; temporary `#eval`s deleted.
+- [ ] `solCount_eq_floor_mod` supersedes the parent sub-plan's separate
+  G2.1 (`gcd_floor_modEq_solCount`) and G2.2; update the parent sub-plan
+  to point at it.

--- a/geb-lean/docs/superpowers/plans/2026-06-15-era-gcd-g2-floor-extraction-plan.md
+++ b/geb-lean/docs/superpowers/plans/2026-06-15-era-gcd-g2-floor-extraction-plan.md
@@ -317,10 +317,26 @@ Decomposition (replaces the single Task 4 with 4a/4b/4c):
   `P/denb`'s digits to `s(n−k) = solCount a b (n−k)` uses the boundary-
   complete (guarded) recurrence `s(m) = [a≤m]s(m−a) + [b≤m]s(m−b) −
   [a+b≤m]s(m−a−b)` for `1 ≤ m` (extends `solCount_recurrence`, which
-  needs `a+b ≤ m`), equivalently the difference-invariance
-  `s(m) − [b≤m]s(m−b) = [a≤m]s(m−a) − [a+b≤m]s(m−a−b)`, telescoped over
-  `a`-steps. This is the Prunescu–Shunia combinatorial core (~150–200
-  lines); the dominant remaining cost.
+  needs `a+b ≤ m`). The dominant remaining cost.
+
+  REFINED (carry-free) decomposition, NUMERICALLY VERIFIED for
+  `1 ≤ a,b ≤ 4` (incl. `a=1`,`b=1`,`a≠b`). Let
+`g B b c := B^(c%b)·Σ_{l<c/b} B^(b·l)` (the per-tooth quotient, so
+  `B^c = denb·(g B b c) + B^(c%b)`); `W := Σ_{i<q} B^((r+a·i)%b)`;
+  `G := Σ_{i<q} (g B b (r+a·i))`. Then:
+  - (i) comb split `gcdPComb a b = denb·G + W` — geometric, from the
+    per-tooth `B^c = denb·g + B^(c mod b)` summed.
+  - (ii) no-carry `W < denb` — each digit `w_j = #{i<q : (r+a·i) ≡ j
+    (mod b)} ≤ q < B`, and `q ≤ b+1`, so `W < Bᵇ − 1`. Hence
+    `gcdPComb a b / denb = G` and `gcdPComb a b % denb = W` (no carry).
+  - (iii) THE CORE: `gcdDigitSum a b = G` (i.e. `S = G`). Coefficient-
+    wise (base `B`): `solCount a b (n−e) = #{i<q : r+a·i ≡ e (mod b)
+    ∧ r+a·i > e}` for `0 ≤ e ≤ n` (and `0` for `e > n`). This 2D-count
+    = 1D-modular-count identity is the irreducible Prunescu–Shunia
+    core (~100–200 lines); provable via the guarded recurrence /
+    difference-invariance over `a`-steps, or a direct counting bijection.
+  Given (i)–(iii): `denb·S = denb·G ≤ gcdPComb a b` and
+  `gcdPComb a b = denb·G + W < denb·G + denb = denb·(S+1)` (4b targets).
 - 4c (remaining, mechanical): the two Task-4 target theorems
   `gcd_den_mul_digitSum_le`, `gcd_num_lt_den_mul_digitSum_succ` from
   4a+4b. `num = dena·P + Bʳ < dena·(P+1) ≤ dena·denb·(S+1)` (using

--- a/geb-lean/docs/superpowers/plans/2026-06-15-era-gcd-term-subplan.md
+++ b/geb-lean/docs/superpowers/plans/2026-06-15-era-gcd-term-subplan.md
@@ -153,6 +153,15 @@ Commit per sub-lemma.
 
 **Files:** `GebLean/Utilities/ArithClosedForms.lean`
 
+> SUPERSEDED AND DONE. Phase G2 was executed under the dedicated
+> micro-plan `2026-06-15-era-gcd-g2-floor-extraction-plan.md`. Its
+> separate G2.1 (`gcd_floor_modEq_solCount`) and G2.2
+> (`solCount_eq_floor_mod`) below are subsumed by the single public
+> theorem `solCount_eq_floor_mod` proved there (the stronger exact
+> identity `num/den = gcdDigitSum a b` via the two-step `Bᵃ−1`/`Bᵇ−1`
+> reduction, the tooth-count bijection `gcd_tooth_count`, and the
+> carry-free comb split). G3 below consumes `solCount_eq_floor_mod`.
+
 Target the CONGRUENCE form (both reviewers' recommendation): proving
 `⌊…⌋ % 5^(ab) = solCount a b (ab)` factors into a `mod` congruence plus
 the window bound, which avoids materialising the whole base-`5^(ab)`

--- a/geb-lean/docs/superpowers/plans/2026-06-15-era-gcd-term-subplan.md
+++ b/geb-lean/docs/superpowers/plans/2026-06-15-era-gcd-term-subplan.md
@@ -1,0 +1,300 @@
+# Era gcd-term sub-plan (M3b Phase-3 re-checkpoint)
+
+<!-- START doctoc generated TOC please keep comment here to allow auto update -->
+<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
+
+- [The closed form (target)](#the-closed-form-target)
+- [File structure](#file-structure)
+- [Re-checkpoint note](#re-checkpoint-note)
+- [Phase G1 — the solution count and the gcd-count identity (HARD CORE 1)](#phase-g1--the-solution-count-and-the-gcd-count-identity-hard-core-1)
+- [Phase G2 — no-carry digit extraction (HARD CORE 2)](#phase-g2--no-carry-digit-extraction-hard-core-2)
+- [Phase G3 — assembly: `gcdClosed5` and `gcdClosed5_eq`](#phase-g3--assembly-gcdclosed5-and-gcdclosed5_eq)
+- [Phase G4 — the `Era` terms `eraGcd` and `eraPow2Val`](#phase-g4--the-era-terms-eragcd-and-erapow2val)
+- [Self-review checklist (run before execution)](#self-review-checklist-run-before-execution)
+
+<!-- END doctoc -->
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use
+> superpowers:subagent-driven-development to execute this sub-plan
+> task-by-task. Steps use checkbox (`- [ ]`) syntax.
+
+**Goal:** realise `gcd` as a closed `Era` term and, from it,
+`2^(v₂ n) = gcd(n, 2^n)` as an `Era` term, unblocking `eraNu2`/`eraSigma`
+(M3b plan Phase 3 Task 3.1).
+
+**Why this exists.** M3b plan Task 3.1 assumed a lightweight closed form
+for `2^(v₂ n)`; investigation proved none exists over the basis
+(exhaustive depth-≤3 search). The only route is a general
+`gcd`-as-arithmetic-term. This sub-plan scopes that as a focused
+development. Source: Prunescu–Shunia, arXiv:2411.06430, Theorem 4.1
+(the base-5 div-mod form, cleaner than Mazzanti's and unconditional for
+`a,b ≥ 1`).
+
+**Architecture.** Prove the closed form as a finite `ℕ` identity (NOT via
+formal power series). `gcd(a,b)` is the count
+`s_{a,b}(ab) = #{(x,y) : a·x + b·y = ab} = gcd(a,b) + 1`, read off as a
+base-5 digit by no-carry digit extraction. Then mirror the closed form as
+an `ETm` and specialise to `gcd(n, 2^n)`.
+
+**Tech stack:** Lean 4, Mathlib (pin `v4.29.0-rc6`),
+`lake build`/`lake test`/`lake lint`, `scripts/check-axioms.sh`.
+Constructive-only; axiom-clean.
+
+---
+
+## The closed form (target)
+
+```text
+gcdClosed5 a b =
+  (⌊ 5 ^ (a*b*(a*b + a + b)) / ((5 ^ (a^2*b) − 1) * (5 ^ (a*b^2) − 1)) ⌋
+     mod 5 ^ (a*b)) − 1
+```
+
+Theorem 4.1 (arXiv:2411.06430): for `1 ≤ a`, `1 ≤ b`,
+`gcdClosed5 a b = Nat.gcd a b`. Base 5 is the smallest base making the
+form unconditional (bases 2/3/4 fail only at `(a,b) = (1,1)`); base 5
+also gives the carry bound `n + 1 < 5^(n−2)` for `n ≥ 3`. Numerically
+validated for `1 ≤ a,b ≤ 7`.
+
+Writing `n := a*b`, the numerator exponent is `n² + a·n + b·n` and the
+denominator exponents are `a·n`, `b·n`; the extraction window is `5^n`.
+
+## File structure
+
+- `GebLean/Utilities/ArithClosedForms.lean` (extend): the `ℕ`
+  development — the solution count, the two count identities, the
+  digit-extraction lemma, and `gcdClosed5` / `gcdClosed5_eq`. Reuses the
+  file's existing `private` digit infrastructure (`ofDigits_ofFn`, the
+  `Nat.ofDigits_*` usage) and geometric-sum lemmas in
+  `EraBoundedSum.lean`.
+- `GebLean/EraCompleteness.lean` (extend): the `Era` terms `eraGcd`,
+  `eraPow2Val` and their `eval` lemmas.
+
+## Re-checkpoint note
+
+Phases G1 and G2 are the two hard cores (the Diophantine count and the
+no-carry extraction). They are decomposed into sub-lemma signatures with
+strategy below, not fabricated proof bodies. After G1+G2 land, reassess
+G3/G4 against the then-exact shapes. Budget `lean4:sorry-filler-deep` for
+the cores. Each sub-lemma is one or more `jj` commits; implementers
+verify (`lake build`/`lint`/`check-axioms`), controller commits.
+
+---
+
+## Phase G1 — the solution count and the gcd-count identity (HARD CORE 1)
+
+**Files:** `GebLean/Utilities/ArithClosedForms.lean`
+
+- [ ] **G1.1 — define the solution count (finite).**
+
+```lean
+/-- The number of `(x,y) ∈ ℕ²` with `a·x + b·y = n`. Finite for
+`1 ≤ a` (then `x ≤ n`), so realised as a `Finset.card`. -/
+def solCount (a b n : ℕ) : ℕ :=
+  ((Finset.range (n + 1) ×ˢ Finset.range (n + 1)).filter
+    (fun p => a * p.1 + b * p.2 = n)).card
+```
+
+Also prove the box-capture helper (needed by G1.2/G1.3 to reason about
+membership):
+
+```lean
+private theorem mem_solCount_box (a b n x y : ℕ) (ha : 1 ≤ a) (hb : 1 ≤ b)
+    (h : a * x + b * y = n) : x < n + 1 ∧ y < n + 1
+```
+
+For `1 ≤ a, 1 ≤ b`: `x ≤ a*x ≤ n` and `y ≤ b*y ≤ n` (`Nat.le_mul_of_pos_left`),
+so both `< n + 1`. This shows the `range (n+1)²` box captures every
+solution, so `solCount` counts them all.
+
+- [ ] **G1.2 — `s_{a,b}(n) ≤ n + 1` (carry bound).**
+
+```lean
+theorem solCount_le_succ (a b n : ℕ) (ha : 1 ≤ a) (hb : 1 ≤ b) :
+    solCount a b n ≤ n + 1
+```
+
+Use the NON-STRICT `≤` form: the strict `<` is FALSE at `a = b = 1`
+(`solCount 1 1 n = n + 1` exactly), validated numerically. `≤ n + 1`
+holds unconditionally and is all G2 needs (with `n + 1 ≤ 5^n` it gives
+the window bound `solCount a b n < 5^n`). Strategy (Lemma 3.2): the map
+`(x,y) ↦ (a*x, b*y)` injects the `a·x+b·y=n` solutions into
+`{(X,Y) : X+Y=n}` (the `Finset.Nat.antidiagonal n`, card `n+1` via
+`Finset.Nat.card_antidiagonal`). Reuse: `Finset.card_le_card` of the
+injection. Medium difficulty.
+
+- [ ] **G1.3 — `s_{a,b}(ab) = gcd(a,b) + 1` (the Diophantine count).**
+
+```lean
+theorem solCount_mul_eq_gcd_succ (a b : ℕ) (ha : 1 ≤ a) (hb : 1 ≤ b) :
+    solCount a b (a * b) = Nat.gcd a b + 1
+```
+
+Strategy (Lemma 3.1, the hardest piece). Let `d := Nat.gcd a b`,
+`a = d*a'`, `b = d*b'` with `Nat.Coprime a' b'`. The solutions of
+`a*x + b*y = a*b` are exactly `(x, y) = (b' - b'·... )`... precisely:
+all integer solutions are `x = b − (b/d)·t`, `y = (a/d)·t`, `t ∈ ℤ`
+(Bézout parametrisation from `(x₀,y₀) = (b, 0)`); non-negativity forces
+`0 ≤ t ≤ d`, giving `d + 1` solutions. Formalise as a `Finset.card_bij`
+(or `Finset.card_nbij'`) between the solution finset and
+`Finset.range (d + 1)` via `t ↦ (b − (b/d)*t, (a/d)*t)` with inverse
+`(x,y) ↦ y / (a/d)`. Reuse: `Nat.gcd_dvd_left`/`right` (`d ∣ a`, `d ∣ b`),
+`Nat.div_mul_cancel`, `Nat.Coprime` to pin the step `b/d = b'`, and the
+non-negativity range. The crux is the bijection's well-definedness and
+the `0 ≤ t ≤ d` bound; keep all arithmetic in `ℕ` (truncated subtraction
+`b − (b/d)*t` is exact because `t ≤ d` ⇒ `(b/d)*t ≤ b`). This is the
+largest single proof — budget `lean4:sorry-filler-deep`.
+
+Commit per sub-lemma.
+
+---
+
+## Phase G2 — no-carry digit extraction (HARD CORE 2)
+
+**Files:** `GebLean/Utilities/ArithClosedForms.lean`
+
+Target the CONGRUENCE form (both reviewers' recommendation): proving
+`⌊…⌋ % 5^(ab) = solCount a b (ab)` factors into a `mod` congruence plus
+the window bound, which avoids materialising the whole base-`5^(ab)`
+digit list. If `Nat.ofDigits` is used, the base must be the SINGLE big
+base `B := 5^(ab)` end-to-end (the lemma `Nat.ofDigits_mod_eq_head!`
+extracts `% B`, NOT `% B^k`; do not mix base 5 with `% 5^(ab)`).
+
+- [ ] **G2.1 — the floor congruence.** The floor is congruent to the
+solution count modulo the window:
+
+```lean
+private theorem gcd_floor_modEq_solCount (a b : ℕ) (ha : 1 ≤ a)
+    (hb : 1 ≤ b) :
+    Nat.ModEq (5 ^ (a*b))
+      (5 ^ (a*b*(a*b + a + b)) / ((5 ^ (a^2*b) − 1) * (5 ^ (a*b^2) − 1)))
+      (solCount a b (a * b))
+```
+
+Strategy: writing `n := a*b`, the floor is the truncated base-`5^n`
+positional encoding `Σ_{k} solCount a b k · (5^n)^?` of the geometric
+convolution `1/((5^(an)−1)(5^(bn)−1))` (finite geometric sums); modulo
+`5^n` only the position-0 block survives, which is `solCount a b (ab)`.
+The exponent identities `a^2*b = a*(a*b)`, `a*b^2 = b*(a*b)`,
+`a*b*(a*b+a+b) = (a*b)^2 + a*(a*b) + b*(a*b)` connect the closed-form
+exponents to the `n = a*b` form (`ring`/`Nat.pow_add`/`pow_mul`). Reuse:
+`natGeomSum_eq`/`natGeomSum_mul` (`EraBoundedSum.lean`), the
+`ofDigits_ofFn` infra in this file, `Nat.sub_one_mul`,
+`(c^m − 1) ∣ (c^(km) − 1)`, `Nat.ModEq` API. HARD — the convolution
+identity is the crux; budget `lean4:sorry-filler-deep`.
+
+- [ ] **G2.2 — the no-carry extraction.**
+
+```lean
+private theorem solCount_eq_floor_mod (a b : ℕ) (ha : 1 ≤ a) (hb : 1 ≤ b) :
+    (5 ^ (a*b*(a*b + a + b)) / ((5 ^ (a^2*b) − 1) * (5 ^ (a*b^2) − 1)))
+        % 5 ^ (a*b)
+      = solCount a b (a * b)
+```
+
+Strategy: from G2.1's congruence, `⌊…⌋ % 5^(ab) = solCount a b (ab) %
+5^(ab)`; the window bound `solCount a b (ab) < 5^(ab)` (from G1.2
+`solCount a b (ab) ≤ ab + 1` plus `ab + 1 ≤ 5^(ab)` via `Nat.one_le_pow`
+/ `Nat.lt_pow_self`) then gives `solCount a b (ab) % 5^(ab) =
+solCount a b (ab)` by `Nat.mod_eq_of_lt`. This case is `≤`-bound +
+`Nat.ModEq` bookkeeping; the real work is G2.1.
+
+Commit per sub-lemma. RE-CHECKPOINT here: with G1+G2 done, confirm
+G3/G4 shapes.
+
+---
+
+## Phase G3 — assembly: `gcdClosed5` and `gcdClosed5_eq`
+
+**Files:** `GebLean/Utilities/ArithClosedForms.lean`
+
+- [ ] **G3.1 — define `gcdClosed5`** (the closed form above), with a
+docstring.
+
+```lean
+/-- Prunescu–Shunia base-5 gcd closed form (arXiv:2411.06430, Thm 4.1). -/
+def gcdClosed5 (a b : ℕ) : ℕ :=
+  (5 ^ (a*b*(a*b + a + b)) / ((5 ^ (a^2*b) − 1) * (5 ^ (a*b^2) − 1))
+    % 5 ^ (a*b)) − 1
+```
+
+- [ ] **G3.2 — `gcdClosed5_eq`.**
+
+```lean
+theorem gcdClosed5_eq (a b : ℕ) (ha : 1 ≤ a) (hb : 1 ≤ b) :
+    gcdClosed5 a b = Nat.gcd a b
+```
+
+Strategy: `gcdClosed5 a b = (solCount a b (ab)) − 1
+= (gcd a b + 1) − 1 = gcd a b`, chaining G2.2
+(`solCount_eq_floor_mod`) and G1.3 (`solCount_mul_eq_gcd_succ`). The
+`(1,1)` case needs no special handling at base 5 (it is the reason base 5
+was chosen); confirm `gcdClosed5 1 1 = 1` by `decide`/the chain. Numeric
+guard: a TEMPORARY `#eval` over `1 ≤ a,b ≤ 6` (then delete) — feasible at
+these sizes.
+
+Commit.
+
+---
+
+## Phase G4 — the `Era` terms `eraGcd` and `eraPow2Val`
+
+**Files:** `GebLean/EraCompleteness.lean`
+
+- [ ] **G4.1 — `eraGcd : ETm 2`** mirroring `gcdClosed5` (variables 0=a,
+1=b), built from `epow`/`etsub`/`emul`/`ediv`/`emod` and the constant
+`5` (a `Tm.succ`-chain numeral) and `1`. Prove
+
+```lean
+theorem eraGcd_eval (a b : ℕ) (ha : 1 ≤ a) (hb : 1 ≤ b) :
+    Tm.eval eraInterp eraGcd ![a, b] = Nat.gcd a b
+```
+
+by reducing `eval` to `gcdClosed5` (simp over the term-formers, model
+`eraCentralBinom_eval`) then `gcdClosed5_eq`. Note: `5` as an `ETm`
+constant is the five-fold `Tm.succ` of `Tm.zero`; pick the cleanest. The
+exponents (`a*b*(a*b+a+b)` etc.) are built from `var0`,`var1` via
+`emul`/`eadd`/`epow`. The `eval` arithmetic-normalisation may need
+`ring_nf` for the exponent shapes.
+
+- [ ] **G4.2 — `eraPow2Val : ETm 1`** as `eraGcd` substituted at
+`(var 0, epow2 (var 0))` (via `Tm.subst`/`sub0`), with
+
+```lean
+theorem eraPow2Val_eval (n : ℕ) (hn : 1 ≤ n) :
+    Tm.eval eraInterp eraPow2Val ![n] = Nat.gcd n (2 ^ n)
+```
+
+proved by `Tm.eval_subst` + `eraGcd_eval n (2^n)` (needs `1 ≤ 2^n`,
+trivial). The eval target is `Nat.gcd n (2^n)` (exactly what `nu2Closed`'s
+body needs); by the existing private `gcd_pow_eq` this value equals
+`2^(padicValNat 2 n)` — hence the name `eraPow2Val` — but the lemma is
+stated in the `gcd` form so it slots directly into `eraNu2`. Downstream,
+`eraNu2` mirrors `nu2Closed`'s `^ (n+1) % base^2 / base` shell around
+`eraPow2Val` and closes via `nu2Closed_eq`.
+
+All public theorems (`gcdClosed5_eq`, `eraGcd_eval`, `eraPow2Val_eval`)
+and defs (`solCount`, `gcdClosed5`, `eraGcd`, `eraPow2Val`) carry `/-- … -/`
+docstrings (lean-coding.md).
+
+Commit per term. After G4, return to the M3b plan: `eraNu2`,
+`eraSigma` (Phase 3 Task 3.2 remainder) are then unblocked.
+
+---
+
+## Self-review checklist (run before execution)
+
+- [ ] Every sub-lemma signature is consistent across phases
+  (`solCount`, `gcdClosed5`, `eraGcd`, `eraPow2Val`).
+- [ ] No fabricated Mathlib names: confirm
+  `Finset.card_bij`/`card_nbij'`, `Finset.Nat.antidiagonal`,
+  `Nat.gcd_dvd_left`/`right`, `Nat.div_mul_cancel`,
+  `Nat.ofDigits_div_pow_eq_ofDigits_drop`,
+  `Nat.ofDigits_mod_eq_head!`, `Nat.sub_one_mul` exist in the pin
+  (Phase-0 sweep, as in the M3b plan).
+- [ ] `Era.lean` untouched; new content in `ArithClosedForms.lean` and
+  `EraCompleteness.lean` only.
+- [ ] Each committed step: no `sorry`/`admit`/underscore; axiom-clean;
+  100-char; docstrings on public decls; pre-commit green.
+- [ ] `gcd(n,2^n)` is realised by SUBSTITUTION into the general `eraGcd`,
+  not a separate specialised term (no power-of-2 shortcut exists).


### PR DESCRIPTION
Formalize a number of on-paper mathematical results leading up to implementing `gcd` in finite-basis elementary recursive arithmetic.