### PR TITLE
test(vendor): drop #check noise from geb-mathlib smoke test

### DIFF
--- a/geb-lean/GebLeanTests/Vendor/GebMathlibSmoke.lean
+++ b/geb-lean/GebLeanTests/Vendor/GebMathlibSmoke.lean
@@ -4,9 +4,6 @@ import Geb.Mathlib.Data.PFunctor.Slice.Basic
 its declarations are usable under `v4.29.0-rc6`. Replace with a genuine
 ported import once `geb-lean` consumes curated content directly. -/
 
-#check @SliceDomPFunctor.obj
-#check @SliceDomPFunctor.map
-
 example (dom : Type) (F : SliceDomPFunctor dom) {X : Type} (p : X → dom)
     (a : F.A) (v : F.B a → X) :
     F.Compatible p a v ↔ ∀ b, p (v b) = F.s ⟨a, b⟩ :=


### PR DESCRIPTION
Remove a couple of stray `#check`s.