### PR TITLE
fix(ci): lint vendored Geb root module to bound runLinter memory

### DIFF
--- a/.github/workflows/geb-mathlib-refresh.yml
+++ b/.github/workflows/geb-mathlib-refresh.yml
@@ -33,14 +33,20 @@ jobs:
       - name: Refresh and re-apply the back-port patch
         id: refresh
         run: bash scripts/refresh-geb-mathlib.sh
+      - name: Guard the vendored lint-coverage invariant
+        run: bash scripts/tests/test-lint-driver.sh
       - name: Build, test, and lint the whole vendored lib
         run: |
           lake build Geb
           lake test
-          # Lint every vendored module (list computed from disk, generic).
-          VMODS=$(cd vendor/geb-mathlib && find . -name '*.lean' -printf '%P\n' \
-            | sed 's|\.lean$||; s|/|.|g' | tr '\n' ' ')
-          lake lint -- $VMODS
+          # Lint the single root module. runLinter loads one flat
+          # environment whose declaration set (getDeclsInPackage) covers
+          # every module the `Geb` umbrella transitively imports.
+          # Enumerating each module instead loads a separate environment
+          # per module, scaling peak memory with module count and
+          # exhausting the runner. The guard step above checks no
+          # vendored module is orphaned from the umbrella.
+          lake lint -- Geb
       - name: Open or update the refresh pull request
         if: success()
         uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1  # v8.1.1

--- a/geb-lean/.claude/rules/ci-and-workflow.md
+++ b/geb-lean/.claude/rules/ci-and-workflow.md
@@ -81,7 +81,15 @@ Run by `scripts/pre-push.sh`:
    gates; a non-standard axiom dependency fails the build. CI
    repeats the build and smoke test in
    `geb/.github/workflows/lean_action_ci.yml`.
-7. User-driven gate reminders surfaced as prompts: `lean4:golf`
+7. `bash scripts/tests/test-lint-driver.sh` passes. The
+   `geb-mathlib` refresh workflow lints the vendored tree with
+   `lake lint -- Geb` (one flat environment); the guard checks
+   that the workflow keeps the root-module invocation and that
+   no vendored `Geb.*` module is orphaned from the `Geb`
+   umbrella (an orphan would silently escape the linter). CI
+   runs the same guard in
+   `geb/.github/workflows/geb-mathlib-refresh.yml`.
+8. User-driven gate reminders surfaced as prompts: `lean4:golf`
    and `lean4:review` ran on changed Lean code; line-by-line
    user diff review of every change about to be pushed; the
    push target is `origin`, not `upstream`. Upstream receives

--- a/geb-lean/scripts/pre-push.sh
+++ b/geb-lean/scripts/pre-push.sh
@@ -64,6 +64,13 @@ lake build GebLeanAxiomChecks
 step "Step 6b: scripts/tests/test-axiom-linter.sh"
 bash scripts/tests/test-axiom-linter.sh
 
+# Step 6c: vendored lint-coverage invariant. The refresh workflow lints
+# the vendored tree via `lake lint -- Geb`; this guards that no vendored
+# module is orphaned from the `Geb` umbrella (which would silently escape
+# the linter) and that the workflow keeps the root-module invocation.
+step "Step 6c: scripts/tests/test-lint-driver.sh"
+bash scripts/tests/test-lint-driver.sh
+
 # Step 7: user-driven gates (reminders, not mechanical checks).
 step "Step 7: user-driven gates (reminders)"
 cat <<'EOF'

--- a/geb-lean/scripts/tests/test-lint-driver.sh
+++ b/geb-lean/scripts/tests/test-lint-driver.sh
@@ -1,0 +1,96 @@
+#!/usr/bin/env bash
+#
+# scripts/tests/test-lint-driver.sh
+#
+# Guards the lint-coverage invariant that bounds runLinter memory
+# when linting the vendored geb-mathlib tree.
+#
+# The geb-mathlib refresh workflow lints the vendored library by
+# invoking batteries/runLinter on the single root module `Geb`.
+# runLinter loads one flat environment whose declaration set
+# (getDeclsInPackage) covers every module the `Geb` umbrella
+# transitively imports. Passing each `Geb.*` module as a separate
+# argument instead loads one environment per module — each
+# re-importing the full mathlib closure — so peak memory scales
+# with module count and exhausts a standard 16 GiB CI runner.
+#
+# Two properties are checked:
+#   1. Invocation form: the refresh workflow lints root module
+#      `Geb` (`lake lint -- Geb`) and does not enumerate the
+#      vendored modules into the lint arguments.
+#   2. Coverage completeness: every vendored `Geb.*` source module
+#      is transitively imported by the `Geb` umbrella, so linting
+#      the root module reaches every declaration the per-module
+#      form would have. A module orphaned from the umbrella would
+#      escape the linter entirely under the root-module invocation.
+#
+# Exit 0 if both hold; non-zero otherwise.
+
+set -uo pipefail
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$repo_root"
+failed=0
+
+vroot="vendor/geb-mathlib"
+workflow="../.github/workflows/geb-mathlib-refresh.yml"
+
+# --- 1. Invocation form -------------------------------------------------
+# The refresh workflow lives in the parent monorepo's .github tree.
+if [[ ! -f "$workflow" ]]; then
+  echo "NOTE: $workflow not found; skipping invocation-form check." >&2
+else
+  if ! grep -qE '^\s*lake lint -- Geb\s*$' "$workflow"; then
+    echo "FAIL: refresh workflow does not lint root module Geb" >&2
+    echo "  expected a 'lake lint -- Geb' line in $workflow" >&2
+    failed=1
+  fi
+  if grep -qE 'lake lint.*VMODS' "$workflow"; then
+    echo "FAIL: refresh workflow lints enumerated modules (high memory)" >&2
+    echo "  found a per-module 'lake lint -- \$VMODS' form in $workflow" >&2
+    failed=1
+  fi
+fi
+
+# --- 2. Coverage completeness (no module orphaned from the umbrella) -----
+# Module name to file path: dots map to slashes; the root module
+# `Geb` lives at `$vroot/Geb.lean`, the rest under `$vroot/Geb/`.
+mod_to_file() { echo "$vroot/${1//.//}.lean"; }
+
+all_mods="$( { echo Geb; find "$vroot/Geb" -name '*.lean' \
+  | sed -E "s,^$vroot/,,; s,/,.,g; s,\.lean\$,,"; } | sort -u )"
+
+# Transitive closure of `import Geb.*` reachable from the `Geb` root.
+reachable="Geb"
+frontier="Geb"
+while [[ -n "$frontier" ]]; do
+  next=""
+  for m in $frontier; do
+    f="$(mod_to_file "$m")"
+    [[ -f "$f" ]] || continue
+    imps="$(grep -oE '^(public )?import Geb(\.[A-Za-z0-9_]+)+' "$f" \
+      | sed -E 's/^(public )?import //')"
+    for i in $imps; do
+      if ! grep -qxF "$i" <<<"$reachable"; then
+        reachable="$reachable"$'\n'"$i"
+        next="$next $i"
+      fi
+    done
+  done
+  frontier="$next"
+done
+reachable="$(sort -u <<<"$reachable")"
+
+orphans="$(comm -23 <(echo "$all_mods") <(echo "$reachable"))"
+if [[ -n "$orphans" ]]; then
+  echo "FAIL: vendored modules not reachable from the 'Geb' umbrella" >&2
+  echo "  (these would escape 'lake lint -- Geb'):" >&2
+  echo "$orphans" | sed 's/^/  /' >&2
+  failed=1
+fi
+
+if [[ "$failed" -ne 0 ]]; then
+  echo "test-lint-driver: FAIL" >&2
+  exit 1
+fi
+echo "test-lint-driver: ok"
+exit 0


### PR DESCRIPTION
The geb-mathlib refresh workflow linted the vendored tree by passing every module to `lake lint`. runLinter loads each argument module in its own importModules environment, each re-importing the full mathlib closure, so peak memory scaled with module count and exhausted the 16 GiB runner; the job died mid-lint with a runner shutdown signal, surfaced as "The operation was canceled".

Lint the single root module `Geb` instead. Its getDeclsInPackage set covers every module the umbrella transitively imports, so coverage is unchanged while one flat environment loads.

Add scripts/tests/test-lint-driver.sh, run in the refresh workflow and pre-push, asserting the root-module invocation and that no vendored Geb.* module is orphaned from the umbrella, which would otherwise silently escape the linter under the root-module form.