### PR TITLE
chore(deps): refresh vendored geb-mathlib to c6c59d7

### DIFF
--- a/geb-lean/scripts/geb-mathlib-backport.patch
+++ b/geb-lean/scripts/geb-mathlib-backport.patch
@@ -17,7 +17,7 @@ index 5d37c79..9b07ec4 100644
  /-!
  # Geb root module
 diff --git a/vendor/geb-mathlib/Geb/Mathlib/Data/PFunctor/Slice/Basic.lean b/vendor/geb-mathlib/Geb/Mathlib/Data/PFunctor/Slice/Basic.lean
-index 131b203..c2eb712 100644
+index 8505d67..eedaebb 100644
 --- a/vendor/geb-mathlib/Geb/Mathlib/Data/PFunctor/Slice/Basic.lean
 +++ b/vendor/geb-mathlib/Geb/Mathlib/Data/PFunctor/Slice/Basic.lean
 @@ -3,6 +3,7 @@ Copyright (c) 2026 The geb-mathlib contributors. All rights reserved.
@@ -28,15 +28,15 @@ index 131b203..c2eb712 100644
  module
  
  public import Mathlib.Data.PFunctor.Univariate.Basic
-@@ -64,7 +65,6 @@ public section
+@@ -78,7 +79,6 @@ public section
  
- universe uA uB uD uC uX
+ universe uA uB uD uC uX uX' uY uZ
  
 -set_option linter.checkUnivs false in
  /-- A polynomial functor with a constraint leg `s` assigning each
- direction (an element of `PFunctor.Idx`) a `dom`-index. -/
+ `(shape, direction)` pair (an element of `PFunctor.Idx`) a `dom`-index. -/
  @[nolint checkUnivs]
-@@ -73,7 +73,6 @@ structure SliceDomPFunctor (dom : Type uD) : Type (max (uA + 1) (uB + 1) uD)
+@@ -87,7 +87,6 @@ structure SliceDomPFunctor (dom : Type uD) : Type (max (uA + 1) (uB + 1) uD)
    /-- The constraint leg: each direction is assigned a `dom`-index. -/
    s : toPFunctor.Idx → dom
  
@@ -45,7 +45,7 @@ index 131b203..c2eb712 100644
  `cod`-index. -/
  @[nolint checkUnivs]
 diff --git a/vendor/geb-mathlib/Geb/Mathlib/Data/PFunctor/Slice/Functor.lean b/vendor/geb-mathlib/Geb/Mathlib/Data/PFunctor/Slice/Functor.lean
-index 60a6fba..95791f5 100644
+index 621ea74..d925fad 100644
 --- a/vendor/geb-mathlib/Geb/Mathlib/Data/PFunctor/Slice/Functor.lean
 +++ b/vendor/geb-mathlib/Geb/Mathlib/Data/PFunctor/Slice/Functor.lean
 @@ -3,6 +3,7 @@ Copyright (c) 2026 The geb-mathlib contributors. All rights reserved.
@@ -63,9 +63,9 @@ index 60a6fba..95791f5 100644
 -read through `ConcreteCategory.hom`, the slice-morphism hypothesis is
 +read as functions, the slice-morphism hypothesis is
  `SliceDomPFunctor.over_hom_comp` (the function-level form of `Over.w`),
- results promoted with `↾`, and the functor laws discharged by `ext`
- plus the core `map_id`/`map_comp`. `functor` is the `Functor.toOver`
-@@ -60,21 +61,19 @@ open CategoryTheory
+ results promoted with `↾`, the identity law discharged by `ext` and the
+ core `map_id`, and the composition law by `ext` and `rfl`. `functor` is
+@@ -63,21 +64,19 @@ open CategoryTheory
  namespace SliceDomPFunctor
  
  /-- The function-level form of `Over.w`: a slice morphism `g : Y ⟶ Z`
@@ -85,14 +85,14 @@ index 60a6fba..95791f5 100644
  over `Over dom`. -/
  @[expose] def domFunctor {dom : Type uD} (F : SliceDomPFunctor.{uA, uB} dom) :
      CategoryTheory.Functor (Over dom) (Type (max uA uB uD)) where
--  obj Y := F.obj (ConcreteCategory.hom Y.hom)
+-  obj Y := F.Obj (ConcreteCategory.hom Y.hom)
 -  map {Y Z} h := ↾(F.map (ConcreteCategory.hom h.left) (over_hom_comp h))
-+  obj Y := F.obj (Y.hom)
++  obj Y := F.Obj (Y.hom)
 +  map {Y Z} h := ↾(F.map (h.left) (over_hom_comp h))
    map_id Y := by
      ext z
      exact congrFun (F.map_id _) z
-@@ -96,7 +95,7 @@ private theorem tagTriangle {dom : Type uD} {cod : Type (max uA uB uD)}
+@@ -97,7 +96,7 @@ private theorem tag_triangle {dom : Type uD} {cod : Type (max uA uB uD)}
      F.toSliceDomPFunctor.domFunctor.map g ≫ (↾fun z => F.t z.1.1) =
        (↾fun z => F.t z.1.1) := by
    ext z
@@ -101,16 +101,16 @@ index 60a6fba..95791f5 100644
      (SliceDomPFunctor.over_hom_comp g) z)
  
  /-- The slice polynomial functor `Over dom ⥤ Over cod`: the
-@@ -119,7 +118,7 @@ theorem functor_comp_forget {dom : Type uD} {cod : Type (max uA uB uD)}
- categorical object map carries no data beyond the constructive core. -/
+@@ -120,7 +119,7 @@ theorem functor_comp_forget {dom : Type uD} {cod : Type (max uA uB uD)}
+ categorical object map carries no data beyond the core. -/
  theorem functor_obj {dom : Type uD} {cod : Type (max uA uB uD)}
      (F : SlicePFunctor.{uA, uB, uD, max uA uB uD} dom cod) (Y : Over dom) :
 -    F.functor.obj Y = Over.mk (↾ F.obj (ConcreteCategory.hom Y.hom)) :=
 +    F.functor.obj Y = Over.mk (↾ F.obj (Y.hom)) :=
    rfl
  
- /-- `functor.map`'s underlying function is the choice-free `map`. An `Over`
-@@ -128,7 +127,7 @@ morphism map up to its `Prop`-valued commuting condition. -/
+ /-- `functor.map`'s underlying function is the core `map`. An `Over`
+@@ -129,7 +128,7 @@ morphism map up to its `Prop`-valued commuting condition. -/
  theorem functor_map {dom : Type uD} {cod : Type (max uA uB uD)}
      (F : SlicePFunctor.{uA, uB, uD, max uA uB uD} dom cod) {Y Z : Over dom} (g : Y ⟶ Z) :
      (F.functor.map g).left =
@@ -120,7 +120,7 @@ index 60a6fba..95791f5 100644
  
  end SlicePFunctor
 diff --git a/vendor/geb-mathlib/Geb/Mathlib/Data/PFunctor/Presheaf/Basic.lean b/vendor/geb-mathlib/Geb/Mathlib/Data/PFunctor/Presheaf/Basic.lean
-index 38d7d5b..b8132aa 100644
+index b6b7479..140e6cc 100644
 --- a/vendor/geb-mathlib/Geb/Mathlib/Data/PFunctor/Presheaf/Basic.lean
 +++ b/vendor/geb-mathlib/Geb/Mathlib/Data/PFunctor/Presheaf/Basic.lean
 @@ -3,6 +3,7 @@ Copyright (c) 2026 The geb-mathlib contributors. All rights reserved.
@@ -131,7 +131,7 @@ index 38d7d5b..b8132aa 100644
  module
  
  public import Geb.Mathlib.Data.PFunctor.Slice.Basic
-@@ -114,7 +115,6 @@ open CategoryTheory
+@@ -137,7 +138,6 @@ open CategoryTheory
  
  universe uI uJ uA uB uZ u v vI vJ
  
@@ -139,9 +139,9 @@ index 38d7d5b..b8132aa 100644
  /-- Operations of a presheaf-domain polynomial functor over `I`: a
  `SliceDomPFunctor` on `I`'s objects, with the contravariant `I`-action
  `restr` making each arity a presheaf on `I`. -/
-@@ -211,8 +211,7 @@ the functor-category hom, to stay choice-free). -/
+@@ -245,8 +245,7 @@ private theorem value_map {I : Type uI} [Category.{vI} I]
      intro i i' f b
-     rw [comp_map F α x.1, comp_map F α x.1]
+     simp only [value_map]
      refine (congrArg (fun w => α.app ⟨i'⟩ w) (x.2 f b)).trans ?_
 -    simp only [← ConcreteCategory.comp_apply]
 -    rw [α.naturality f.op]⟩
@@ -149,7 +149,7 @@ index 38d7d5b..b8132aa 100644
  
  /-- Functoriality in the input presheaf: the identity transformation acts as
  the identity. -/
-@@ -241,7 +240,6 @@ theorem map_comp {I : Type uI} [Category.{vI} I] (F : PresheafDomPFunctorData.{u
+@@ -275,7 +274,6 @@ theorem map_comp {I : Type uI} [Category.{vI} I] (F : PresheafDomPFunctorData.{u
  
  end PresheafDomPFunctorData
  
@@ -157,7 +157,7 @@ index 38d7d5b..b8132aa 100644
  /-- A presheaf-domain polynomial functor: operations together with a
  proof they are functorial. Its action is a functor `(Iᵒᵖ ⥤ Type) ⥤ Type`
  (packaged in `Presheaf.Functor`). -/
-@@ -254,7 +252,6 @@ structure PresheafDomPFunctor (I : Type uI) [Category.{vI} I] :
+@@ -288,7 +286,6 @@ structure PresheafDomPFunctor (I : Type uI) [Category.{vI} I] :
  
  attribute [ext] PresheafDomPFunctorData PresheafDomPFunctor
  
@@ -165,7 +165,7 @@ index 38d7d5b..b8132aa 100644
  /-- Operations of a presheaf polynomial functor `(Iᵒᵖ ⥤ Type) → (Jᵒᵖ ⥤ Type)`:
  the dom operations plus the tag leg `t` (via `SlicePFunctor`), the `J`-action
  `tagRestr` on shapes, and the arity reindexing `reindex`. -/
-@@ -347,7 +344,6 @@ structure IsFunctorial {I : Type uI} [Category.{vI} I] {J : Type uJ} [Category.{
+@@ -381,7 +378,6 @@ structure IsFunctorial {I : Type uI} [Category.{vI} I] {J : Type uJ} [Category.{
  
  end PresheafPFunctorData
  

--- a/geb-lean/vendor/geb-mathlib/Geb/Mathlib/Data/PFunctor/Presheaf/Basic.lean
+++ b/geb-lean/vendor/geb-mathlib/Geb/Mathlib/Data/PFunctor/Presheaf/Basic.lean
@@ -19,7 +19,9 @@ objects of a category `I` with a contravariant `I`-action on arities: for
 each shape `a`, the assignment `i ↦ Direction a i` extends to a presheaf on
 `I` via a restriction map `restr a f`. This file is the p.r.a. (parametric
 right adjoint) construction restricted to the domain side; the full
-categorical packaging appears in sibling modules.
+categorical packaging appears in sibling modules. Every declaration here is
+`Classical.choice`-free; the categorical packaging that pulls in
+`Classical.choice` from mathlib is in the sibling `Presheaf.Functor` module.
 
 The design uses the option-(A) fibre encoding: directions over `i` are
 `SliceDomPFunctor.Direction a i = Subtype (DirectionOver a i)`, the fibre of
@@ -39,8 +41,10 @@ fibres contravariantly.
 * `PresheafDomPFunctorData.IsNatural` — naturality of the direction
   assignment with respect to `restr` and `Z.map`.
 * `PresheafDomPFunctorData.obj` — the functor's value on a presheaf `Z`.
+* `PresheafDomPFunctorData.elemMap` — the action of a presheaf morphism `α` on
+  the categories of elements, `el(Z) ⟶ el(Z')`.
 * `PresheafDomPFunctorData.map` — the action on morphisms of input presheaves
-  (the bare `NatTrans`, choice-free).
+  (the bare `NatTrans`).
 * `PresheafDomPFunctor` — the bundle: operations with a functoriality proof.
 * `PresheafPFunctorData` — the full operations: the dom operations and the
   tag leg, with the `J`-action `tagRestr` on shapes and the arity reindexing
@@ -54,8 +58,9 @@ fibres contravariantly.
 * `PresheafPFunctor.objRestrElt` / `objRestr` — the restriction action of the
   output presheaf on a `J`-morphism, on the dom value and on `F.obj Z`.
 * `PresheafPFunctor.objPresheaf` — the output presheaf `T(Z) : Jᵒᵖ ⥤ Type`, a
-  `Classical.choice`-free `Functor` value with `map_id` / `map_comp` discharged
-  from `isFunctorial`.
+  `Functor` value with `map_id` / `map_comp` discharged from `isFunctorial`.
+* `PresheafPFunctor.mapPresheaf` — the presheaf morphism
+  `objPresheaf Z ⟶ objPresheaf Z'` induced by a morphism of input presheaves.
 
 ## Main statements
 
@@ -63,6 +68,22 @@ fibres contravariantly.
   domain-restricted action in the input presheaf.
 * `PresheafPFunctor.map_objRestr` — the domain map is natural with respect
   to the output presheaf's restriction maps.
+
+## Notation
+
+The declaration docstrings use the parametric-right-adjoint notation of
+[Weber2007]:
+
+* `T1` — the shape presheaf `j ↦ Shape j` on `J`, with `tagRestr` as its
+  restriction maps.
+* `E_T(a)` — the arity presheaf `i ↦ Direction a.1 i` of a shape `a` on `I`,
+  with `restr` as its restriction maps.
+* `el(T1)` — the category of elements of `T1`: objects are pairs `(j, a)` with
+  `a : Shape j`. As `T1` is a presheaf, its elements vary contravariantly, so a
+  morphism `(j, a) ⟶ (j', a')` is backed by a `J`-morphism `g : j' ⟶ j` (the
+  opposite direction) with `tagRestr g a = a'`. The arity assignment `a ↦ E_T(a)`
+  is therefore contravariant on `el(T1)` (a functor on `el(T1)ᵒᵖ`); `reindex g a`
+  is its action, the presheaf morphism `E_T(tagRestr g a) ⟶ E_T(a)`.
 
 ## Implementation notes
 
@@ -87,21 +108,23 @@ the same situation mathlib suppresses in `PFunctor`.
 `extends PresheafDomPFunctorData.{uI, uA, uB, vI} I,
 SlicePFunctor.{uA, uB, uI, uJ} I J`,
 which shares the single `SliceDomPFunctor` parent. The `reindex` laws
-`ReindexId` / `ReindexComp` cannot be bare `Prop`s: comparing `reindex` along
+`ReindexId` / `ReindexComp` are stated in homogeneous-`Eq` form, parameterized
+on a `tagRestr` law, rather than as bare `Prop`s: comparing `reindex` along
 `𝟙` (resp. a composite) with the identity (resp. the composite of `reindex`es)
 requires a source-type transport whose target equality
 (`tagRestr (𝟙 j) a = a`, resp. `tagRestr (h ≫ g) a = tagRestr h (tagRestr g a)`)
 is `TagRestrId` (resp. `TagRestrComp`) content, not definitional. They are
 therefore parameterized on that law and apply it via `cast`; `IsFunctorial`
-supplies the proof from its earlier `tagRestr_id` / `tagRestr_comp` fields.
+supplies the proof from its earlier `tagRestr_id` / `tagRestr_comp` fields. A
+heterogeneous-`Eq` formulation would avoid the parameter at the cost of
+`rw`-convenience and mathlib idiom.
 
 ## References
 
-* M. Weber, *Familial 2-functors and parametric right adjoints*, 2007.
-* nLab, *Parametric right adjoint*.
-* N. Gambino and M. Hyland, *Wellfounded trees and dependent
-  polynomial functors*, TYPES 2003.
-* J. Kock, *Polynomial functors and polynomial monads*.
+* [Weber2007]
+* [nLabParametricRightAdjoint]
+* [GambinoHyland2004]
+* [GambinoKock2013]
 
 ## Tags
 
@@ -159,7 +182,7 @@ structure IsFunctorial {I : Type uI} [Category.{vI} I]
 compatibility of `x` and the constraint condition on `b` to `Z.obj ⟨i⟩`. -/
 @[expose] def value {I : Type uI} [Category.{vI} I]
     (F : PresheafDomPFunctorData.{uI, uA, uB, vI} I)
-    {Z : Iᵒᵖ ⥤ Type uZ} (x : F.toSliceDomPFunctor.obj (elemProj Z)) ⦃i : I⦄
+    {Z : Iᵒᵖ ⥤ Type uZ} (x : F.toSliceDomPFunctor.Obj (elemProj Z)) ⦃i : I⦄
     (b : F.toSliceDomPFunctor.Direction x.1.1 i) : Z.obj ⟨i⟩ :=
   cast (congrArg (fun k : I => Z.obj ⟨k⟩)
     (((F.compatible_iff (elemProj Z) x.1.1 x.1.2).mp x.2 b.1).trans b.2)) (x.1.2 b.1).2
@@ -169,7 +192,7 @@ where `a := x.1.1`: for every `f : i' ⟶ i` and direction `b` over `i`, the
 component assigned to `restr a f b` equals `Z.map f.op` applied to `value x b`. -/
 @[expose] def IsNatural {I : Type uI} [Category.{vI} I]
     (F : PresheafDomPFunctorData.{uI, uA, uB, vI} I)
-    {Z : Iᵒᵖ ⥤ Type uZ} (x : F.toSliceDomPFunctor.obj (elemProj Z)) : Prop :=
+    {Z : Iᵒᵖ ⥤ Type uZ} (x : F.toSliceDomPFunctor.Obj (elemProj Z)) : Prop :=
   ∀ ⦃i i' : I⦄ (f : i' ⟶ i) (b : F.toSliceDomPFunctor.Direction x.1.1 i),
     F.value x (F.restr x.1.1 f b) = Z.map f.op (F.value x b)
 
@@ -177,39 +200,50 @@ component assigned to `restr a f b` equals `Z.map f.op` applied to `value x b`. 
 of the slice object on the total-space projection `elemProj Z`. -/
 @[expose] def obj {I : Type uI} [Category.{vI} I] (F : PresheafDomPFunctorData.{uI, uA, uB, vI} I)
     (Z : Iᵒᵖ ⥤ Type uZ) : Type (max uI uZ uA uB) :=
-  { x : F.toSliceDomPFunctor.obj (elemProj Z) // F.IsNatural x }
+  { x : F.toSliceDomPFunctor.Obj (elemProj Z) // F.IsNatural x }
+
+/-- The shape of an element of `F.obj Z`: its underlying `PFunctor` shape. -/
+@[expose, reducible] def obj.shape {I : Type uI} [Category.{vI} I]
+    {F : PresheafDomPFunctorData.{uI, uA, uB, vI} I} {Z : Iᵒᵖ ⥤ Type uZ} (x : F.obj Z) : F.A :=
+  x.1.1.1
 
 /-- A component of a natural transformation commutes with the reindexing
 `cast` along an equality of base points. -/
 private theorem app_cast {I : Type uI} [Category.{vI} I] {Z Z' : Iᵒᵖ ⥤ Type uZ}
-    (α : CategoryTheory.NatTrans Z Z') {k i : I} (e : k = i) (z : Z.obj ⟨k⟩) :
+    (α : NatTrans Z Z') {k i : I} (e : k = i) (z : Z.obj ⟨k⟩) :
     cast (congrArg (fun k : I => Z'.obj ⟨k⟩) e) (α.app ⟨k⟩ z) =
       α.app ⟨i⟩ (cast (congrArg (fun k : I => Z.obj ⟨k⟩) e) z) := by
   cases e
   rfl
 
+/-- The action of a natural transformation `α : Z ⟶ Z'` on the categories of
+elements, `el(Z) ⟶ el(Z')`: `⟨i, z⟩ ↦ ⟨i, α.app ⟨i⟩ z⟩`. It preserves the
+base-point projection `elemProj`, so it is a slice morphism over `elemProj`. -/
+@[expose] def elemMap {I : Type uI} [Category.{vI} I] {Z Z' : Iᵒᵖ ⥤ Type uZ}
+    (α : NatTrans Z Z') : (Σ i : I, Z.obj ⟨i⟩) → (Σ i : I, Z'.obj ⟨i⟩) :=
+  fun p => ⟨p.1, α.app ⟨p.1⟩ p.2⟩
+
 /-- The `Z'`-component the image under `α` of a slice element assigns to a
 direction is `α.app` of the `Z`-component the original assigns to it. -/
-private theorem comp_map {I : Type uI} [Category.{vI} I]
+private theorem value_map {I : Type uI} [Category.{vI} I]
     (F : PresheafDomPFunctorData.{uI, uA, uB, vI} I)
-    {Z Z' : Iᵒᵖ ⥤ Type uZ} (α : CategoryTheory.NatTrans Z Z')
-    (x : F.toSliceDomPFunctor.obj (elemProj Z)) ⦃i : I⦄
+    {Z Z' : Iᵒᵖ ⥤ Type uZ} (α : NatTrans Z Z')
+    (x : F.toSliceDomPFunctor.Obj (elemProj Z)) ⦃i : I⦄
     (b : F.toSliceDomPFunctor.Direction (F.toSliceDomPFunctor.map (p' := elemProj Z')
-      (fun p : Σ i : I, Z.obj ⟨i⟩ => (⟨p.1, α.app ⟨p.1⟩ p.2⟩ : Σ i : I, Z'.obj ⟨i⟩)) rfl x).1.1 i) :
+      (elemMap α) rfl x).1.1 i) :
     F.value (F.toSliceDomPFunctor.map (p' := elemProj Z')
-      (fun p : Σ i : I, Z.obj ⟨i⟩ => (⟨p.1, α.app ⟨p.1⟩ p.2⟩ : Σ i : I, Z'.obj ⟨i⟩)) rfl x) b =
+      (elemMap α) rfl x) b =
       α.app ⟨i⟩ (F.value x b) :=
   app_cast α (((F.compatible_iff (elemProj Z) x.1.1 x.1.2).mp x.2 b.1).trans b.2) _
 
-/-- Action on a morphism of input presheaves (the bare `NatTrans`, not
-the functor-category hom, to stay choice-free). -/
+/-- Action on a morphism of input presheaves (the bare `NatTrans`). -/
 @[expose] def map {I : Type uI} [Category.{vI} I] (F : PresheafDomPFunctorData.{uI, uA, uB, vI} I)
-    {Z Z' : Iᵒᵖ ⥤ Type uZ} (α : CategoryTheory.NatTrans Z Z') :
+    {Z Z' : Iᵒᵖ ⥤ Type uZ} (α : NatTrans Z Z') :
     F.obj Z → F.obj Z' :=
   fun x => ⟨F.toSliceDomPFunctor.map
-    (fun p : Σ i : I, Z.obj ⟨i⟩ => (⟨p.1, α.app ⟨p.1⟩ p.2⟩ : Σ i : I, Z'.obj ⟨i⟩)) rfl x.1, by
+    (elemMap α) rfl x.1, by
     intro i i' f b
-    rw [comp_map F α x.1, comp_map F α x.1]
+    simp only [value_map]
     refine (congrArg (fun w => α.app ⟨i'⟩ w) (x.2 f b)).trans ?_
     exact FunctorToTypes.naturality _ _ α f.op _⟩
 
@@ -225,8 +259,8 @@ theorem map_id {I : Type uI} [Category.{vI} I] (F : PresheafDomPFunctorData.{uI,
 /-- Functoriality in the input presheaf: the vertical composite of
 transformations acts as the composite of the actions. -/
 theorem map_comp {I : Type uI} [Category.{vI} I] (F : PresheafDomPFunctorData.{uI, uA, uB, vI} I)
-    {Z Z' Z'' : Iᵒᵖ ⥤ Type uZ} (α : CategoryTheory.NatTrans Z Z')
-    (β : CategoryTheory.NatTrans Z' Z'') :
+    {Z Z' Z'' : Iᵒᵖ ⥤ Type uZ} (α : NatTrans Z Z')
+    (β : NatTrans Z' Z'') :
     F.map { app := fun i => α.app i ≫ β.app i, naturality := fun _ _ g =>
         (by rw [← Category.assoc, α.naturality, Category.assoc, β.naturality,
           ← Category.assoc]) } =
@@ -234,8 +268,8 @@ theorem map_comp {I : Type uI} [Category.{vI} I] (F : PresheafDomPFunctorData.{u
   funext x
   exact Subtype.ext (congrFun (F.toSliceDomPFunctor.map_comp (p := elemProj Z) (q := elemProj Z')
     (r := elemProj Z'')
-    (fun p : Σ i : I, Z.obj ⟨i⟩ => (⟨p.1, α.app ⟨p.1⟩ p.2⟩ : Σ i : I, Z'.obj ⟨i⟩))
-    (fun p : Σ i : I, Z'.obj ⟨i⟩ => (⟨p.1, β.app ⟨p.1⟩ p.2⟩ : Σ i : I, Z''.obj ⟨i⟩))
+    (elemMap α)
+    (elemMap β)
     rfl rfl) x.1)
 
 end PresheafDomPFunctorData
@@ -363,8 +397,8 @@ namespace PresheafPFunctor
 direction-assignment along `reindex g`. -/
 @[expose] def objRestrElt {I : Type uI} [Category.{vI} I] {J : Type uJ} [Category.{vJ} J]
     (F : PresheafPFunctor.{uI, uJ, uA, uB, vI, vJ} I J) {Z : Iᵒᵖ ⥤ Type uZ} ⦃j j' : J⦄ (g : j' ⟶ j)
-    (x : F.toSliceDomPFunctor.obj (PresheafDomPFunctorData.elemProj Z)) (htag : F.t x.1.1 = j) :
-    F.toSliceDomPFunctor.obj (PresheafDomPFunctorData.elemProj Z) :=
+    (x : F.toSliceDomPFunctor.Obj (PresheafDomPFunctorData.elemProj Z)) (htag : F.t x.1.1 = j) :
+    F.toSliceDomPFunctor.Obj (PresheafDomPFunctorData.elemProj Z) :=
   ⟨⟨(F.tagRestr g ⟨x.1.1, htag⟩).1,
       fun b' => x.1.2 (F.reindex g ⟨x.1.1, htag⟩ (i := F.sCurried _ b') ⟨b', rfl⟩).1⟩,
     (F.compatible_iff _ _ _).mpr fun b' =>
@@ -374,13 +408,12 @@ direction-assignment along `reindex g`. -/
 
 /-- The component the restricted element assigns to a direction is the component
 the original assigns to the direction's `reindex`. -/
-private theorem comp_objRestrElt {I : Type uI} [Category.{vI} I] {J : Type uJ} [Category.{vJ} J]
+private theorem value_objRestrElt {I : Type uI} [Category.{vI} I] {J : Type uJ} [Category.{vJ} J]
     (F : PresheafPFunctor.{uI, uJ, uA, uB, vI, vJ} I J) {Z : Iᵒᵖ ⥤ Type uZ} ⦃j j' : J⦄ (g : j' ⟶ j)
-    (x : F.toSliceDomPFunctor.obj (PresheafDomPFunctorData.elemProj Z)) (htag : F.t x.1.1 = j)
+    (x : F.toSliceDomPFunctor.Obj (PresheafDomPFunctorData.elemProj Z)) (htag : F.t x.1.1 = j)
     ⦃i : I⦄ (b : F.Direction (F.objRestrElt g x htag).1.1 i) :
     F.value (F.objRestrElt g x htag) b = F.value x (F.reindex g ⟨x.1.1, htag⟩ b) := by
-  obtain ⟨b1, hb⟩ := b
-  cases hb
+  obtain ⟨b1, rfl⟩ := b
   rfl
 
 /-- The restriction action of `objPresheaf` on a `J`-morphism `g`, at the level
@@ -388,18 +421,18 @@ of `F.obj Z`: `objRestrElt` packaged with its naturality, supplied by
 `reindex_naturality`. -/
 @[expose] def objRestr {I : Type uI} [Category.{vI} I] {J : Type uJ} [Category.{vJ} J]
     (F : PresheafPFunctor.{uI, uJ, uA, uB, vI, vJ} I J) {Z : Iᵒᵖ ⥤ Type uZ} ⦃j j' : J⦄ (g : j' ⟶ j)
-    (x : F.obj Z) (htag : F.t x.1.1.1 = j) : F.obj Z :=
+    (x : F.obj Z) (htag : F.t x.shape = j) : F.obj Z :=
   ⟨F.objRestrElt g x.1 htag, by
     intro i i' f b
-    rw [F.comp_objRestrElt, F.comp_objRestrElt,
-      show F.reindex g ⟨x.1.1.1, htag⟩ (F.restr (F.objRestrElt g x.1 htag).1.1 f b)
-          = F.restr x.1.1.1 f (F.reindex g ⟨x.1.1.1, htag⟩ b) from
-        (congrFun (F.isFunctorial.reindex_naturality g ⟨x.1.1.1, htag⟩ f) b).symm]
-    exact x.2 f (F.reindex g ⟨x.1.1.1, htag⟩ b)⟩
+    rw [F.value_objRestrElt, F.value_objRestrElt,
+      show F.reindex g ⟨x.shape, htag⟩ (F.restr (F.objRestrElt g x.1 htag).1.1 f b)
+          = F.restr x.shape f (F.reindex g ⟨x.shape, htag⟩ b) from
+        (congrFun (F.isFunctorial.reindex_naturality g ⟨x.shape, htag⟩ f) b).symm]
+    exact x.2 f (F.reindex g ⟨x.shape, htag⟩ b)⟩
 
-/-- The underlying index of a direction cast along a shape equality is the
-original index, up to the transport of its type along that equality. -/
-private theorem coe_cast_pos {I : Type uI} [Category.{vI} I] {J : Type uJ} [Category.{vJ} J]
+/-- The underlying value of a direction cast along a shape equality is the
+original value, up to the transport of its type along that equality. -/
+private theorem cast_val_heq {I : Type uI} [Category.{vI} I] {J : Type uJ} [Category.{vJ} J]
     (F : PresheafPFunctor.{uI, uJ, uA, uB, vI, vJ} I J) {j : J} {s s' : F.Shape j} (h : s = s')
     {i : I} (p : F.Direction s.1 i) :
     (cast (congrArg (fun t : F.Shape j => F.Direction t.1 i) h) p).1 ≍ (p.1 : F.B s.1) := by
@@ -415,17 +448,14 @@ private theorem reindex_val_heq {I : Type uI} [Category.{vI} I] {J : Type uJ} [C
     (hb : (b.1 : F.B (F.tagRestr h S).1) ≍ (b'.1 : F.B (F.tagRestr h S').1)) :
     (F.reindex h S b).1 ≍ ((F.reindex h S' b').1 : F.B S'.1) := by
   cases hSS
-  obtain ⟨bv, hbi⟩ := b
-  obtain ⟨bv', hbi'⟩ := b'
-  have hvv : bv = bv' := eq_of_heq hb
-  subst hvv
-  cases hbi
-  cases hbi'
+  obtain ⟨bv, rfl⟩ := b
+  obtain ⟨bv', rfl⟩ := b'
+  cases eq_of_heq hb
   rfl
 
 /-- Two functions into a common type whose domains are equal are heterogeneously
-equal when they agree on heterogeneously-equal inputs. A `Classical.choice`-free
-restriction of `Function.hfunext` to a non-dependent codomain. -/
+equal when they agree on heterogeneously-equal inputs. A restriction of
+`Function.hfunext` to a non-dependent codomain. -/
 private theorem heq_fun {α β : Type u} {X : Type v} (h : α = β) {f : α → X} {g : β → X}
     (hfg : ∀ (a : α) (b : β), a ≍ b → f a = g b) : f ≍ g := by
   cases h
@@ -437,7 +467,7 @@ private theorem heq_fun {α β : Type u} {X : Type v} (h : α = β) {f : α → 
 identity. -/
 private theorem objRestrElt_id {I : Type uI} [Category.{vI} I] {J : Type uJ} [Category.{vJ} J]
     (F : PresheafPFunctor.{uI, uJ, uA, uB, vI, vJ} I J) {Z : Iᵒᵖ ⥤ Type uZ} {j : J}
-    (x : F.toSliceDomPFunctor.obj (PresheafDomPFunctorData.elemProj Z)) (htag : F.t x.1.1 = j) :
+    (x : F.toSliceDomPFunctor.Obj (PresheafDomPFunctorData.elemProj Z)) (htag : F.t x.1.1 = j) :
     F.objRestrElt (𝟙 j) x htag = x := by
   apply Subtype.ext
   obtain ⟨⟨a, v⟩, hc⟩ := x
@@ -452,15 +482,15 @@ private theorem objRestrElt_id {I : Type uI} [Category.{vI} I] {J : Type uJ} [Ca
   dsimp only
   rw [F.isFunctorial.reindex_id]
   congr 1
-  apply eq_of_heq
-  exact HEq.trans (F.coe_cast_pos (congrFun (F.isFunctorial.tagRestr_id j) ⟨a, htag⟩) ⟨b1, rfl⟩) hb
+  exact eq_of_heq
+    (HEq.trans (F.cast_val_heq (congrFun (F.isFunctorial.tagRestr_id j) ⟨a, htag⟩) ⟨b1, rfl⟩) hb)
 
 /-- Composition law for the restriction action: `objRestrElt` along a composite
 factors as the composite of the actions. -/
 private theorem objRestrElt_comp {I : Type uI} [Category.{vI} I] {J : Type uJ} [Category.{vJ} J]
     (F : PresheafPFunctor.{uI, uJ, uA, uB, vI, vJ} I J) {Z : Iᵒᵖ ⥤ Type uZ} ⦃j j' j'' : J⦄
     (g : j' ⟶ j) (h : j'' ⟶ j')
-    (x : F.toSliceDomPFunctor.obj (PresheafDomPFunctorData.elemProj Z)) (htag : F.t x.1.1 = j)
+    (x : F.toSliceDomPFunctor.Obj (PresheafDomPFunctorData.elemProj Z)) (htag : F.t x.1.1 = j)
     (htag' : F.t (F.objRestrElt g x htag).1.1 = j') :
     F.objRestrElt (h ≫ g) x htag = F.objRestrElt h (F.objRestrElt g x htag) htag' := by
   apply Subtype.ext
@@ -481,25 +511,25 @@ private theorem objRestrElt_comp {I : Type uI} [Category.{vI} I] {J : Type uJ} [
   refine F.reindex_val_heq g rfl _ _ ?_
   refine F.reindex_val_heq h rfl _ _ ?_
   exact HEq.trans
-    (F.coe_cast_pos (congrFun (F.isFunctorial.tagRestr_comp g h) ⟨a, htag⟩) ⟨b1, rfl⟩) hb
+    (F.cast_val_heq (congrFun (F.isFunctorial.tagRestr_comp g h) ⟨a, htag⟩) ⟨b1, rfl⟩) hb
 
 /-- The output presheaf `T(Z) : Jᵒᵖ ⥤ Type`, built directly as a `Functor`
-value (a presheaf value is `Classical.choice`-free). Its fibre over `j` is the
+value. Its fibre over `j` is the
 `t`-tagged subtype of the dom value `F.obj Z`; its restriction maps are the
 retag-and-reindex action `objRestr`, whose `map_id` / `map_comp` are discharged
 from `F.isFunctorial`. -/
 @[expose] def objPresheaf {I : Type uI} [Category.{vI} I] {J : Type uJ} [Category.{vJ} J]
     (F : PresheafPFunctor.{uI, uJ, uA, uB, vI, vJ} I J) (Z : Iᵒᵖ ⥤ Type uZ) :
     Jᵒᵖ ⥤ Type (max uI uZ uA uB) where
-  obj j := { z : F.toPresheafDomPFunctorData.obj Z // F.t z.1.1.1 = j.unop }
-  map g := ↾ fun w => ⟨F.objRestr g.unop w.1 w.2, (F.tagRestr g.unop ⟨w.1.1.1.1, w.2⟩).2⟩
+  obj j := { z : F.toPresheafDomPFunctorData.obj Z // F.t z.shape = j.unop }
+  map g := ↾ fun w => ⟨F.objRestr g.unop w.1 w.2, (F.tagRestr g.unop ⟨w.1.shape, w.2⟩).2⟩
   map_id j := by
     ext w
     exact Subtype.ext (F.objRestrElt_id w.1.1 w.2)
   map_comp g h := by
     ext w
     apply Subtype.ext
-    exact F.objRestrElt_comp g.unop h.unop w.1.1 w.2 (F.tagRestr g.unop ⟨w.1.1.1.1, w.2⟩).2
+    exact F.objRestrElt_comp g.unop h.unop w.1.1 w.2 (F.tagRestr g.unop ⟨w.1.shape, w.2⟩).2
 
 /-- Naturality of the dom morphism map with respect to `objPresheaf`'s
 `J`-restriction: for `α : NatTrans Z Z'`, the dom `map α` carries the fibre of
@@ -510,10 +540,23 @@ interchange of the postcomposition with `α` (the morphism action) and the
 precomposition with `reindex g` (the restriction), needing no functor law. -/
 theorem map_objRestr {I : Type uI} [Category.{vI} I] {J : Type uJ} [Category.{vJ} J]
     (F : PresheafPFunctor.{uI, uJ, uA, uB, vI, vJ} I J) {Z Z' : Iᵒᵖ ⥤ Type uZ}
-    (α : CategoryTheory.NatTrans Z Z') ⦃j j' : J⦄ (g : j' ⟶ j)
-    (x : F.toPresheafDomPFunctorData.obj Z) (htag : F.t x.1.1.1 = j) :
+    (α : NatTrans Z Z') ⦃j j' : J⦄ (g : j' ⟶ j)
+    (x : F.toPresheafDomPFunctorData.obj Z) (htag : F.t x.shape = j) :
     F.toPresheafDomPFunctorData.map α (F.objRestr g x htag) =
       F.objRestr g (F.toPresheafDomPFunctorData.map α x) htag :=
   Subtype.ext rfl
+
+/-- The natural transformation `objPresheaf Z ⟶ objPresheaf Z'` induced by a
+morphism `α : Z ⟶ Z'` of input presheaves: each component is the dom `map α` on
+the underlying element, restricted to the `t`-tagged fibre (the dom map preserves
+the tag, the shape being fixed by `SliceDomPFunctor.map_fst`); naturality is
+`map_objRestr`. The categorical wrapper `functor.map` reuses it. -/
+@[expose] def mapPresheaf {I : Type uI} [Category.{vI} I] {J : Type uJ} [Category.{vJ} J]
+    (F : PresheafPFunctor.{uI, uJ, uA, uB, vI, vJ} I J) {Z Z' : Iᵒᵖ ⥤ Type uZ}
+    (α : NatTrans Z Z') : NatTrans (F.objPresheaf Z) (F.objPresheaf Z') where
+  app X := ↾fun w => (⟨F.toPresheafDomPFunctorData.map α w.1, w.2⟩ : (F.objPresheaf Z').obj X)
+  naturality _ _ g := by
+    ext w
+    exact Subtype.ext (F.map_objRestr α g.unop w.1 w.2)
 
 end PresheafPFunctor

--- a/geb-lean/vendor/geb-mathlib/Geb/Mathlib/Data/PFunctor/Presheaf/Functor.lean
+++ b/geb-lean/vendor/geb-mathlib/Geb/Mathlib/Data/PFunctor/Presheaf/Functor.lean
@@ -6,6 +6,7 @@ Authors: The geb-mathlib contributors
 module
 
 public import Geb.Mathlib.Data.PFunctor.Presheaf.Basic
+public import Mathlib.CategoryTheory.Elements
 
 /-!
 # Presheaf-domain polynomial functors: categorical wrapper
@@ -18,44 +19,53 @@ over presheaf categories and discharging their laws — is
 module from the choice-free core; the module
 `Data.PFunctor.Presheaf.Functor` is on
 `GebMeta.classicalAllowedModules`. The notation `↾` (`TypeCat.ofHom`) is
-choice-free: `objPresheaf` uses `↾` and is `{propext, Quot.sound}`.
+choice-free: `objPresheaf` uses `↾` and is `{propext, Quot.sound}`. This
+module also relates the core to mathlib's category of elements:
+`elemMap_eq_categoryOfElements_map` proves the choice-free core `elemMap` is
+the object map of mathlib's `Classical.choice`-dependent
+`CategoryOfElements.map`.
 
 ## Main definitions
 
 * `PresheafDomPFunctorData.domFunctor` — the functor `(Iᵒᵖ ⥤ Type) ⥤ Type`.
+* `PresheafDomPFunctorData.toElements` — the bridge from the core's `I`-indexed
+  element set to mathlib's category of elements `Z.Elements`.
 * `PresheafPFunctor.functor` — the functor `(Iᵒᵖ ⥤ Type) ⥤ (Jᵒᵖ ⥤ Type)`.
 
 ## Main statements
 
 * `PresheafPFunctor.functor_obj` / `functor_map` — the categorical functor's
-  object and morphism maps are the choice-free core `objPresheaf` and dom
-  `map`.
+  object map is the core `objPresheaf`, and its morphism map is the
+  dom `map` retagged onto the `t`-tagged fibre.
+* `PresheafDomPFunctorData.elemMap_eq_categoryOfElements_map` — the core's
+  choice-free `elemMap` is the object map of mathlib's
+  `Classical.choice`-dependent `CategoryOfElements.map`, across `toElements`.
 
 ## Implementation notes
 
 `domFunctor` reuses the core `obj`/`map`. A functor-category hom
 `h : Z ⟶ Z'` is definitionally a `CategoryTheory.NatTrans Z Z'`, the input
 the core `map` expects, so `map` promotes the core `map` with `↾`; the
-functor laws discharge by `ext` plus the core `map_id`/`map_comp`. Unlike
-the slice wrapper there is no `Functor.toOver` shortcut: the codomain is a
-plain type category, not an `Over` category.
+identity law discharges by `ext` and the core `map_id`, and the composition
+law by `ext` and `rfl`. Unlike the slice wrapper there is no `Functor.toOver`
+shortcut: the codomain is a plain type category, not an `Over` category.
 
-`functor` assembles directly: its object map is `objPresheaf`, and its
-morphism map carries a functor-category hom `α` to the natural transformation
-whose component over `j` is the dom `map α` restricted to the `t`-tagged fibre
-(the dom map preserves the tag, so it restricts). Each component's naturality
-with respect to `objPresheaf`'s restriction maps is `map_objRestr`; the outer
-functor laws come from the dom `map_id` / `map_comp`. There is no `Functor.toOver`
+`functor` assembles directly: its object map is `objPresheaf`, and its morphism
+map is the core `mapPresheaf` — the natural transformation a
+functor-category hom `α` induces, whose component is the dom `map α` restricted
+to the `t`-tagged fibre (the dom map preserves the tag, so it restricts), with
+naturality `map_objRestr`. The outer functor laws come from the dom
+`map_id` / `map_comp`. There is no `Functor.toOver`
 analogue for presheaf codomains. The morphism universes of `I` and `J` are
-named so the input presheaf's value universe and the `PresheafPFunctor` arity
-universes pin the output presheaf's value universe explicitly.
+named (`vI`, `vJ`) so the input presheaf's value universe `uZ` and the
+`PresheafPFunctor` arity universes `uA` / `uB` pin the output presheaf's value
+universe `max uI uZ uA uB` explicitly.
 
 ## References
 
-* M. Weber, *Familial 2-functors and parametric right adjoints*, 2007.
-* N. Gambino and M. Hyland, *Wellfounded trees and dependent
-  polynomial functors*, TYPES 2003.
-* J. Kock, *Polynomial functors and polynomial monads*.
+* [Weber2007]
+* [GambinoHyland2004]
+* [GambinoKock2013]
 
 ## Tags
 
@@ -74,39 +84,47 @@ namespace PresheafDomPFunctorData
 /-- The functor `(Iᵒᵖ ⥤ Type) ⥤ Type` of a presheaf-domain polynomial
 functor: the core `obj`/`map` packaged on the presheaf category. A
 functor-category hom is definitionally the bare `NatTrans` the core `map`
-consumes, and the functor laws come from the core `map_id`/`map_comp`. -/
+consumes; the identity law comes from the core `map_id`, the composition law
+by `rfl`. -/
 @[expose] def domFunctor {I : Type uI} [Category I]
     (F : PresheafDomPFunctorData.{uI, uA, uB} I) :
-    CategoryTheory.Functor (Iᵒᵖ ⥤ Type uZ) (Type (max uA uB uI uZ)) where
+    CategoryTheory.Functor (Iᵒᵖ ⥤ Type uZ) (Type (max uI uZ uA uB)) where
   obj Z := F.obj Z
   map {Z Z'} h := ↾(F.map h)
   map_id Z := by
     ext z
     exact congrFun (F.map_id Z) z
-  map_comp f g := by
-    ext z
-    rfl
+  map_comp _ _ := rfl
+
+/-- The bridge from the core's `I`-indexed element set `Σ i, Z.obj ⟨i⟩` to
+mathlib's `Iᵒᵖ`-indexed category of elements `Z.Elements`, sending `⟨i, z⟩` to
+`⟨op i, z⟩`. -/
+@[expose] def toElements {I : Type uI} [Category.{vI} I] (Z : Iᵒᵖ ⥤ Type uZ) :
+    (Σ i : I, Z.obj ⟨i⟩) → Z.Elements := fun p => ⟨⟨p.1⟩, p.2⟩
+
+/-- The core's `elemMap` is the object map of the functor on categories of
+elements that `α` induces — mathlib's `CategoryOfElements.map` — across the
+index bridge `toElements`. `CategoryOfElements.map` consumes a functor-category
+hom and is `Classical.choice`-dependent, so the core takes a bare `NatTrans` and
+defines `elemMap` directly; this theorem certifies the two agree. -/
+theorem elemMap_eq_categoryOfElements_map {I : Type uI} [Category.{vI} I]
+    {Z Z' : Iᵒᵖ ⥤ Type uZ} (α : NatTrans Z Z') :
+    toElements Z' ∘ elemMap α = (CategoryOfElements.map α).obj ∘ toElements Z :=
+  rfl
 
 end PresheafDomPFunctorData
 
 namespace PresheafPFunctor
 
 /-- The presheaf polynomial functor `(Iᵒᵖ ⥤ Type) ⥤ (Jᵒᵖ ⥤ Type)` of `F`: its
-object map is the choice-free output presheaf `objPresheaf`, and its morphism
-map carries a functor-category hom `α` to the natural transformation whose
-component over `j` is the dom `map α` restricted to the `t`-tagged fibre. Each
-component's naturality is `map_objRestr`; the functor laws come from the dom
-`map_id` / `map_comp`. -/
+object map is the output presheaf `objPresheaf`, and its morphism map
+is `mapPresheaf` (the induced presheaf morphism). The functor
+laws come from the dom `map_id` / `map_comp`. -/
 @[expose] def functor {I : Type uI} [Category.{vI} I] {J : Type uJ} [Category.{vJ} J]
     (F : PresheafPFunctor.{uI, uJ, uA, uB, vI, vJ} I J) :
     CategoryTheory.Functor (Iᵒᵖ ⥤ Type uZ) (Jᵒᵖ ⥤ Type (max uI uZ uA uB)) where
   obj Z := F.objPresheaf Z
-  map {Z Z'} α :=
-    { app := fun X => ↾ (fun w => (⟨F.toPresheafDomPFunctorData.map α w.1, w.2⟩ :
-        (F.objPresheaf Z').obj X))
-      naturality := fun _ _ g => by
-        ext w
-        exact Subtype.ext (F.map_objRestr α g.unop w.1 w.2) }
+  map {Z Z'} α := F.mapPresheaf α
   map_id Z := by
     ext j w
     exact Subtype.ext (congrFun (F.toPresheafDomPFunctorData.map_id Z) w.1)
@@ -114,8 +132,8 @@ component's naturality is `map_objRestr`; the functor laws come from the dom
     ext j w
     exact Subtype.ext (congrFun (F.toPresheafDomPFunctorData.map_comp α β) w.1)
 
-/-- `functor.obj` is the choice-free output presheaf `objPresheaf`. The
-categorical object map carries no data beyond the constructive core. -/
+/-- `functor.obj` is the output presheaf `objPresheaf`. The
+categorical object map carries no data beyond the core. -/
 theorem functor_obj {I : Type uI} [Category.{vI} I] {J : Type uJ} [Category.{vJ} J]
     (F : PresheafPFunctor.{uI, uJ, uA, uB, vI, vJ} I J) (Z : Iᵒᵖ ⥤ Type uZ) :
     F.functor.obj Z = F.objPresheaf Z :=

--- a/geb-lean/vendor/geb-mathlib/Geb/Mathlib/Data/PFunctor/Slice/Basic.lean
+++ b/geb-lean/vendor/geb-mathlib/Geb/Mathlib/Data/PFunctor/Slice/Basic.lean
@@ -27,33 +27,47 @@ categorical packaging is in the sibling `Slice.Functor` module.
 
 * `SliceDomPFunctor`, `SlicePFunctor` — the structures.
 * `SliceDomPFunctor.Compatible` — the direction-compatibility predicate.
-* `SliceDomPFunctor.obj` / `map` — the domain-restricted functor's
+* `SliceDomPFunctor.ofCurried` / `sCurried` — the curried constructor and
+  the constraint leg in dependently-curried form.
+* `SliceDomPFunctor.DirectionOver` / `Direction` — the constraint-leg
+  condition on a direction of shape `a`, and the fibre of `sCurried a`
+  over `i`.
+* `SliceDomPFunctor.Obj` / `map` — the domain-restricted functor's
   object and morphism maps; `map_id` / `map_comp` its functoriality.
 * `SlicePFunctor.obj` / `map` — the slice functor `Type/dom → Type/cod`:
   `obj` is the output object's structure map into `cod`, `map` the
   underlying function; `map_w` that it lies over `cod`, `map_id` /
   `map_comp` its functoriality.
 * `SlicePFunctor.ShapeOver` / `Shape` — the tag-leg condition and the
-  fibre of `t` over `j`, the object-map of the shape presheaf `T1`.
+  fibre of `t` over `j`.
+
+## Main statements
+
+* `SliceDomPFunctor.compatible_iff` — `Compatible` stated pointwise.
+* `SliceDomPFunctor.map_fst` — `map` fixes the shape component.
+* `SliceDomPFunctor.map_id` / `map_comp` — functoriality of the
+  domain-restricted action.
+* `SlicePFunctor.map_w` — the slice morphism lies over `cod`.
+* `SlicePFunctor.map_id` / `map_comp` — functoriality of the slice functor.
 
 ## Implementation notes
 
-`SliceDomPFunctor.obj` is a subtype of `PFunctor.Obj`; `map` is
+`SliceDomPFunctor.Obj` is a subtype of `PFunctor.Obj`; `map` is
 `PFunctor.map` restricted; functoriality reuses
-`LawfulFunctor (PFunctor.Obj _)`. The `SlicePFunctor` interpretation
-reuses these — its carrier is `SliceDomPFunctor.obj` and its `map` the
+`PFunctor.id_map` / `PFunctor.map_map`. The `SlicePFunctor` interpretation
+reuses these — its carrier is `SliceDomPFunctor.Obj` and its `map` the
 `SliceDomPFunctor` map — adding only the `t`-tag (`obj`) and the
 tag-compatibility (`map_w`); `map_id` / `map_comp` delegate to the
-domain-side ones. Both namespaces' `obj`, `map`,
+domain-side ones. `SliceDomPFunctor.Obj` and `SlicePFunctor.obj`, both
+namespaces' `map`,
 `SliceDomPFunctor.ofCurried` / `sCurried` / `DirectionOver` / `Direction`,
 and `SlicePFunctor.ShapeOver` / `Shape` are `@[expose]` so the
 wrapper and tests can unfold them across the module boundary.
 
 ## References
 
-* N. Gambino and M. Hyland, *Wellfounded trees and dependent
-  polynomial functors*, TYPES 2003.
-* J. Kock, *Polynomial functors and polynomial monads*.
+* [GambinoHyland2004]
+* [GambinoKock2013]
 
 ## Tags
 
@@ -63,10 +77,10 @@ container, PFunctor
 
 public section
 
-universe uA uB uD uC uX
+universe uA uB uD uC uX uX' uY uZ
 
 /-- A polynomial functor with a constraint leg `s` assigning each
-direction (an element of `PFunctor.Idx`) a `dom`-index. -/
+`(shape, direction)` pair (an element of `PFunctor.Idx`) a `dom`-index. -/
 @[nolint checkUnivs]
 structure SliceDomPFunctor (dom : Type uD) : Type (max (uA + 1) (uB + 1) uD)
     extends PFunctor.{uA, uB} where
@@ -117,22 +131,23 @@ image under `sCurried a` is `i`. Point-free as `(· = i) ∘ sCurried a`. -/
   (· = i) ∘ F.sCurried a
 
 /-- The directions of shape `a` lying over the base point `i`: the fibre
-of `sCurried a` over `i`, the object-map of shape `a`'s arity presheaf. -/
+of `sCurried a` over `i`. -/
 @[expose] def Direction {dom : Type uD} (F : SliceDomPFunctor.{uA, uB} dom)
     (a : F.A) (i : dom) : Type uB :=
   Subtype (F.DirectionOver a i)
 
 /-- Value of the domain-restricted functor on `(X, p)`: the
 compatibility subtype of the `PFunctor` interpretation. -/
-@[expose] def obj {dom : Type uD} (F : SliceDomPFunctor.{uA, uB} dom) {X : Type uX}
+@[expose] def Obj {dom : Type uD} (F : SliceDomPFunctor.{uA, uB} dom) {X : Type uX}
     (p : X → dom) : Type (max uA uB uX) :=
   { x : F.toPFunctor.Obj X // F.Compatible p x.1 x.2 }
 
 /-- Action on a slice morphism `f` (with `p' ∘ f = p`): `PFunctor.map f`
 restricted to the compatibility subtype. -/
-@[expose] def map {dom : Type uD} (F : SliceDomPFunctor.{uA, uB} dom) {X X' : Type uX}
+@[expose] def map {dom : Type uD} (F : SliceDomPFunctor.{uA, uB} dom)
+    {X : Type uX} {X' : Type uX'}
     {p : X → dom} {p' : X' → dom} (f : X → X') (hf : p' ∘ f = p) :
-    F.obj p → F.obj p' :=
+    F.Obj p → F.Obj p' :=
   fun x => ⟨F.toPFunctor.map f x.1, by
     obtain ⟨⟨a, v⟩, hx⟩ := x
     change p' ∘ (f ∘ v) = F.s ∘ Sigma.mk a
@@ -140,26 +155,24 @@ restricted to the compatibility subtype. -/
     exact hx⟩
 
 /-- `map` fixes the shape component. -/
-theorem map_fst {dom : Type uD} (F : SliceDomPFunctor.{uA, uB} dom) {X X' : Type uX}
+theorem map_fst {dom : Type uD} (F : SliceDomPFunctor.{uA, uB} dom)
+    {X : Type uX} {X' : Type uX'}
     {p : X → dom} {p' : X' → dom} (f : X → X') (hf : p' ∘ f = p)
-    (x : F.obj p) : (F.map f hf x).1.1 = x.1.1 := by
-  obtain ⟨⟨a, v⟩, hx⟩ := x
-  rfl
+    (x : F.Obj p) : (F.map f hf x).1.1 = x.1.1 := rfl
 
 /-- Functoriality: identity. -/
 theorem map_id {dom : Type uD} (F : SliceDomPFunctor.{uA, uB} dom) {X : Type uX}
-    (p : X → dom) : F.map id (by simp) = (id : F.obj p → F.obj p) := by
-  funext x
-  exact Subtype.ext (F.toPFunctor.id_map x.1)
+    (p : X → dom) : F.map id (by simp) = (id : F.Obj p → F.Obj p) :=
+  funext fun x => Subtype.ext (F.toPFunctor.id_map x.1)
 
 /-- Functoriality: composition. -/
-theorem map_comp {dom : Type uD} (F : SliceDomPFunctor.{uA, uB} dom) {X Y Z : Type uX}
+theorem map_comp {dom : Type uD} (F : SliceDomPFunctor.{uA, uB} dom)
+    {X : Type uX} {Y : Type uY} {Z : Type uZ}
     {p : X → dom} {q : Y → dom} {r : Z → dom} (f : X → Y) (g : Y → Z)
     (hf : q ∘ f = p) (hg : r ∘ g = q) :
     F.map (g ∘ f) (by rw [← hf, ← hg, Function.comp_assoc]) =
-      F.map g hg ∘ F.map f hf := by
-  funext x
-  exact Subtype.ext (F.toPFunctor.map_map f g x.1).symm
+      F.map g hg ∘ F.map f hf :=
+  funext fun x => Subtype.ext (F.toPFunctor.map_map f g x.1).symm
 
 end SliceDomPFunctor
 
@@ -167,34 +180,34 @@ namespace SlicePFunctor
 
 /-- The slice functor's value on `(X, p)`, as an object of `Type/cod`: its
 structure map into `cod`, the tag leg applied to each shape. The carrier is
-the `SliceDomPFunctor` value `F.toSliceDomPFunctor.obj p`. -/
+the `SliceDomPFunctor` value `F.toSliceDomPFunctor.Obj p`. -/
 @[expose] def obj {dom : Type uD} {cod : Type uC} (F : SlicePFunctor.{uA, uB, uD, uC} dom cod)
-    {X : Type uX} (p : X → dom) : F.toSliceDomPFunctor.obj p → cod :=
+    {X : Type uX} (p : X → dom) : F.toSliceDomPFunctor.Obj p → cod :=
   fun z => F.t z.1.1
 
 /-- The slice functor's action on a morphism: the `SliceDomPFunctor` morphism
 map underlying it. -/
 @[expose] def map {dom : Type uD} {cod : Type uC} (F : SlicePFunctor.{uA, uB, uD, uC} dom cod)
-    {X X' : Type uX} {p : X → dom} {p' : X' → dom} (f : X → X') (hf : p' ∘ f = p) :
-    F.toSliceDomPFunctor.obj p → F.toSliceDomPFunctor.obj p' :=
+    {X : Type uX} {X' : Type uX'} {p : X → dom} {p' : X' → dom} (f : X → X') (hf : p' ∘ f = p) :
+    F.toSliceDomPFunctor.Obj p → F.toSliceDomPFunctor.Obj p' :=
   F.toSliceDomPFunctor.map f hf
 
 /-- `map` lies over `cod`: it commutes with the `obj` structure maps. -/
 theorem map_w {dom : Type uD} {cod : Type uC} (F : SlicePFunctor.{uA, uB, uD, uC} dom cod)
-    {X X' : Type uX} {p : X → dom} {p' : X' → dom} (f : X → X') (hf : p' ∘ f = p) :
-    F.obj p' ∘ F.map f hf = F.obj p := by
-  funext z
-  exact congrArg F.t (F.toSliceDomPFunctor.map_fst f hf z)
+    {X : Type uX} {X' : Type uX'} {p : X → dom} {p' : X' → dom} (f : X → X') (hf : p' ∘ f = p) :
+    F.obj p' ∘ F.map f hf = F.obj p :=
+  funext fun z => congrArg F.t (F.toSliceDomPFunctor.map_fst f hf z)
 
 /-- Functoriality: identity. -/
 theorem map_id {dom : Type uD} {cod : Type uC} (F : SlicePFunctor.{uA, uB, uD, uC} dom cod)
     {X : Type uX} (p : X → dom) :
-    F.map id (by simp) = (id : F.toSliceDomPFunctor.obj p → F.toSliceDomPFunctor.obj p) :=
+    F.map id (by simp) = (id : F.toSliceDomPFunctor.Obj p → F.toSliceDomPFunctor.Obj p) :=
   F.toSliceDomPFunctor.map_id p
 
 /-- Functoriality: composition. -/
 theorem map_comp {dom : Type uD} {cod : Type uC} (F : SlicePFunctor.{uA, uB, uD, uC} dom cod)
-    {X Y Z : Type uX} {p : X → dom} {q : Y → dom} {r : Z → dom} (f : X → Y) (g : Y → Z)
+    {X : Type uX} {Y : Type uY} {Z : Type uZ}
+    {p : X → dom} {q : Y → dom} {r : Z → dom} (f : X → Y) (g : Y → Z)
     (hf : q ∘ f = p) (hg : r ∘ g = q) :
     F.map (g ∘ f) (by rw [← hf, ← hg, Function.comp_assoc]) = F.map g hg ∘ F.map f hf :=
   F.toSliceDomPFunctor.map_comp f g hf hg
@@ -205,8 +218,7 @@ Point-free as `(· = j) ∘ t`. -/
     (F : SlicePFunctor.{uA, uB, uD, uC} dom cod) (j : cod) : F.A → Prop :=
   (· = j) ∘ F.t
 
-/-- The shapes lying over `j`: the fibre of `t` over `j`, the object-map
-of the shape presheaf `T1`. -/
+/-- The shapes lying over `j`: the fibre of `t` over `j`. -/
 @[expose] def Shape {dom : Type uD} {cod : Type uC}
     (F : SlicePFunctor.{uA, uB, uD, uC} dom cod) (j : cod) : Type uA :=
   Subtype (F.ShapeOver j)

--- a/geb-lean/vendor/geb-mathlib/Geb/Mathlib/Data/PFunctor/Slice/Functor.lean
+++ b/geb-lean/vendor/geb-mathlib/Geb/Mathlib/Data/PFunctor/Slice/Functor.lean
@@ -26,7 +26,7 @@ packaging is kept in a separate module from the choice-free core.
 
 * `SlicePFunctor.functor_obj` / `functor_map` — the categorical
   functor's object and morphism maps are definitionally the
-  constructive-core `SlicePFunctor.obj` / `map`.
+  core `SlicePFunctor.obj` / `map`.
 * `SlicePFunctor.functor_comp_forget` — the wrapper forgets back to
   `domFunctor`.
 
@@ -35,17 +35,20 @@ packaging is kept in a separate module from the choice-free core.
 `domFunctor` reuses the core `obj`/`map`; `Over` structure maps are
 read as functions, the slice-morphism hypothesis is
 `SliceDomPFunctor.over_hom_comp` (the function-level form of `Over.w`),
-results promoted with `↾`, and the functor laws discharged by `ext`
-plus the core `map_id`/`map_comp`. `functor` is the `Functor.toOver`
-lift along the tag `t`; it is `@[expose]` so `functor_obj` /
-`functor_map` can state the definitional equalities as exported `rfl`
-theorems.
+results promoted with `↾`, the identity law discharged by `ext` and the
+core `map_id`, and the composition law by `ext` and `rfl`. `functor` is
+the `Functor.toOver` lift along the tag `t`; it is `@[expose]` so
+`functor_obj` / `functor_map` can state the definitional equalities as
+exported `rfl` theorems. `cod` is pinned to `domFunctor`'s codomain
+universe `max uA uB uD` because `Functor.toOver` requires its over-base
+object to inhabit the codomain category of the lifted functor, so the
+core's `cod`-universe polymorphism cannot survive into the categorical
+layer.
 
 ## References
 
-* N. Gambino and M. Hyland, *Wellfounded trees and dependent
-  polynomial functors*, TYPES 2003.
-* J. Kock, *Polynomial functors and polynomial monads*.
+* [GambinoHyland2004]
+* [GambinoKock2013]
 
 ## Tags
 
@@ -72,14 +75,12 @@ interpretation to `s`-compatible assignments; the core maps packaged
 over `Over dom`. -/
 @[expose] def domFunctor {dom : Type uD} (F : SliceDomPFunctor.{uA, uB} dom) :
     CategoryTheory.Functor (Over dom) (Type (max uA uB uD)) where
-  obj Y := F.obj (Y.hom)
+  obj Y := F.Obj (Y.hom)
   map {Y Z} h := ↾(F.map (h.left) (over_hom_comp h))
   map_id Y := by
     ext z
     exact congrFun (F.map_id _) z
-  map_comp f g := by
-    ext z
-    rfl
+  map_comp _ _ := rfl
 
 end SliceDomPFunctor
 
@@ -89,7 +90,7 @@ namespace SlicePFunctor
 post-composing with the `t`-tag is preserved. This is the
 `Functor.toOver` triangle obligation for `functor`, shared with
 `functor_comp_forget`. -/
-private theorem tagTriangle {dom : Type uD} {cod : Type (max uA uB uD)}
+private theorem tag_triangle {dom : Type uD} {cod : Type (max uA uB uD)}
     (F : SlicePFunctor.{uA, uB, uD, max uA uB uD} dom cod)
     {Y Z : Over dom} (g : Y ⟶ Z) :
     F.toSliceDomPFunctor.domFunctor.map g ≫ (↾fun z => F.t z.1.1) =
@@ -105,23 +106,23 @@ private theorem tagTriangle {dom : Type uD} {cod : Type (max uA uB uD)}
     CategoryTheory.Functor (Over dom) (Over cod) :=
   Functor.toOver F.toSliceDomPFunctor.domFunctor cod
     (fun _ => ↾(fun z => F.t z.1.1))
-    (by intro Y Z g; exact F.tagTriangle g)
+    (by intro Y Z g; exact F.tag_triangle g)
 
 /-- The wrapper forgets back to `domFunctor`. -/
 theorem functor_comp_forget {dom : Type uD} {cod : Type (max uA uB uD)}
     (F : SlicePFunctor.{uA, uB, uD, max uA uB uD} dom cod) :
     F.functor ⋙ Over.forget cod = F.toSliceDomPFunctor.domFunctor := by
   rw [functor]
-  exact Functor.toOver_comp_forget _ _ _ fun g => F.tagTriangle g
+  exact Functor.toOver_comp_forget _ _ _ fun g => F.tag_triangle g
 
-/-- `functor.obj` is the choice-free `obj`, packaged with `Over.mk`. The
-categorical object map carries no data beyond the constructive core. -/
+/-- `functor.obj` is the core `obj`, packaged with `Over.mk`. The
+categorical object map carries no data beyond the core. -/
 theorem functor_obj {dom : Type uD} {cod : Type (max uA uB uD)}
     (F : SlicePFunctor.{uA, uB, uD, max uA uB uD} dom cod) (Y : Over dom) :
     F.functor.obj Y = Over.mk (↾ F.obj (Y.hom)) :=
   rfl
 
-/-- `functor.map`'s underlying function is the choice-free `map`. An `Over`
+/-- `functor.map`'s underlying function is the core `map`. An `Over`
 morphism's only data is its `left` component, so this fixes the categorical
 morphism map up to its `Prop`-valued commuting condition. -/
 theorem functor_map {dom : Type uD} {cod : Type (max uA uB uD)}

--- a/geb-lean/vendor/geb-mathlib/PROVENANCE.md
+++ b/geb-lean/vendor/geb-mathlib/PROVENANCE.md
@@ -1,6 +1,6 @@
 # Vendored geb-mathlib provenance
 
 - Source: https://github.com/rokopt/geb-mathlib.git
-- Source commit: 7c223425024cb5cd4c969c249aae92c7ea793d00
-- Back-port patch: scripts/geb-mathlib-backport.patch (commit 18a4911f5b91e95daf210919bd8b59c896b00208)
+- Source commit: c6c59d7e865feeb251b0735ab416779493fed4bd
+- Back-port patch: scripts/geb-mathlib-backport.patch (commit 8973046d7f0ac1abaa36d0d126489b9e6e669f96)
 - The files under `Geb/` are an unmodified mirror of the source commit except where the back-port patch changes them; modified files carry a change notice in their header comment.


### PR DESCRIPTION
Update vendor/geb-mathlib to upstream main c6c59d7 and re-anchor scripts/geb-mathlib-backport.patch onto the new revision. Upstream context drift displaced every hunk; the SliceDomPFunctor.obj->Obj rename additionally changed a deletion target in the domFunctor hunk, re-authored by hand against the new spelling. The adaptations are unchanged: strip the GebMeta import, drop the set_option linter.checkUnivs lines, drop the ConcreteCategory.hom wrappers, and close the input-presheaf naturality goal with FunctorToTypes.naturality.

lake build Geb, lake test, lake lint -- Geb, and
lake build GebLeanAxiomChecks pass; the refresh is idempotent against c6c59d7.