### PR TITLE
docs: document the theoremsearch MCP for literature search

### DIFF
--- a/geb-lean/CLAUDE.md
+++ b/geb-lean/CLAUDE.md
@@ -75,6 +75,8 @@ active topic branches.
   each definition as transcription or novel. In `.lean` files,
   citations live in the module docstring's `## References`
   section or inside the declaration's `/-- ... -/` docstring.
+  The `theoremsearch` MCP (`theorem_search`) locates published
+  statements and their identifiers.
 - **Document only the persistent.** Comments and committed text
   describe what is enduring about the code as it is — its purpose,
   its contracts, non-obvious external constraints. They do not
@@ -96,6 +98,7 @@ active topic branches.
 | Executing-plan | `superpowers:executing-plans` (or `superpowers:subagent-driven-development`) | phase-relevant Lean skills |
 | Lean code work | `lean4` umbrella (sub-skills below) | `lean-lsp`, `serena` MCPs |
 | Mathlib search | `lean-lsp` (`leansearch`, `loogle`, `local_search`, `hammer_premise`) | — |
+| Literature search | `theoremsearch` MCP (`theorem_search`) | `docs/lean-resources.md` § Searchable |
 | Pre-commit | `superpowers:verification-before-completion` | `scripts/pre-commit.sh` (`.lean`-touching commits) |
 | Receiving review | `superpowers:receiving-code-review` | — |
 

--- a/geb-lean/docs/lean-resources.md
+++ b/geb-lean/docs/lean-resources.md
@@ -49,6 +49,22 @@ so that `CLAUDE.md` itself can stay short.
   machine, Turing machine, automaton, λ-calculus variant,
   programming-language semantics, etc.), search CSLib first, just
   as mathlib is searched for general mathematical concepts.
+- [TheoremSearch](https://www.theoremsearch.com/) indexes informal
+  published mathematics (arXiv, the Stacks Project, ProofWiki, the
+  CRing Project, the HoTT book, the Open Logic Project, and the
+  Napkin) by semantic similarity. It is available in-session as the
+  `theoremsearch` MCP, whose single tool `theorem_search` takes a
+  natural-language `query` and returns, per hit, the arXiv
+  identifier, authors, year, `theorem_type`, the LaTeX statement
+  `body`, a plain-language `slogan`, and a similarity score;
+  optional filters include `sources`, `authors`, `types`,
+  `year_range`, `citation_range`, and `n_results`. Use it during
+  brainstorming and spec phases to locate a published statement and
+  its searchable identifier, as the "Cite the literature when
+  transcribing" rule requires. It indexes the informal literature,
+  not mathlib; for formal statements use Loogle and the `lean_*`
+  tools above. The endpoint is a hosted HTTP MCP server requiring
+  no credentials.
 
 ## Lean language
 


### PR DESCRIPTION
Record the `theoremsearch` MCP (`theorem_search`) in the searchable resources catalog and the phase-driven workflow table, and point the "Cite the literature when transcribing" rule at it. The server offers semantic search over informal published mathematics and returns arXiv identifiers usable as the citations that rule requires.