### PR TITLE
chore(deps): refresh vendored geb-mathlib to a2f7b18

### DIFF
--- a/geb-lean/GebLeanTests/Vendor/GebMathlibSmoke.lean
+++ b/geb-lean/GebLeanTests/Vendor/GebMathlibSmoke.lean
@@ -6,5 +6,5 @@ ported import once `geb-lean` consumes curated content directly. -/
 
 example (dom : Type) (F : SliceDomPFunctor dom) {X : Type} (p : X → dom)
     (a : F.A) (v : F.B a → X) :
-    F.Compatible p a v ↔ ∀ b, p (v b) = F.s ⟨a, b⟩ :=
+    F.Compatible p a v ↔ ∀ b, p (v b) = F.r ⟨a, b⟩ :=
   F.compatible_iff p a v

--- a/geb-lean/docs/geb-mathlib-backport-notes.md
+++ b/geb-lean/docs/geb-mathlib-backport-notes.md
@@ -8,6 +8,7 @@
   - [1. `GebMeta` not vendored](#1-gebmeta-not-vendored)
   - [2. `linter.checkUnivs` configuration absent in v4.29](#2-lintercheckunivs-configuration-absent-in-v429)
   - [3. `ConcreteCategory` redesign (mathlib pull request 34741)](#3-concretecategory-redesign-mathlib-pull-request-34741)
+  - [4. `WType.rec` motive left as an unreduced beta-redex](#4-wtyperec-motive-left-as-an-unreduced-beta-redex)
 - [Updating the patch for a new upstream](#updating-the-patch-for-a-new-upstream)
   - [The no-op condition](#the-no-op-condition)
 - [The hard wall](#the-hard-wall)
@@ -41,6 +42,12 @@ genuinely new (decide the adaptation, add a category here).
   fires on the structures, and `nolint` is the v4.29-compatible
   suppression). The deletions span `Slice/Basic.lean` (two lines) and
   `Presheaf/Basic.lean` (four lines).
+- Prose adaptation: `Presheaf/Basic.lean`'s module docstring describes
+  the suppression as "The `linter.checkUnivs false` option and
+  `@[nolint checkUnivs]` suppress the ...". Because the option line is
+  deleted, the vendored copy no longer uses it; reword to "The
+  `@[nolint checkUnivs]` attribute suppresses the ..." so the docstring
+  describes the code as it stands in v4.29.
 
 ### 3. `ConcreteCategory` redesign (mathlib pull request 34741)
 
@@ -59,6 +66,28 @@ genuinely new (decide the adaptation, add a category here).
   Replace both tactics with `exact FunctorToTypes.naturality _ _ α f.op _`,
   the `Type`-valued naturality lemma whose statement is the goal
   (`α.app Y (Z.map f x) = Z'.map f (α.app X x)`).
+- Adaptation in `Presheaf/W.lean` (`value_wRestrTree`): the same
+  `ConcreteCategory.comp_apply` gap appears in a naturality step written
+  `rw [← ConcreteCategory.comp_apply, ← α.naturality f.op,
+  ConcreteCategory.comp_apply]`. Replace with
+  `exact (FunctorToTypes.naturality _ _ α f.op _).symm`; the `.symm` is
+  needed because this goal is the naturality equation with sides
+  reversed.
+
+### 4. `WType.rec` motive left as an unreduced beta-redex
+
+- Upstream cause: `Slice/W.lean`'s `elimData_valid` proves an `↔` by
+  applying the dependent recursor `WType.rec` with an explicit `motive`,
+  entering the minor premise via `fun a f ih => by ...`.
+- v4.29 symptom: the goal is `(fun w => ...) (WType.mk a f)` — the motive
+  lambda is not beta-reduced at the constructor — so the opening
+  `rw [F.wValid_mk, elimData_valid_mk]` reports "Did not find an
+  occurrence of the pattern" (the `F.WValid (WType.mk a f)` subterm is
+  hidden inside the unapplied lambda). Later mathlib elaborates the
+  recursor's motive application in reduced form, so upstream needs no
+  such step.
+- Adaptation: prepend `beta_reduce` as the first tactic of the minor
+  premise, exposing `F.WValid (WType.mk a f)` for the existing rewrite.
 
 ## Updating the patch for a new upstream
 

--- a/geb-lean/scripts/geb-mathlib-backport.patch
+++ b/geb-lean/scripts/geb-mathlib-backport.patch
@@ -1,23 +1,89 @@
-diff --git a/vendor/geb-mathlib/Geb.lean b/vendor/geb-mathlib/Geb.lean
-index 5d37c79..9b07ec4 100644
---- a/vendor/geb-mathlib/Geb.lean
-+++ b/vendor/geb-mathlib/Geb.lean
-@@ -3,12 +3,12 @@ Copyright (c) 2026 The geb-mathlib contributors. All rights reserved.
+diff --git a/vendor/geb-mathlib/Geb/Mathlib/Data/PFunctor/Presheaf/Basic.lean b/vendor/geb-mathlib/Geb/Mathlib/Data/PFunctor/Presheaf/Basic.lean
+index ba86cbd..5ce254f 100644
+--- a/vendor/geb-mathlib/Geb/Mathlib/Data/PFunctor/Presheaf/Basic.lean
++++ b/vendor/geb-mathlib/Geb/Mathlib/Data/PFunctor/Presheaf/Basic.lean
+@@ -3,6 +3,7 @@ Copyright (c) 2026 The geb-mathlib contributors. All rights reserved.
  Released under Apache 2.0 license as described in the file LICENSE.
  Authors: The geb-mathlib contributors
  -/
 +-- Modified from geb-mathlib by scripts/geb-mathlib-backport.patch.
- module -- shake: keep-all, shake: keep-downstream
+ module
  
- public import Geb.Mathlib
- public import Geb.Cslib
- public import Geb.Internal
--import GebMeta
+ public import Geb.Mathlib.Data.PFunctor.Slice.Basic
+@@ -97,7 +98,7 @@ later diamond via `PresheafDomPFunctorData` and `SlicePFunctor`); pinned
+ references to it elsewhere take the synthesized order
+ `PresheafDomPFunctorData.{uI, uA, uB, vI}`.
  
- /-!
- # Geb root module
+-The `linter.checkUnivs false` option and `@[nolint checkUnivs]` suppress the
++The `@[nolint checkUnivs]` attribute suppresses the
+ `checkUnivs` warning on the inherited `PFunctor` universes `uA`/`uB`: they are
+ the two `Type` universes of the `PFunctor` parent and appear only together in
+ the result `max`, so the linter flags them as a pair that could be unified. The
+@@ -139,7 +140,6 @@ open CategoryTheory
+ 
+ universe uI uJ uA uB uZ u v vI vJ uX
+ 
+-set_option linter.checkUnivs false in
+ /-- Operations of a presheaf-domain polynomial functor over `I`: a
+ `SliceDomPFunctor` on `I`'s objects, with the contravariant `I`-action
+ `directionRestr` making each arity a presheaf on `I`. -/
+@@ -248,8 +248,7 @@ private theorem value_map {I : Type uI} [Category.{vI} I]
+     intro i i' f b
+     simp only [value_map]
+     refine (congrArg (fun w => α.app ⟨i'⟩ w) (x.2 f b)).trans ?_
+-    simp only [← ConcreteCategory.comp_apply]
+-    rw [α.naturality f.op]⟩
++    exact FunctorToTypes.naturality _ _ α f.op _⟩
+ 
+ /-- Functoriality in the input presheaf: the identity transformation acts as
+ the identity. -/
+@@ -278,7 +277,6 @@ theorem map_comp {I : Type uI} [Category.{vI} I] (F : PresheafDomPFunctorData.{u
+ 
+ end PresheafDomPFunctorData
+ 
+-set_option linter.checkUnivs false in
+ /-- A presheaf-domain polynomial functor: operations together with a
+ proof they are functorial. Its action is a functor `(Iᵒᵖ ⥤ Type) ⥤ Type`
+ (packaged in `Presheaf.Functor`). -/
+@@ -291,7 +289,6 @@ structure PresheafDomPFunctor (I : Type uI) [Category.{vI} I] :
+ 
+ attribute [ext] PresheafDomPFunctorData PresheafDomPFunctor
+ 
+-set_option linter.checkUnivs false in
+ /-- Operations of a presheaf polynomial functor `(Iᵒᵖ ⥤ Type) → (Jᵒᵖ ⥤ Type)`:
+ the dom operations plus the shape-output map `q` (via `SlicePFunctor`), the
+ `J`-action `shapeRestr` on shapes, and the arity reindexing `reindex`. -/
+@@ -385,7 +382,6 @@ structure IsFunctorial {I : Type uI} [Category.{vI} I] {J : Type uJ} [Category.{
+ 
+ end PresheafPFunctorData
+ 
+-set_option linter.checkUnivs false in
+ /-- A presheaf polynomial functor: operations together with a proof they are
+ functorial. Its action is a functor `(Iᵒᵖ ⥤ Type) ⥤ (Jᵒᵖ ⥤ Type)`. -/
+ @[nolint checkUnivs]
+diff --git a/vendor/geb-mathlib/Geb/Mathlib/Data/PFunctor/Presheaf/W.lean b/vendor/geb-mathlib/Geb/Mathlib/Data/PFunctor/Presheaf/W.lean
+index 9adfe8d..1c48437 100644
+--- a/vendor/geb-mathlib/Geb/Mathlib/Data/PFunctor/Presheaf/W.lean
++++ b/vendor/geb-mathlib/Geb/Mathlib/Data/PFunctor/Presheaf/W.lean
+@@ -3,6 +3,7 @@ Copyright (c) 2026 The geb-mathlib contributors. All rights reserved.
+ Released under Apache 2.0 license as described in the file LICENSE.
+ Authors: The geb-mathlib contributors
+ -/
++-- Modified from geb-mathlib by scripts/geb-mathlib-backport.patch.
+ module
+ 
+ public import Geb.Mathlib.Data.PFunctor.Slice.W
+@@ -619,7 +620,7 @@ theorem value_wRestrTree {I : Type uI} [Category.{vI} I]
+             hn.2 hn.1⟩, rfl⟩ : (F.objPresheaf Y).obj ⟨F.q a⟩)) =
+           α.app ⟨i'⟩ ((F.objPresheaf Y).map f.op
+             ⟨⟨pnodeSlice (fun b => pelimData F Y α (fchild b)) hv hn.1, hn.2 hn.1⟩, rfl⟩) := by
+-      rw [← ConcreteCategory.comp_apply, ← α.naturality f.op, ConcreteCategory.comp_apply]
++      exact (FunctorToTypes.naturality _ _ α f.op _).symm
+     change (α.app ⟨F.q (F.shapeRestr f ⟨a, hqi⟩).1⟩
+           (⟨⟨F.objRestrElt f (pnodeSlice (fun b => pelimData F Y α (fchild b)) hv hn.1) hqi,
+             hn'.2 hn'.1⟩, rfl⟩ : (F.objPresheaf Y).obj ⟨F.q (F.shapeRestr f ⟨a, hqi⟩).1⟩)) ≍
 diff --git a/vendor/geb-mathlib/Geb/Mathlib/Data/PFunctor/Slice/Basic.lean b/vendor/geb-mathlib/Geb/Mathlib/Data/PFunctor/Slice/Basic.lean
-index 8505d67..eedaebb 100644
+index d810684..dcca284 100644
 --- a/vendor/geb-mathlib/Geb/Mathlib/Data/PFunctor/Slice/Basic.lean
 +++ b/vendor/geb-mathlib/Geb/Mathlib/Data/PFunctor/Slice/Basic.lean
 @@ -3,6 +3,7 @@ Copyright (c) 2026 The geb-mathlib contributors. All rights reserved.
@@ -28,24 +94,24 @@ index 8505d67..eedaebb 100644
  module
  
  public import Mathlib.Data.PFunctor.Univariate.Basic
-@@ -78,7 +79,6 @@ public section
+@@ -89,7 +90,6 @@ public section
  
  universe uA uB uD uC uX uX' uY uZ
  
 -set_option linter.checkUnivs false in
- /-- A polynomial functor with a constraint leg `s` assigning each
+ /-- A polynomial functor with a direction-input map `r` assigning each
  `(shape, direction)` pair (an element of `PFunctor.Idx`) a `dom`-index. -/
  @[nolint checkUnivs]
-@@ -87,7 +87,6 @@ structure SliceDomPFunctor (dom : Type uD) : Type (max (uA + 1) (uB + 1) uD)
-   /-- The constraint leg: each direction is assigned a `dom`-index. -/
-   s : toPFunctor.Idx → dom
+@@ -98,7 +98,6 @@ structure SliceDomPFunctor (dom : Type uD) : Type (max (uA + 1) (uB + 1) uD)
+   /-- The direction-input map: each direction is assigned a `dom`-index. -/
+   r : toPFunctor.Idx → dom
  
 -set_option linter.checkUnivs false in
- /-- A `SliceDomPFunctor` with a tag leg `t` assigning each shape a
+ /-- A `SliceDomPFunctor` with a shape-output map `q` assigning each shape a
  `cod`-index. -/
  @[nolint checkUnivs]
 diff --git a/vendor/geb-mathlib/Geb/Mathlib/Data/PFunctor/Slice/Functor.lean b/vendor/geb-mathlib/Geb/Mathlib/Data/PFunctor/Slice/Functor.lean
-index 621ea74..d925fad 100644
+index 5c048ee..f1e06ab 100644
 --- a/vendor/geb-mathlib/Geb/Mathlib/Data/PFunctor/Slice/Functor.lean
 +++ b/vendor/geb-mathlib/Geb/Mathlib/Data/PFunctor/Slice/Functor.lean
 @@ -3,6 +3,7 @@ Copyright (c) 2026 The geb-mathlib contributors. All rights reserved.
@@ -65,13 +131,13 @@ index 621ea74..d925fad 100644
  `SliceDomPFunctor.over_hom_comp` (the function-level form of `Over.w`),
  results promoted with `↾`, the identity law discharged by `ext` and the
  core `map_id`, and the composition law by `ext` and `rfl`. `functor` is
-@@ -63,21 +64,19 @@ open CategoryTheory
+@@ -64,21 +65,19 @@ open CategoryTheory
  namespace SliceDomPFunctor
  
  /-- The function-level form of `Over.w`: a slice morphism `g : Y ⟶ Z`
--commutes with the base maps, `Z.hom ∘ g.left = Y.hom`, read through
+-commutes with the projections, `Z.hom ∘ g.left = Y.hom`, read through
 -`ConcreteCategory.hom`. -/
-+commutes with the base maps, `Z.hom ∘ g.left = Y.hom`, read as functions. -/
++commutes with the projections, `Z.hom ∘ g.left = Y.hom`, read as functions. -/
  theorem over_hom_comp {dom : Type uD} {Y Z : Over dom} (g : Y ⟶ Z) :
 -    ConcreteCategory.hom Z.hom ∘ ConcreteCategory.hom g.left =
 -      ConcreteCategory.hom Y.hom := by
@@ -81,7 +147,7 @@ index 621ea74..d925fad 100644
 +  exact congrFun (Over.w g) z
  
  /-- The functor `Over dom ⥤ Type` restricting the `PFunctor`
- interpretation to `s`-compatible assignments; the core maps packaged
+ interpretation to `r`-compatible assignments; the core maps packaged
  over `Over dom`. -/
  @[expose] def domFunctor {dom : Type uD} (F : SliceDomPFunctor.{uA, uB} dom) :
      CategoryTheory.Functor (Over dom) (Type (max uA uB uD)) where
@@ -92,16 +158,16 @@ index 621ea74..d925fad 100644
    map_id Y := by
      ext z
      exact congrFun (F.map_id _) z
-@@ -97,7 +96,7 @@ private theorem tag_triangle {dom : Type uD} {cod : Type (max uA uB uD)}
-     F.toSliceDomPFunctor.domFunctor.map g ≫ (↾fun z => F.t z.1.1) =
-       (↾fun z => F.t z.1.1) := by
+@@ -98,7 +97,7 @@ private theorem output_triangle {dom : Type uD} {cod : Type (max uA uB uD)}
+     F.toSliceDomPFunctor.domFunctor.map g ≫ (↾fun z => F.q z.1.1) =
+       (↾fun z => F.q z.1.1) := by
    ext z
--  exact congrArg F.t (F.toSliceDomPFunctor.map_fst (ConcreteCategory.hom g.left)
-+  exact congrArg F.t (F.toSliceDomPFunctor.map_fst (g.left)
+-  exact congrArg F.q (F.toSliceDomPFunctor.map_fst (ConcreteCategory.hom g.left)
++  exact congrArg F.q (F.toSliceDomPFunctor.map_fst (g.left)
      (SliceDomPFunctor.over_hom_comp g) z)
  
  /-- The slice polynomial functor `Over dom ⥤ Over cod`: the
-@@ -120,7 +119,7 @@ theorem functor_comp_forget {dom : Type uD} {cod : Type (max uA uB uD)}
+@@ -121,7 +120,7 @@ theorem functor_comp_forget {dom : Type uD} {cod : Type (max uA uB uD)}
  categorical object map carries no data beyond the core. -/
  theorem functor_obj {dom : Type uD} {cod : Type (max uA uB uD)}
      (F : SlicePFunctor.{uA, uB, uD, max uA uB uD} dom cod) (Y : Over dom) :
@@ -110,7 +176,7 @@ index 621ea74..d925fad 100644
    rfl
  
  /-- `functor.map`'s underlying function is the core `map`. An `Over`
-@@ -129,7 +128,7 @@ morphism map up to its `Prop`-valued commuting condition. -/
+@@ -130,7 +129,7 @@ morphism map up to its `Prop`-valued commuting condition. -/
  theorem functor_map {dom : Type uD} {cod : Type (max uA uB uD)}
      (F : SlicePFunctor.{uA, uB, uD, max uA uB uD} dom cod) {Y Z : Over dom} (g : Y ⟶ Z) :
      (F.functor.map g).left =
@@ -119,10 +185,10 @@ index 621ea74..d925fad 100644
    rfl
  
  end SlicePFunctor
-diff --git a/vendor/geb-mathlib/Geb/Mathlib/Data/PFunctor/Presheaf/Basic.lean b/vendor/geb-mathlib/Geb/Mathlib/Data/PFunctor/Presheaf/Basic.lean
-index b6b7479..140e6cc 100644
---- a/vendor/geb-mathlib/Geb/Mathlib/Data/PFunctor/Presheaf/Basic.lean
-+++ b/vendor/geb-mathlib/Geb/Mathlib/Data/PFunctor/Presheaf/Basic.lean
+diff --git a/vendor/geb-mathlib/Geb/Mathlib/Data/PFunctor/Slice/W.lean b/vendor/geb-mathlib/Geb/Mathlib/Data/PFunctor/Slice/W.lean
+index ca0f572..47e3658 100644
+--- a/vendor/geb-mathlib/Geb/Mathlib/Data/PFunctor/Slice/W.lean
++++ b/vendor/geb-mathlib/Geb/Mathlib/Data/PFunctor/Slice/W.lean
 @@ -3,6 +3,7 @@ Copyright (c) 2026 The geb-mathlib contributors. All rights reserved.
  Released under Apache 2.0 license as described in the file LICENSE.
  Authors: The geb-mathlib contributors
@@ -131,45 +197,29 @@ index b6b7479..140e6cc 100644
  module
  
  public import Geb.Mathlib.Data.PFunctor.Slice.Basic
-@@ -137,7 +138,6 @@ open CategoryTheory
+@@ -330,6 +331,7 @@ theorem elimData_valid {I : Type uI} (F : SlicePFunctor.{uA, uB, uI, uI} I I)
+     (w : F.toPFunctor.W) : (elimData F Y p g hg w).valid ↔ F.WValid w :=
+   WType.rec (motive := fun w => (elimData F Y p g hg w).valid ↔ F.WValid w)
+     (fun a f ih => by
++      beta_reduce
+       rw [F.wValid_mk, elimData_valid_mk]
+       exact and_congr (forall_congr' ih) (by simp only [OverInput, elimData_index]; rfl))
+     w
+diff --git a/vendor/geb-mathlib/Geb.lean b/vendor/geb-mathlib/Geb.lean
+index 5d37c79..9b07ec4 100644
+--- a/vendor/geb-mathlib/Geb.lean
++++ b/vendor/geb-mathlib/Geb.lean
+@@ -3,12 +3,12 @@ Copyright (c) 2026 The geb-mathlib contributors. All rights reserved.
+ Released under Apache 2.0 license as described in the file LICENSE.
+ Authors: The geb-mathlib contributors
+ -/
++-- Modified from geb-mathlib by scripts/geb-mathlib-backport.patch.
+ module -- shake: keep-all, shake: keep-downstream
  
- universe uI uJ uA uB uZ u v vI vJ
+ public import Geb.Mathlib
+ public import Geb.Cslib
+ public import Geb.Internal
+-import GebMeta
  
--set_option linter.checkUnivs false in
- /-- Operations of a presheaf-domain polynomial functor over `I`: a
- `SliceDomPFunctor` on `I`'s objects, with the contravariant `I`-action
- `restr` making each arity a presheaf on `I`. -/
-@@ -245,8 +245,7 @@ private theorem value_map {I : Type uI} [Category.{vI} I]
-     intro i i' f b
-     simp only [value_map]
-     refine (congrArg (fun w => α.app ⟨i'⟩ w) (x.2 f b)).trans ?_
--    simp only [← ConcreteCategory.comp_apply]
--    rw [α.naturality f.op]⟩
-+    exact FunctorToTypes.naturality _ _ α f.op _⟩
- 
- /-- Functoriality in the input presheaf: the identity transformation acts as
- the identity. -/
-@@ -275,7 +274,6 @@ theorem map_comp {I : Type uI} [Category.{vI} I] (F : PresheafDomPFunctorData.{u
- 
- end PresheafDomPFunctorData
- 
--set_option linter.checkUnivs false in
- /-- A presheaf-domain polynomial functor: operations together with a
- proof they are functorial. Its action is a functor `(Iᵒᵖ ⥤ Type) ⥤ Type`
- (packaged in `Presheaf.Functor`). -/
-@@ -288,7 +286,6 @@ structure PresheafDomPFunctor (I : Type uI) [Category.{vI} I] :
- 
- attribute [ext] PresheafDomPFunctorData PresheafDomPFunctor
- 
--set_option linter.checkUnivs false in
- /-- Operations of a presheaf polynomial functor `(Iᵒᵖ ⥤ Type) → (Jᵒᵖ ⥤ Type)`:
- the dom operations plus the tag leg `t` (via `SlicePFunctor`), the `J`-action
- `tagRestr` on shapes, and the arity reindexing `reindex`. -/
-@@ -381,7 +378,6 @@ structure IsFunctorial {I : Type uI} [Category.{vI} I] {J : Type uJ} [Category.{
- 
- end PresheafPFunctorData
- 
--set_option linter.checkUnivs false in
- /-- A presheaf polynomial functor: operations together with a proof they are
- functorial. Its action is a functor `(Iᵒᵖ ⥤ Type) ⥤ (Jᵒᵖ ⥤ Type)`. -/
- @[nolint checkUnivs]
+ /-!
+ # Geb root module

--- a/geb-lean/vendor/geb-mathlib/Geb/Mathlib.lean
+++ b/geb-lean/vendor/geb-mathlib/Geb/Mathlib.lean
@@ -6,6 +6,7 @@ Authors: The geb-mathlib contributors
 module
 
 public import Geb.Mathlib.Data
+public import Geb.Mathlib.CategoryTheory
 
 /-!
 # Geb.Mathlib — upstream-eligible content for mathlib4

--- a/geb-lean/vendor/geb-mathlib/Geb/Mathlib/CategoryTheory.lean
+++ b/geb-lean/vendor/geb-mathlib/Geb/Mathlib/CategoryTheory.lean
@@ -5,10 +5,8 @@ Authors: The geb-mathlib contributors
 -/
 module
 
-public import Geb.Mathlib.Data.PFunctor.Presheaf.Basic
-public import Geb.Mathlib.Data.PFunctor.Presheaf.Functor
-public import Geb.Mathlib.Data.PFunctor.Presheaf.W
+public import Geb.Mathlib.CategoryTheory.Grothendieck
 
 /-!
-# Presheaf — index
+# CategoryTheory — index
 -/

--- a/geb-lean/vendor/geb-mathlib/Geb/Mathlib/CategoryTheory/Grothendieck.lean
+++ b/geb-lean/vendor/geb-mathlib/Geb/Mathlib/CategoryTheory/Grothendieck.lean
@@ -1,0 +1,578 @@
+/-
+Copyright (c) 2026 The geb-mathlib contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The geb-mathlib contributors
+-/
+module
+
+public import Mathlib.CategoryTheory.Grothendieck
+public import Mathlib.CategoryTheory.Category.Cat.Op
+public import Mathlib.CategoryTheory.Comma.Over.Basic
+public import Mathlib.CategoryTheory.Whiskering
+
+/-!
+# Covariant and contravariant Grothendieck constructions
+
+For a functor `F : C ⥤ Cat`, mathlib's `CategoryTheory.Grothendieck F`
+is the covariant Grothendieck construction. This module adds:
+
+* a `Cat`-valued packaging of the covariant construction
+  (`Grothendieck.functorToCat`);
+* `GrothendieckOp F`, the covariant construction applied to the
+  oppositization `F ⋙ Cat.opFunctor`;
+* `CoGrothendieck G`, the contravariant Grothendieck construction of
+  `G : Cᵒᵖ ⥤ Cat`, defined as `(GrothendieckOp G)ᵒᵖ`, together with an
+  interface whose constructors and destructors use morphisms of `C`.
+
+## Main definitions
+
+* `CategoryTheory.Grothendieck.functorToCat`
+* `CategoryTheory.GrothendieckOp`
+* `CategoryTheory.CoGrothendieck`
+
+## Main statements
+
+* `GrothendieckOp.hom_ext` and `CoGrothendieck.hom_ext`
+* `GrothendieckOp.map_id_eq`/`map_comp_eq` and the `CoGrothendieck`
+  counterparts
+
+## Implementation notes
+
+`GrothendieckOp` and `CoGrothendieck` are semireducible `def` type
+synonyms, not `abbrev`s and not new structures: instance synthesis and
+object-level dot notation stop at the new names, while all round-trip
+lemmas hold by `rfl`. Morphism-level dot notation resolves through
+`Quiver.Hom` to `Grothendieck.Hom`'s own projections (whose op-side
+types make direction misuse a type error); the wrapper accessors
+`homBase`/`homFiber` are therefore free functions, used qualified or
+via `open`.
+
+Universe levels match the covariant construction exactly: for
+`F : C ⥤ Cat.{v₂, u₂}` with `C : Type u` and `Category.{v} C`, both
+`GrothendieckOp F` and `CoGrothendieck G` live in `Type (max u u₂)`
+with `Category.{max v v₂}` instances, since `ᵒᵖ` and `Cat.opFunctor`
+preserve universes. The packaged functors (`functor`, `functorToCat`)
+restrict to `E : Cat.{v, u}` with fibers in the same `Cat.{v, u}`,
+inherited from mathlib's `Grothendieck.functor`.
+
+`Cat` is a semireducible `def` (`Bundled Category`), not an `abbrev`,
+so a keyed `rw`/`simp` rewrite that must unify a generic `Cᵒᵖ`-shaped
+lemma (`unop_comp`, `eqToHom_unop`, `Grothendieck.id_fiber`,
+`Grothendieck.comp_fiber`) against a term routed through
+`Cat.opFunctor.obj`/`F.map _ |>.toFunctor` fails even though the two
+sides are definitionally equal. `GrothendieckOp.hom_ext`, `homFiber_id`, `homFiber_comp`, and
+`GrothendieckOp.homFiber_map_map` isolate a single `erw` step — which
+unifies at a higher transparency — to cross exactly that reducibility boundary; the
+surrounding steps stay on `rfl`/`rw`/`simp`.
+
+## References
+
+The contravariant Grothendieck construction is standard; see
+[Vistoli2008] and [JohnsonYau2021].
+
+## Tags
+
+Grothendieck construction, contravariant, opposite category, fibered
+category
+-/
+
+@[expose] public section
+
+universe u v u₂ v₂
+
+namespace CategoryTheory
+
+open Functor
+
+variable {C : Type u} [Category.{v} C]
+
+/-! ## Covariant construction: `Cat`-valued packaging -/
+
+namespace Grothendieck
+
+/-- The covariant Grothendieck construction as a functor to `Cat`:
+`Grothendieck.functor` followed by forgetting the projection to the
+base. -/
+def functorToCat {E : Cat.{v, u}} : (↑E ⥤ Cat.{v, u}) ⥤ Cat.{v, u} :=
+  Grothendieck.functor ⋙ Over.forget E
+
+/-- `functorToCat` sends a functor to the Grothendieck construction on it. -/
+@[simp]
+theorem functorToCat_obj {E : Cat.{v, u}} (F : ↑E ⥤ Cat.{v, u}) :
+    functorToCat.obj F = Cat.of (Grothendieck F) :=
+  rfl
+
+/-- `functorToCat` sends a natural transformation to the induced functor. -/
+@[simp]
+theorem functorToCat_map {E : Cat.{v, u}} {F F' : ↑E ⥤ Cat.{v, u}}
+    (α : F ⟶ F') : functorToCat.map α = (Grothendieck.map α).toCatHom :=
+  rfl
+
+end Grothendieck
+
+/-! ## The Grothendieck construction of an oppositized functor -/
+
+/-- The covariant Grothendieck construction applied to the
+oppositization of `F`: objects are pairs of a base object `c : C` and a
+fiber object of `F.obj c`, and morphisms reverse the fiber direction
+relative to `Grothendieck F`. -/
+def GrothendieckOp (F : C ⥤ Cat.{v₂, u₂}) : Type (max u u₂) :=
+  Grothendieck (F ⋙ Cat.opFunctor)
+
+namespace GrothendieckOp
+
+/-- The category structure on `GrothendieckOp F`, inherited from the
+underlying covariant Grothendieck construction. -/
+instance category (F : C ⥤ Cat.{v₂, u₂}) :
+    Category.{max v v₂} (GrothendieckOp F) :=
+  inferInstanceAs (Category (Grothendieck (F ⋙ Cat.opFunctor)))
+
+variable {F : C ⥤ Cat.{v₂, u₂}}
+
+/-- Construct an object of `GrothendieckOp F` from a base object and a
+fiber object. -/
+def mk (base : C) (fiber : F.obj base) : GrothendieckOp F :=
+  ⟨base, Opposite.op fiber⟩
+
+/-- The base object of an object of `GrothendieckOp F`. -/
+def base (X : GrothendieckOp F) : C :=
+  Grothendieck.base X
+
+/-- The fiber object of an object of `GrothendieckOp F`. -/
+def fiber (X : GrothendieckOp F) : F.obj X.base :=
+  Opposite.unop (Grothendieck.fiber X)
+
+/-- `mk` recovers the base component on the nose. -/
+@[simp]
+theorem base_mk (b : C) (f : F.obj b) : (mk b f).base = b :=
+  rfl
+
+/-- `mk` recovers the fiber component on the nose. -/
+@[simp]
+theorem fiber_mk (b : C) (f : F.obj b) : (mk b f).fiber = f :=
+  rfl
+
+/-- Every object of `GrothendieckOp F` is `mk` applied to its own base
+and fiber. -/
+@[simp]
+theorem mk_base_fiber (X : GrothendieckOp F) : mk X.base X.fiber = X :=
+  rfl
+
+/-- Construct a morphism of `GrothendieckOp F` from a base morphism and
+a fiber morphism. The fiber morphism runs from the target fiber to the
+pushforward of the source fiber — the reversal relative to
+`Grothendieck.Hom`. -/
+def homMk {X Y : GrothendieckOp F} (base : X.base ⟶ Y.base)
+    (fiber : Y.fiber ⟶ (F.map base).toFunctor.obj X.fiber) : X ⟶ Y :=
+  ⟨base, fiber.op⟩
+
+/-- The base morphism of a morphism of `GrothendieckOp F`. -/
+def homBase {X Y : GrothendieckOp F} (f : X ⟶ Y) : X.base ⟶ Y.base :=
+  Grothendieck.Hom.base f
+
+/-- The fiber morphism of a morphism of `GrothendieckOp F`. -/
+def homFiber {X Y : GrothendieckOp F} (f : X ⟶ Y) :
+    Y.fiber ⟶ (F.map (homBase f)).toFunctor.obj X.fiber :=
+  Quiver.Hom.unop (Grothendieck.Hom.fiber f)
+
+/-- `homMk` recovers the base component on the nose. -/
+@[simp]
+theorem homBase_homMk {X Y : GrothendieckOp F} (b : X.base ⟶ Y.base)
+    (φ : Y.fiber ⟶ (F.map b).toFunctor.obj X.fiber) :
+    homBase (homMk b φ) = b :=
+  rfl
+
+/-- `homMk` recovers the fiber component on the nose. -/
+@[simp]
+theorem homFiber_homMk {X Y : GrothendieckOp F} (b : X.base ⟶ Y.base)
+    (φ : Y.fiber ⟶ (F.map b).toFunctor.obj X.fiber) :
+    homFiber (homMk b φ) = φ :=
+  rfl
+
+/-- Every morphism of `GrothendieckOp F` is `homMk` applied to its own
+base and fiber components. -/
+@[simp]
+theorem homMk_base_fiber {X Y : GrothendieckOp F} (f : X ⟶ Y) :
+    homMk (homBase f) (homFiber f) = f :=
+  rfl
+
+/-- Two morphisms of `GrothendieckOp F` agree once their base
+components agree and their fiber components agree after transport
+along that agreement. -/
+@[ext (iff := false)]
+theorem hom_ext {X Y : GrothendieckOp F} (f g : X ⟶ Y)
+    (hbase : homBase f = homBase g)
+    (hfiber : homFiber f ≫ eqToHom (by rw [hbase]) = homFiber g) :
+    f = g := by
+  refine Grothendieck.ext f g hbase ?_
+  apply Quiver.Hom.unop_inj
+  erw [unop_comp, eqToHom_unop]
+  exact hfiber
+
+/-- `homBase` sends the identity morphism to the identity morphism. -/
+@[simp]
+theorem homBase_id (X : GrothendieckOp F) : homBase (𝟙 X) = 𝟙 X.base :=
+  rfl
+
+/-- `homFiber` of the identity morphism is the canonical transport
+isomorphism. -/
+@[simp]
+theorem homFiber_id (X : GrothendieckOp F) :
+    homFiber (𝟙 X) = eqToHom (by simp) := by
+  erw [homFiber, Grothendieck.id_fiber, eqToHom_unop]
+  rfl
+
+/-- `homBase` is functorial: it sends composition to composition. -/
+@[simp]
+theorem homBase_comp {X Y Z : GrothendieckOp F} (f : X ⟶ Y) (g : Y ⟶ Z) :
+    homBase (f ≫ g) = homBase f ≫ homBase g :=
+  rfl
+
+/-- `homFiber` of a composite is the composite of the fiber morphisms,
+transported along the base functoriality. -/
+@[simp]
+theorem homFiber_comp {X Y Z : GrothendieckOp F} (f : X ⟶ Y)
+    (g : Y ⟶ Z) :
+    homFiber (f ≫ g) =
+      homFiber g ≫ (F.map (homBase g)).toFunctor.map (homFiber f) ≫
+        eqToHom (by simp) := by
+  erw [homFiber, Grothendieck.comp_fiber, unop_comp, unop_comp, eqToHom_unop,
+    Functor.op_map, Category.assoc]
+  rfl
+
+/-- The projection `GrothendieckOp F ⥤ C` onto the base category. -/
+def forget (F : C ⥤ Cat.{v₂, u₂}) : GrothendieckOp F ⥤ C :=
+  Grothendieck.forget (F ⋙ Cat.opFunctor)
+
+/-- `forget` sends an object of `GrothendieckOp F` to its base object. -/
+@[simp]
+theorem forget_obj (X : GrothendieckOp F) : (forget F).obj X = X.base :=
+  rfl
+
+/-- `forget` sends a morphism of `GrothendieckOp F` to its base morphism. -/
+@[simp]
+theorem forget_map {X Y : GrothendieckOp F} (f : X ⟶ Y) :
+    (forget F).map f = homBase f :=
+  rfl
+
+/-- A natural transformation `α : F ⟶ F'` induces a functor
+`GrothendieckOp F ⥤ GrothendieckOp F'`. -/
+def map {F F' : C ⥤ Cat.{v₂, u₂}} (α : F ⟶ F') :
+    GrothendieckOp F ⥤ GrothendieckOp F' :=
+  Grothendieck.map (whiskerRight α Cat.opFunctor)
+
+/-- `map` sends `mk b f` to `mk b` applied to the pushforward of `f` along `α`. -/
+@[simp]
+theorem map_obj_mk {F F' : C ⥤ Cat.{v₂, u₂}} (α : F ⟶ F') (b : C)
+    (f : F.obj b) :
+    (map α).obj (mk b f) = mk b ((α.app b).toFunctor.obj f) :=
+  rfl
+
+/-- `map` leaves the base component of a morphism unchanged. -/
+@[simp]
+theorem homBase_map_map {F F' : C ⥤ Cat.{v₂, u₂}} (α : F ⟶ F')
+    {X Y : GrothendieckOp F} (f : X ⟶ Y) :
+    homBase ((map α).map f) = homBase f :=
+  rfl
+
+/-- `map` transports the fiber component of a morphism along `α`, up to the
+canonical isomorphism supplied by `α`'s naturality. -/
+@[simp]
+theorem homFiber_map_map {F F' : C ⥤ Cat.{v₂, u₂}} (α : F ⟶ F')
+    {X Y : GrothendieckOp F} (f : X ⟶ Y) :
+    homFiber ((map α).map f) =
+      (α.app Y.base).toFunctor.map (homFiber f) ≫
+        eqToHom (congrArg
+          (fun p : F.obj X.base ⟶ F'.obj Y.base =>
+            p.toFunctor.obj X.fiber)
+          (α.naturality (homBase f))) := by
+  simp only [map, homBase, homFiber, Grothendieck.map_map_fiber, Functor.comp_map,
+    Cat.Hom.comp_toFunctor]
+  erw [Functor.op_map, unop_comp, eqToHom_unop]
+  rfl
+
+/-- `map` sends the identity natural transformation to the identity functor. -/
+theorem map_id_eq (F : C ⥤ Cat.{v₂, u₂}) :
+    map (𝟙 F) = 𝟭 (GrothendieckOp F) := by
+  rw [map, whiskerRight_id']
+  exact Grothendieck.map_id_eq
+
+/-- `map` sends composition of natural transformations to composition of
+functors. -/
+theorem map_comp_eq {F F' F'' : C ⥤ Cat.{v₂, u₂}} (α : F ⟶ F')
+    (β : F' ⟶ F'') : map (α ≫ β) = map α ⋙ map β := by
+  rw [map, whiskerRight_comp]
+  exact Grothendieck.map_comp_eq _ _
+
+/-- `map (𝟙 F)` is the identity functor, as an isomorphism. -/
+def mapIdIso (F : C ⥤ Cat.{v₂, u₂}) : map (𝟙 F) ≅ 𝟭 (GrothendieckOp F) :=
+  eqToIso (map_id_eq F)
+
+/-- `map` sends composition of natural transformations to composition
+of functors, as an isomorphism. -/
+def mapCompIso {F F' F'' : C ⥤ Cat.{v₂, u₂}} (α : F ⟶ F')
+    (β : F' ⟶ F'') : map (α ≫ β) ≅ map α ⋙ map β :=
+  eqToIso (map_comp_eq α β)
+
+/-- The `GrothendieckOp` construction as a functor from `↑E ⥤ Cat` to
+the over category of `E` in `Cat`: post-compose with `Cat.opFunctor`,
+then apply mathlib's `Grothendieck.functor`. -/
+def functor {E : Cat.{v, u}} :
+    (↑E ⥤ Cat.{v, u}) ⥤ Over (T := Cat.{v, u}) E :=
+  (whiskeringRight ↑E Cat.{v, u} Cat.{v, u}).obj Cat.opFunctor ⋙
+    Grothendieck.functor
+
+/-- `functor` sends `F` to an over-object whose hom component is
+`forget F`. -/
+@[simp]
+theorem functor_obj_hom {E : Cat.{v, u}} (F : ↑E ⥤ Cat.{v, u}) :
+    (functor.obj F).hom = (forget F).toCatHom :=
+  rfl
+
+/-- The `GrothendieckOp` construction as a functor to `Cat`. -/
+def functorToCat {E : Cat.{v, u}} : (↑E ⥤ Cat.{v, u}) ⥤ Cat.{v, u} :=
+  functor ⋙ Over.forget E
+
+/-- `functorToCat` sends a functor to the `GrothendieckOp` construction
+on it. -/
+@[simp]
+theorem functorToCat_obj {E : Cat.{v, u}} (F : ↑E ⥤ Cat.{v, u}) :
+    functorToCat.obj F = Cat.of (GrothendieckOp F) :=
+  rfl
+
+end GrothendieckOp
+
+/-! ## The contravariant Grothendieck construction -/
+
+/-- The contravariant Grothendieck construction of `G : Cᵒᵖ ⥤ Cat`:
+the opposite category of `GrothendieckOp G`. Objects are pairs of
+`c : C` and an object of `G.obj (op c)`; a morphism `X ⟶ Y` consists of
+`β : X.base ⟶ Y.base` in `C` and a fiber morphism
+`X.fiber ⟶ (G.map β.op).toFunctor.obj Y.fiber`. -/
+def CoGrothendieck (G : Cᵒᵖ ⥤ Cat.{v₂, u₂}) : Type (max u u₂) :=
+  (GrothendieckOp G)ᵒᵖ
+
+namespace CoGrothendieck
+
+/-- The category structure on `CoGrothendieck G`, inherited from the
+opposite of `GrothendieckOp G`. -/
+instance category (G : Cᵒᵖ ⥤ Cat.{v₂, u₂}) :
+    Category.{max v v₂} (CoGrothendieck G) :=
+  inferInstanceAs (Category (GrothendieckOp G)ᵒᵖ)
+
+variable {G : Cᵒᵖ ⥤ Cat.{v₂, u₂}}
+
+/-- Construct an object of `CoGrothendieck G` from a base object and a
+fiber object. -/
+def mk (base : C) (fiber : G.obj (Opposite.op base)) :
+    CoGrothendieck G :=
+  Opposite.op (GrothendieckOp.mk (Opposite.op base) fiber)
+
+/-- The base object of an object of `CoGrothendieck G`, as an object
+of `C`. -/
+def base (X : CoGrothendieck G) : C :=
+  Opposite.unop (GrothendieckOp.base (Opposite.unop X))
+
+/-- The fiber object of an object of `CoGrothendieck G`. -/
+def fiber (X : CoGrothendieck G) : G.obj (Opposite.op X.base) :=
+  GrothendieckOp.fiber (Opposite.unop X)
+
+/-- `mk` recovers the base component on the nose. -/
+@[simp]
+theorem base_mk (b : C) (f : G.obj (Opposite.op b)) : (mk b f).base = b :=
+  rfl
+
+/-- `mk` recovers the fiber component on the nose. -/
+@[simp]
+theorem fiber_mk (b : C) (f : G.obj (Opposite.op b)) :
+    (mk b f).fiber = f :=
+  rfl
+
+/-- Every object of `CoGrothendieck G` is `mk` applied to its own base
+and fiber. -/
+@[simp]
+theorem mk_base_fiber (X : CoGrothendieck G) : mk X.base X.fiber = X :=
+  rfl
+
+/-- Construct a morphism of `CoGrothendieck G` from a base morphism in
+`C` and a fiber morphism. -/
+def homMk {X Y : CoGrothendieck G} (base : X.base ⟶ Y.base)
+    (fiber : X.fiber ⟶ (G.map base.op).toFunctor.obj Y.fiber) :
+    X ⟶ Y :=
+  Quiver.Hom.op (GrothendieckOp.homMk base.op fiber)
+
+/-- The base morphism of a morphism of `CoGrothendieck G`, as a
+morphism of `C`. -/
+def homBase {X Y : CoGrothendieck G} (f : X ⟶ Y) : X.base ⟶ Y.base :=
+  Quiver.Hom.unop (GrothendieckOp.homBase (Quiver.Hom.unop f))
+
+/-- The fiber morphism of a morphism of `CoGrothendieck G`. -/
+def homFiber {X Y : CoGrothendieck G} (f : X ⟶ Y) :
+    X.fiber ⟶ (G.map (homBase f).op).toFunctor.obj Y.fiber :=
+  GrothendieckOp.homFiber (Quiver.Hom.unop f)
+
+/-- `homMk` recovers the base component on the nose. -/
+@[simp]
+theorem homBase_homMk {X Y : CoGrothendieck G} (b : X.base ⟶ Y.base)
+    (φ : X.fiber ⟶ (G.map b.op).toFunctor.obj Y.fiber) :
+    homBase (homMk b φ) = b :=
+  rfl
+
+/-- `homMk` recovers the fiber component on the nose. -/
+@[simp]
+theorem homFiber_homMk {X Y : CoGrothendieck G} (b : X.base ⟶ Y.base)
+    (φ : X.fiber ⟶ (G.map b.op).toFunctor.obj Y.fiber) :
+    homFiber (homMk b φ) = φ :=
+  rfl
+
+/-- Every morphism of `CoGrothendieck G` is `homMk` applied to its own
+base and fiber components. -/
+@[simp]
+theorem homMk_base_fiber {X Y : CoGrothendieck G} (f : X ⟶ Y) :
+    homMk (homBase f) (homFiber f) = f :=
+  rfl
+
+/-- Two morphisms of `CoGrothendieck G` agree once their base
+components agree and their fiber components agree after transport
+along that agreement. -/
+@[ext (iff := false)]
+theorem hom_ext {X Y : CoGrothendieck G} (f g : X ⟶ Y)
+    (hbase : homBase f = homBase g)
+    (hfiber : homFiber f ≫ eqToHom (by rw [hbase]) = homFiber g) :
+    f = g := by
+  apply Quiver.Hom.unop_inj
+  refine GrothendieckOp.hom_ext _ _ (Quiver.Hom.unop_inj hbase) ?_
+  exact hfiber
+
+/-- `homBase` sends the identity morphism to the identity morphism. -/
+@[simp]
+theorem homBase_id (X : CoGrothendieck G) : homBase (𝟙 X) = 𝟙 X.base :=
+  rfl
+
+/-- `homFiber` of the identity morphism is the canonical transport
+isomorphism. -/
+@[simp]
+theorem homFiber_id (X : CoGrothendieck G) :
+    homFiber (𝟙 X) = eqToHom (by simp) :=
+  GrothendieckOp.homFiber_id (Opposite.unop X)
+
+/-- `homBase` is functorial: it sends composition to composition. -/
+@[simp]
+theorem homBase_comp {X Y Z : CoGrothendieck G} (f : X ⟶ Y)
+    (g : Y ⟶ Z) : homBase (f ≫ g) = homBase f ≫ homBase g :=
+  rfl
+
+/-- `homFiber` of a composite is the composite of the fiber morphisms,
+transported along the base functoriality. -/
+@[simp]
+theorem homFiber_comp {X Y Z : CoGrothendieck G} (f : X ⟶ Y)
+    (g : Y ⟶ Z) :
+    homFiber (f ≫ g) =
+      homFiber f ≫ (G.map (homBase f).op).toFunctor.map (homFiber g) ≫
+        eqToHom (by simp) :=
+  GrothendieckOp.homFiber_comp (Quiver.Hom.unop g) (Quiver.Hom.unop f)
+
+/-- The projection `CoGrothendieck G ⥤ C` onto the base category. -/
+def forget (G : Cᵒᵖ ⥤ Cat.{v₂, u₂}) : CoGrothendieck G ⥤ C :=
+  (GrothendieckOp.forget G).leftOp
+
+/-- `forget` sends an object of `CoGrothendieck G` to its base object. -/
+@[simp]
+theorem forget_obj (X : CoGrothendieck G) : (forget G).obj X = X.base :=
+  rfl
+
+/-- `forget` sends a morphism of `CoGrothendieck G` to its base morphism. -/
+@[simp]
+theorem forget_map {X Y : CoGrothendieck G} (f : X ⟶ Y) :
+    (forget G).map f = homBase f :=
+  rfl
+
+/-- A natural transformation `α : G ⟶ G'` induces a functor
+`CoGrothendieck G ⥤ CoGrothendieck G'` (covariantly in `α`). -/
+def map {G G' : Cᵒᵖ ⥤ Cat.{v₂, u₂}} (α : G ⟶ G') :
+    CoGrothendieck G ⥤ CoGrothendieck G' :=
+  (GrothendieckOp.map α).op
+
+/-- `map` sends `mk b f` to `mk b` applied to the pushforward of `f` along `α`. -/
+@[simp]
+theorem map_obj_mk {G G' : Cᵒᵖ ⥤ Cat.{v₂, u₂}} (α : G ⟶ G') (b : C)
+    (f : G.obj (Opposite.op b)) :
+    (map α).obj (mk b f) =
+      mk b ((α.app (Opposite.op b)).toFunctor.obj f) :=
+  rfl
+
+/-- `map` leaves the base component of a morphism unchanged. -/
+@[simp]
+theorem homBase_map_map {G G' : Cᵒᵖ ⥤ Cat.{v₂, u₂}} (α : G ⟶ G')
+    {X Y : CoGrothendieck G} (f : X ⟶ Y) :
+    homBase ((map α).map f) = homBase f :=
+  rfl
+
+/-- `map` transports the fiber component of a morphism along `α`, up to the
+canonical isomorphism supplied by `α`'s naturality. -/
+@[simp]
+theorem homFiber_map_map {G G' : Cᵒᵖ ⥤ Cat.{v₂, u₂}} (α : G ⟶ G')
+    {X Y : CoGrothendieck G} (f : X ⟶ Y) :
+    homFiber ((map α).map f) =
+      (α.app (Opposite.op X.base)).toFunctor.map (homFiber f) ≫
+        eqToHom (congrArg
+          (fun p : G.obj (Opposite.op Y.base) ⟶
+              G'.obj (Opposite.op X.base) =>
+            p.toFunctor.obj Y.fiber)
+          (α.naturality ((homBase f).op))) :=
+  GrothendieckOp.homFiber_map_map α (Quiver.Hom.unop f)
+
+/-- `map` sends the identity natural transformation to the identity functor. -/
+theorem map_id_eq (G : Cᵒᵖ ⥤ Cat.{v₂, u₂}) :
+    map (𝟙 G) = 𝟭 (CoGrothendieck G) := by
+  rw [map, GrothendieckOp.map_id_eq]
+  rfl
+
+/-- `map` sends composition of natural transformations to composition of
+functors. -/
+theorem map_comp_eq {G G' G'' : Cᵒᵖ ⥤ Cat.{v₂, u₂}} (α : G ⟶ G')
+    (β : G' ⟶ G'') : map (α ≫ β) = map α ⋙ map β := by
+  rw [map, GrothendieckOp.map_comp_eq]
+  rfl
+
+/-- `map (𝟙 G)` is the identity functor, as an isomorphism. -/
+def mapIdIso (G : Cᵒᵖ ⥤ Cat.{v₂, u₂}) : map (𝟙 G) ≅ 𝟭 (CoGrothendieck G) :=
+  eqToIso (map_id_eq G)
+
+/-- `map` sends composition of natural transformations to composition
+of functors, as an isomorphism. -/
+def mapCompIso {G G' G'' : Cᵒᵖ ⥤ Cat.{v₂, u₂}} (α : G ⟶ G')
+    (β : G' ⟶ G'') : map (α ≫ β) ≅ map α ⋙ map β :=
+  eqToIso (map_comp_eq α β)
+
+/-- The `CoGrothendieck` construction as a functor from `(↑E)ᵒᵖ ⥤ Cat`
+to the over category of `E` in `Cat`: apply `GrothendieckOp.functor`
+over the base `(↑E)ᵒᵖ`, oppositize the total category with
+`Over.post Cat.opFunctor`, and retarget along `unopUnop`. -/
+def functor {E : Cat.{v, u}} :
+    ((↑E)ᵒᵖ ⥤ Cat.{v, u}) ⥤ Over (T := Cat.{v, u}) E :=
+  GrothendieckOp.functor (E := Cat.of (↑E)ᵒᵖ) ⋙
+    Over.post Cat.opFunctor ⋙ Over.map (unopUnop ↑E).toCatHom
+
+/-- `functor` sends `G` to an over-object whose hom component is
+`forget G`. -/
+@[simp]
+theorem functor_obj_hom {E : Cat.{v, u}} (G : (↑E)ᵒᵖ ⥤ Cat.{v, u}) :
+    (functor.obj G).hom = (forget G).toCatHom :=
+  rfl
+
+/-- The `CoGrothendieck` construction as a functor to `Cat`. -/
+def functorToCat {E : Cat.{v, u}} :
+    ((↑E)ᵒᵖ ⥤ Cat.{v, u}) ⥤ Cat.{v, u} :=
+  functor ⋙ Over.forget E
+
+/-- `functorToCat` sends a functor to the `CoGrothendieck` construction
+on it. -/
+@[simp]
+theorem functorToCat_obj {E : Cat.{v, u}} (G : (↑E)ᵒᵖ ⥤ Cat.{v, u}) :
+    functorToCat.obj G = Cat.of (CoGrothendieck G) :=
+  rfl
+
+end CoGrothendieck
+
+end CategoryTheory

--- a/geb-lean/vendor/geb-mathlib/Geb/Mathlib/Data/PFunctor/Presheaf/Basic.lean
+++ b/geb-lean/vendor/geb-mathlib/Geb/Mathlib/Data/PFunctor/Presheaf/Basic.lean
@@ -17,7 +17,7 @@ public import Mathlib.CategoryTheory.Types.Basic
 A presheaf-domain polynomial functor extends a `SliceDomPFunctor` on the
 objects of a category `I` with a contravariant `I`-action on arities: for
 each shape `a`, the assignment `i ↦ Direction a i` extends to a presheaf on
-`I` via a restriction map `restr a f`. This file is the p.r.a. (parametric
+`I` via a restriction map `directionRestr a f`. This file is the p.r.a. (parametric
 right adjoint) construction restricted to the domain side; the full
 categorical packaging appears in sibling modules. Every declaration here is
 `Classical.choice`-free; the categorical packaging that pulls in
@@ -25,21 +25,21 @@ categorical packaging appears in sibling modules. Every declaration here is
 
 The design uses the option-(A) fibre encoding: directions over `i` are
 `SliceDomPFunctor.Direction a i = Subtype (DirectionOver a i)`, the fibre of
-the constraint leg `sCurried a` over `i`. The `restr` field reindexes these
-fibres contravariantly.
+the direction-input map `rCurried a` over `i`. The `directionRestr` field
+reindexes these fibres contravariantly.
 
 ## Main definitions
 
 * `PresheafDomPFunctorData` — the operations: a `SliceDomPFunctor` with a
-  restriction map `restr`.
-* `PresheafDomPFunctorData.RestrId` / `RestrComp` — named law `Prop`s.
+  restriction map `directionRestr`.
+* `PresheafDomPFunctorData.DirectionRestrId` / `DirectionRestrComp` — named law `Prop`s.
 * `PresheafDomPFunctorData.IsFunctorial` — the functor laws bundled.
 * `PresheafDomPFunctorData.elemProj` — projection from the presheaf's elements
   `Σ i, Z.obj ⟨i⟩` to the base `I`.
 * `PresheafDomPFunctorData.value` — the `Z`-value the assignment gives a
   direction.
 * `PresheafDomPFunctorData.IsNatural` — naturality of the direction
-  assignment with respect to `restr` and `Z.map`.
+  assignment with respect to `directionRestr` and `Z.map`.
 * `PresheafDomPFunctorData.obj` — the functor's value on a presheaf `Z`.
 * `PresheafDomPFunctorData.elemMap` — the action of a presheaf morphism `α` on
   the categories of elements, `el(Z) ⟶ el(Z')`.
@@ -47,11 +47,11 @@ fibres contravariantly.
   (the bare `NatTrans`).
 * `PresheafDomPFunctor` — the bundle: operations with a functoriality proof.
 * `PresheafPFunctorData` — the full operations: the dom operations and the
-  tag leg, with the `J`-action `tagRestr` on shapes and the arity reindexing
-  `reindex`.
-* `PresheafPFunctorData.TagRestrId` / `TagRestrComp` / `ReindexNaturality` /
+  shape-output map, with the `J`-action `shapeRestr` on shapes and the arity
+  reindexing `reindex`.
+* `PresheafPFunctorData.ShapeRestrId` / `ShapeRestrComp` / `ReindexNaturality` /
   `ReindexId` / `ReindexComp` — the named `J`-side law `Prop`s. `ReindexId`
-  and `ReindexComp` are parameterized on the relevant `tagRestr` law, whose
+  and `ReindexComp` are parameterized on the relevant `shapeRestr` law, whose
   content supplies the non-definitional source-type transport.
 * `PresheafPFunctorData.IsFunctorial` — the full functor laws bundled.
 * `PresheafPFunctor` — the full bundle: operations with a functoriality proof.
@@ -68,22 +68,24 @@ fibres contravariantly.
   domain-restricted action in the input presheaf.
 * `PresheafPFunctor.map_objRestr` — the domain map is natural with respect
   to the output presheaf's restriction maps.
+* `PresheafPFunctor.objRestrElt_id` / `objRestrElt_comp` — the identity and
+  composition laws of the element-level restriction `objRestrElt`.
 
 ## Notation
 
 The declaration docstrings use the parametric-right-adjoint notation of
 [Weber2007]:
 
-* `T1` — the shape presheaf `j ↦ Shape j` on `J`, with `tagRestr` as its
+* `T1` — the shape presheaf `j ↦ Shape j` on `J`, with `shapeRestr` as its
   restriction maps.
 * `E_T(a)` — the arity presheaf `i ↦ Direction a.1 i` of a shape `a` on `I`,
-  with `restr` as its restriction maps.
+  with `directionRestr` as its restriction maps.
 * `el(T1)` — the category of elements of `T1`: objects are pairs `(j, a)` with
   `a : Shape j`. As `T1` is a presheaf, its elements vary contravariantly, so a
   morphism `(j, a) ⟶ (j', a')` is backed by a `J`-morphism `g : j' ⟶ j` (the
-  opposite direction) with `tagRestr g a = a'`. The arity assignment `a ↦ E_T(a)`
+  opposite direction) with `shapeRestr g a = a'`. The arity assignment `a ↦ E_T(a)`
   is therefore contravariant on `el(T1)` (a functor on `el(T1)ᵒᵖ`); `reindex g a`
-  is its action, the presheaf morphism `E_T(tagRestr g a) ⟶ E_T(a)`.
+  is its action, the presheaf morphism `E_T(shapeRestr g a) ⟶ E_T(a)`.
 
 ## Implementation notes
 
@@ -96,7 +98,7 @@ later diamond via `PresheafDomPFunctorData` and `SlicePFunctor`); pinned
 references to it elsewhere take the synthesized order
 `PresheafDomPFunctorData.{uI, uA, uB, vI}`.
 
-The `linter.checkUnivs false` option and `@[nolint checkUnivs]` suppress the
+The `@[nolint checkUnivs]` attribute suppresses the
 `checkUnivs` warning on the inherited `PFunctor` universes `uA`/`uB`: they are
 the two `Type` universes of the `PFunctor` parent and appear only together in
 the result `max`, so the linter flags them as a pair that could be unified. The
@@ -109,13 +111,13 @@ the same situation mathlib suppresses in `PFunctor`.
 SlicePFunctor.{uA, uB, uI, uJ} I J`,
 which shares the single `SliceDomPFunctor` parent. The `reindex` laws
 `ReindexId` / `ReindexComp` are stated in homogeneous-`Eq` form, parameterized
-on a `tagRestr` law, rather than as bare `Prop`s: comparing `reindex` along
+on a `shapeRestr` law, rather than as bare `Prop`s: comparing `reindex` along
 `𝟙` (resp. a composite) with the identity (resp. the composite of `reindex`es)
 requires a source-type transport whose target equality
-(`tagRestr (𝟙 j) a = a`, resp. `tagRestr (h ≫ g) a = tagRestr h (tagRestr g a)`)
-is `TagRestrId` (resp. `TagRestrComp`) content, not definitional. They are
+(`shapeRestr (𝟙 j) a = a`, resp. `shapeRestr (h ≫ g) a = shapeRestr h (shapeRestr g a)`)
+is `ShapeRestrId` (resp. `ShapeRestrComp`) content, not definitional. They are
 therefore parameterized on that law and apply it via `cast`; `IsFunctorial`
-supplies the proof from its earlier `tagRestr_id` / `tagRestr_comp` fields. A
+supplies the proof from its earlier `shapeRestr_id` / `shapeRestr_comp` fields. A
 heterogeneous-`Eq` formulation would avoid the parameter at the cost of
 `rw`-convenience and mathlib idiom.
 
@@ -136,41 +138,42 @@ public section
 
 open CategoryTheory
 
-universe uI uJ uA uB uZ u v vI vJ
+universe uI uJ uA uB uZ u v vI vJ uX
 
 /-- Operations of a presheaf-domain polynomial functor over `I`: a
 `SliceDomPFunctor` on `I`'s objects, with the contravariant `I`-action
-`restr` making each arity a presheaf on `I`. -/
+`directionRestr` making each arity a presheaf on `I`. -/
 @[nolint checkUnivs]
 structure PresheafDomPFunctorData (I : Type uI) [Category.{vI} I] :
     Type (max (uA + 1) (uB + 1) uI vI)
     extends SliceDomPFunctor.{uA, uB} I where
   /-- The arity-presheaf restriction: for a morphism `i' ⟶ i`, reindex
   directions of shape `a` over `i` to directions over `i'`. -/
-  restr : ∀ (a : toPFunctor.A) ⦃i i' : I⦄, (i' ⟶ i) →
+  directionRestr : ∀ (a : toPFunctor.A) ⦃i i' : I⦄, (i' ⟶ i) →
       toSliceDomPFunctor.Direction a i → toSliceDomPFunctor.Direction a i'
 
 namespace PresheafDomPFunctorData
 
-/-- `restr` preserves identities. -/
-@[expose] def RestrId {I : Type uI} [Category.{vI} I]
+/-- `directionRestr` preserves identities. -/
+@[expose] def DirectionRestrId {I : Type uI} [Category.{vI} I]
     (F : PresheafDomPFunctorData.{uI, uA, uB, vI} I) : Prop :=
-  ∀ (a : F.A) (i : I), F.restr a (𝟙 i) = id
+  ∀ (a : F.A) (i : I), F.directionRestr a (𝟙 i) = id
 
-/-- `restr` reverses composition: `restr a (g ≫ f) = restr a g ∘ restr a f`. -/
-@[expose] def RestrComp {I : Type uI} [Category.{vI} I]
+/-- `directionRestr` reverses composition: `directionRestr a (g ≫ f) = directionRestr a g ∘
+directionRestr a f`. -/
+@[expose] def DirectionRestrComp {I : Type uI} [Category.{vI} I]
     (F : PresheafDomPFunctorData.{uI, uA, uB, vI} I) : Prop :=
   ∀ (a : F.A) ⦃i i' i'' : I⦄ (f : i' ⟶ i) (g : i'' ⟶ i'),
-      F.restr a (g ≫ f) = F.restr a g ∘ F.restr a f
+      F.directionRestr a (g ≫ f) = F.directionRestr a g ∘ F.directionRestr a f
 
-/-- The arities form presheaves on `I`: `restr` satisfies the functor
+/-- The arities form presheaves on `I`: `directionRestr` satisfies the functor
 laws. -/
 structure IsFunctorial {I : Type uI} [Category.{vI} I]
     (F : PresheafDomPFunctorData.{uI, uA, uB, vI} I) : Prop where
-  /-- Identity law for `restr`. -/
-  restr_id : F.RestrId
-  /-- Composition law for `restr`. -/
-  restr_comp : F.RestrComp
+  /-- Identity law for `directionRestr`. -/
+  directionRestr_id : F.DirectionRestrId
+  /-- Composition law for `directionRestr`. -/
+  directionRestr_comp : F.DirectionRestrComp
 
 /-- Total-space projection of a presheaf `Z` on `I` to objects of `I`. -/
 @[expose] def elemProj {I : Type uI} [Category.{vI} I] (Z : Iᵒᵖ ⥤ Type uZ) :
@@ -189,12 +192,12 @@ compatibility of `x` and the constraint condition on `b` to `Z.obj ⟨i⟩`. -/
 
 /-- The direction-assignment of `x` is a natural transformation `E_T(a) ⟶ Z`,
 where `a := x.1.1`: for every `f : i' ⟶ i` and direction `b` over `i`, the
-component assigned to `restr a f b` equals `Z.map f.op` applied to `value x b`. -/
+component assigned to `directionRestr a f b` equals `Z.map f.op` applied to `value x b`. -/
 @[expose] def IsNatural {I : Type uI} [Category.{vI} I]
     (F : PresheafDomPFunctorData.{uI, uA, uB, vI} I)
     {Z : Iᵒᵖ ⥤ Type uZ} (x : F.toSliceDomPFunctor.Obj (elemProj Z)) : Prop :=
   ∀ ⦃i i' : I⦄ (f : i' ⟶ i) (b : F.toSliceDomPFunctor.Direction x.1.1 i),
-    F.value x (F.restr x.1.1 f b) = Z.map f.op (F.value x b)
+    F.value x (F.directionRestr x.1.1 f b) = Z.map f.op (F.value x b)
 
 /-- The value of the presheaf-domain functor on `Z`: the `IsNatural` subtype
 of the slice object on the total-space projection `elemProj Z`. -/
@@ -266,8 +269,8 @@ theorem map_comp {I : Type uI} [Category.{vI} I] (F : PresheafDomPFunctorData.{u
           ← Category.assoc]) } =
       F.map β ∘ F.map α := by
   funext x
-  exact Subtype.ext (congrFun (F.toSliceDomPFunctor.map_comp (p := elemProj Z) (q := elemProj Z')
-    (r := elemProj Z'')
+  exact Subtype.ext (congrFun (F.toSliceDomPFunctor.map_comp (p := elemProj Z) (p' := elemProj Z')
+    (p'' := elemProj Z'')
     (elemMap α)
     (elemMap β)
     rfl rfl) x.1)
@@ -287,94 +290,95 @@ structure PresheafDomPFunctor (I : Type uI) [Category.{vI} I] :
 attribute [ext] PresheafDomPFunctorData PresheafDomPFunctor
 
 /-- Operations of a presheaf polynomial functor `(Iᵒᵖ ⥤ Type) → (Jᵒᵖ ⥤ Type)`:
-the dom operations plus the tag leg `t` (via `SlicePFunctor`), the `J`-action
-`tagRestr` on shapes, and the arity reindexing `reindex`. -/
+the dom operations plus the shape-output map `q` (via `SlicePFunctor`), the
+`J`-action `shapeRestr` on shapes, and the arity reindexing `reindex`. -/
 @[nolint checkUnivs]
 structure PresheafPFunctorData (I : Type uI) [Category.{vI} I]
     (J : Type uJ) [Category.{vJ} J] : Type (max (uA + 1) (uB + 1) uI uJ vI vJ)
     extends PresheafDomPFunctorData.{uI, uA, uB, vI} I, SlicePFunctor.{uA, uB, uI, uJ} I J where
   /-- The shape-presheaf restriction: for `g : j' ⟶ j`, reindex shapes over
   `j` to shapes over `j'`. -/
-  tagRestr : ∀ ⦃j j' : J⦄ (_g : j' ⟶ j),
+  shapeRestr : ∀ ⦃j j' : J⦄ (_g : j' ⟶ j),
       toSlicePFunctor.Shape j → toSlicePFunctor.Shape j'
   /-- The arity reindexing along a `J`-morphism: a presheaf morphism
-  `E_T(tagRestr g a) ⟶ E_T(a)`. -/
+  `E_T(shapeRestr g a) ⟶ E_T(a)`. -/
   reindex : ∀ ⦃j j' : J⦄ (g : j' ⟶ j) (a : toSlicePFunctor.Shape j) ⦃i : I⦄,
-      toSliceDomPFunctor.Direction (tagRestr g a).1 i →
+      toSliceDomPFunctor.Direction (shapeRestr g a).1 i →
         toSliceDomPFunctor.Direction a.1 i
 
-/-- The tag-leg view of the operations: the shared `SliceDomPFunctor` together
-with the tag leg `t`. The diamond merges the `SliceDomPFunctor` parent, so this
-view shares its components with `toPresheafDomPFunctorData`. -/
+/-- The shape-output-map view of the operations: the shared `SliceDomPFunctor`
+together with the shape-output map `q`. The diamond merges the
+`SliceDomPFunctor` parent, so this view shares its components with
+`toPresheafDomPFunctorData`. -/
 add_decl_doc PresheafPFunctorData.toSlicePFunctor
 
 namespace PresheafPFunctorData
 
-/-- `tagRestr` preserves identities. -/
-@[expose] def TagRestrId {I : Type uI} [Category.{vI} I] {J : Type uJ} [Category.{vJ} J]
+/-- `shapeRestr` preserves identities. -/
+@[expose] def ShapeRestrId {I : Type uI} [Category.{vI} I] {J : Type uJ} [Category.{vJ} J]
     (F : PresheafPFunctorData.{uI, uJ, uA, uB, vI, vJ} I J) : Prop :=
-  ∀ (j : J), F.tagRestr (𝟙 j) = id
+  ∀ (j : J), F.shapeRestr (𝟙 j) = id
 
-/-- `tagRestr` reverses composition: `tagRestr (h ≫ g) = tagRestr h ∘ tagRestr g`. -/
-@[expose] def TagRestrComp {I : Type uI} [Category.{vI} I] {J : Type uJ} [Category.{vJ} J]
+/-- `shapeRestr` reverses composition: `shapeRestr (h ≫ g) = shapeRestr h ∘ shapeRestr g`. -/
+@[expose] def ShapeRestrComp {I : Type uI} [Category.{vI} I] {J : Type uJ} [Category.{vJ} J]
     (F : PresheafPFunctorData.{uI, uJ, uA, uB, vI, vJ} I J) : Prop :=
   ∀ ⦃j j' j'' : J⦄ (g : j' ⟶ j) (h : j'' ⟶ j'),
-      F.tagRestr (h ≫ g) = F.tagRestr h ∘ F.tagRestr g
+      F.shapeRestr (h ≫ g) = F.shapeRestr h ∘ F.shapeRestr g
 
-/-- Each `reindex g a` commutes with `restr` (a presheaf morphism
-`E_T(tagRestr g a) ⟶ E_T(a)`): for `f : i' ⟶ i`,
-`restr a.1 f ∘ reindex g a = reindex g a ∘ restr (tagRestr g a).1 f`.
-Ordinary fibre maps only; no `tagRestr` transport. -/
+/-- Each `reindex g a` commutes with `directionRestr` (a presheaf morphism
+`E_T(shapeRestr g a) ⟶ E_T(a)`): for `f : i' ⟶ i`,
+`directionRestr a.1 f ∘ reindex g a = reindex g a ∘ directionRestr (shapeRestr g a).1 f`.
+Ordinary fibre maps only; no `shapeRestr` transport. -/
 @[expose] def ReindexNaturality {I : Type uI} [Category.{vI} I] {J : Type uJ} [Category.{vJ} J]
     (F : PresheafPFunctorData.{uI, uJ, uA, uB, vI, vJ} I J) : Prop :=
   ∀ ⦃j j' : J⦄ (g : j' ⟶ j) (a : F.Shape j) ⦃i i' : I⦄ (f : i' ⟶ i),
-    F.restr a.1 f ∘ F.reindex g a (i := i) =
-      F.reindex g a (i := i') ∘ F.restr (F.tagRestr g a).1 f
+    F.directionRestr a.1 f ∘ F.reindex g a (i := i) =
+      F.reindex g a (i := i') ∘ F.directionRestr (F.shapeRestr g a).1 f
 
 /-- `reindex (𝟙 j) a` is the identity, modulo the transport of its source
-along `TagRestrId` at `j` (`tagRestr (𝟙 j) a = a`). The transport is the
+along `ShapeRestrId` at `j` (`shapeRestr (𝟙 j) a = a`). The transport is the
 `cast` of `b` along `congrArg (fun s => Direction s.1 i) (congrFun (hti j) a)`.
 Parameterized on the identity law `hti` because that source-type equality is
 not definitional. -/
 @[expose] def ReindexId {I : Type uI} [Category.{vI} I] {J : Type uJ} [Category.{vJ} J]
-    (F : PresheafPFunctorData.{uI, uJ, uA, uB, vI, vJ} I J) (hti : F.TagRestrId) : Prop :=
-  ∀ ⦃j : J⦄ (a : F.Shape j) ⦃i : I⦄ (b : F.Direction (F.tagRestr (𝟙 j) a).1 i),
+    (F : PresheafPFunctorData.{uI, uJ, uA, uB, vI, vJ} I J) (hti : F.ShapeRestrId) : Prop :=
+  ∀ ⦃j : J⦄ (a : F.Shape j) ⦃i : I⦄ (b : F.Direction (F.shapeRestr (𝟙 j) a).1 i),
     F.reindex (𝟙 j) a b =
       cast (congrArg (fun s : F.Shape j => F.Direction s.1 i) (congrFun (hti j) a)) b
 
 /-- For `g : j' ⟶ j`, `h : j'' ⟶ j'`,
-`reindex (h ≫ g) a = reindex g a ∘ reindex h (tagRestr g a)` (outer factor the
-`g` leg), modulo the transport of the source along `TagRestrComp`
-(`tagRestr (h ≫ g) a = tagRestr h (tagRestr g a)`). The transport is the `cast`
+`reindex (h ≫ g) a = reindex g a ∘ reindex h (shapeRestr g a)` (`g` is the
+outer factor), modulo the transport of the source along `ShapeRestrComp`
+(`shapeRestr (h ≫ g) a = shapeRestr h (shapeRestr g a)`). The transport is the `cast`
 of `b` along `congrArg (fun s => Direction s.1 i) (congrFun (htc g h) a)`.
 Parameterized on the composition law `htc` because that source-type equality is
 not definitional. -/
 @[expose] def ReindexComp {I : Type uI} [Category.{vI} I] {J : Type uJ} [Category.{vJ} J]
-    (F : PresheafPFunctorData.{uI, uJ, uA, uB, vI, vJ} I J) (htc : F.TagRestrComp) : Prop :=
+    (F : PresheafPFunctorData.{uI, uJ, uA, uB, vI, vJ} I J) (htc : F.ShapeRestrComp) : Prop :=
   ∀ ⦃j j' j'' : J⦄ (g : j' ⟶ j) (h : j'' ⟶ j') (a : F.Shape j) ⦃i : I⦄
-    (b : F.Direction (F.tagRestr (h ≫ g) a).1 i),
+    (b : F.Direction (F.shapeRestr (h ≫ g) a).1 i),
     F.reindex (h ≫ g) a b =
-      F.reindex g a (F.reindex h (F.tagRestr g a)
+      F.reindex g a (F.reindex h (F.shapeRestr g a)
         (cast (congrArg (fun s : F.Shape j'' => F.Direction s.1 i)
           (congrFun (htc g h) a)) b))
 
 /-- All functor laws: the dom laws plus the `J`-side laws making `T1` a
-presheaf and `E_T` a functor on `el(T1)`. The `tagRestr` laws precede the
+presheaf and `E_T` a functor on `el(T1)`. The `shapeRestr` laws precede the
 `reindex` laws because `reindex_id` / `reindex_comp` are stated relative to
-`tagRestr_id` / `tagRestr_comp`. -/
+`shapeRestr_id` / `shapeRestr_comp`. -/
 structure IsFunctorial {I : Type uI} [Category.{vI} I] {J : Type uJ} [Category.{vJ} J]
     (F : PresheafPFunctorData.{uI, uJ, uA, uB, vI, vJ} I J) : Prop
     extends F.toPresheafDomPFunctorData.IsFunctorial where
-  /-- Identity law for `tagRestr`. -/
-  tagRestr_id : F.TagRestrId
-  /-- Composition law for `tagRestr`. -/
-  tagRestr_comp : F.TagRestrComp
-  /-- `reindex` is a presheaf morphism (commutes with `restr`). -/
+  /-- Identity law for `shapeRestr`. -/
+  shapeRestr_id : F.ShapeRestrId
+  /-- Composition law for `shapeRestr`. -/
+  shapeRestr_comp : F.ShapeRestrComp
+  /-- `reindex` is a presheaf morphism (commutes with `directionRestr`). -/
   reindex_naturality : F.ReindexNaturality
-  /-- Identity law for `reindex`, relative to `tagRestr_id`. -/
-  reindex_id : F.ReindexId tagRestr_id
-  /-- Composition law for `reindex`, relative to `tagRestr_comp`. -/
-  reindex_comp : F.ReindexComp tagRestr_comp
+  /-- Identity law for `reindex`, relative to `shapeRestr_id`. -/
+  reindex_id : F.ReindexId shapeRestr_id
+  /-- Composition law for `reindex`, relative to `shapeRestr_comp`. -/
+  reindex_comp : F.ReindexComp shapeRestr_comp
 
 end PresheafPFunctorData
 
@@ -393,26 +397,27 @@ attribute [ext] PresheafPFunctorData
 namespace PresheafPFunctor
 
 /-- The slice element underlying the restriction action of `objPresheaf` on a
-`J`-morphism `g`: retag the shape along `tagRestr g` and reindex the
-direction-assignment along `reindex g`. -/
+`J`-morphism `g`, for a projection `p : X → I`: restrict the shape along
+`shapeRestr g` and reindex the direction-assignment along `reindex g`. -/
 @[expose] def objRestrElt {I : Type uI} [Category.{vI} I] {J : Type uJ} [Category.{vJ} J]
-    (F : PresheafPFunctor.{uI, uJ, uA, uB, vI, vJ} I J) {Z : Iᵒᵖ ⥤ Type uZ} ⦃j j' : J⦄ (g : j' ⟶ j)
-    (x : F.toSliceDomPFunctor.Obj (PresheafDomPFunctorData.elemProj Z)) (htag : F.t x.1.1 = j) :
-    F.toSliceDomPFunctor.Obj (PresheafDomPFunctorData.elemProj Z) :=
-  ⟨⟨(F.tagRestr g ⟨x.1.1, htag⟩).1,
-      fun b' => x.1.2 (F.reindex g ⟨x.1.1, htag⟩ (i := F.sCurried _ b') ⟨b', rfl⟩).1⟩,
+    (F : PresheafPFunctor.{uI, uJ, uA, uB, vI, vJ} I J) {X : Type uX} {p : X → I}
+    ⦃j j' : J⦄ (g : j' ⟶ j)
+    (x : F.toSliceDomPFunctor.Obj p) (hq : F.q x.1.1 = j) :
+    F.toSliceDomPFunctor.Obj p :=
+  ⟨⟨(F.shapeRestr g ⟨x.1.1, hq⟩).1,
+      fun b' => x.1.2 (F.reindex g ⟨x.1.1, hq⟩ (i := F.rCurried _ b') ⟨b', rfl⟩).1⟩,
     (F.compatible_iff _ _ _).mpr fun b' =>
       ((F.compatible_iff _ _ _).mp x.2
-        (F.reindex g ⟨x.1.1, htag⟩ (i := F.sCurried _ b') ⟨b', rfl⟩).1).trans
-        (F.reindex g ⟨x.1.1, htag⟩ (i := F.sCurried _ b') ⟨b', rfl⟩).2⟩
+        (F.reindex g ⟨x.1.1, hq⟩ (i := F.rCurried _ b') ⟨b', rfl⟩).1).trans
+        (F.reindex g ⟨x.1.1, hq⟩ (i := F.rCurried _ b') ⟨b', rfl⟩).2⟩
 
 /-- The component the restricted element assigns to a direction is the component
 the original assigns to the direction's `reindex`. -/
 private theorem value_objRestrElt {I : Type uI} [Category.{vI} I] {J : Type uJ} [Category.{vJ} J]
     (F : PresheafPFunctor.{uI, uJ, uA, uB, vI, vJ} I J) {Z : Iᵒᵖ ⥤ Type uZ} ⦃j j' : J⦄ (g : j' ⟶ j)
-    (x : F.toSliceDomPFunctor.Obj (PresheafDomPFunctorData.elemProj Z)) (htag : F.t x.1.1 = j)
-    ⦃i : I⦄ (b : F.Direction (F.objRestrElt g x htag).1.1 i) :
-    F.value (F.objRestrElt g x htag) b = F.value x (F.reindex g ⟨x.1.1, htag⟩ b) := by
+    (x : F.toSliceDomPFunctor.Obj (PresheafDomPFunctorData.elemProj Z)) (hq : F.q x.1.1 = j)
+    ⦃i : I⦄ (b : F.Direction (F.objRestrElt g x hq).1.1 i) :
+    F.value (F.objRestrElt g x hq) b = F.value x (F.reindex g ⟨x.1.1, hq⟩ b) := by
   obtain ⟨b1, rfl⟩ := b
   rfl
 
@@ -421,14 +426,14 @@ of `F.obj Z`: `objRestrElt` packaged with its naturality, supplied by
 `reindex_naturality`. -/
 @[expose] def objRestr {I : Type uI} [Category.{vI} I] {J : Type uJ} [Category.{vJ} J]
     (F : PresheafPFunctor.{uI, uJ, uA, uB, vI, vJ} I J) {Z : Iᵒᵖ ⥤ Type uZ} ⦃j j' : J⦄ (g : j' ⟶ j)
-    (x : F.obj Z) (htag : F.t x.shape = j) : F.obj Z :=
-  ⟨F.objRestrElt g x.1 htag, by
+    (x : F.obj Z) (hq : F.q x.shape = j) : F.obj Z :=
+  ⟨F.objRestrElt g x.1 hq, by
     intro i i' f b
     rw [F.value_objRestrElt, F.value_objRestrElt,
-      show F.reindex g ⟨x.shape, htag⟩ (F.restr (F.objRestrElt g x.1 htag).1.1 f b)
-          = F.restr x.shape f (F.reindex g ⟨x.shape, htag⟩ b) from
-        (congrFun (F.isFunctorial.reindex_naturality g ⟨x.shape, htag⟩ f) b).symm]
-    exact x.2 f (F.reindex g ⟨x.shape, htag⟩ b)⟩
+      show F.reindex g ⟨x.shape, hq⟩ (F.directionRestr (F.objRestrElt g x.1 hq).1.1 f b)
+          = F.directionRestr x.shape f (F.reindex g ⟨x.shape, hq⟩ b) from
+        (congrFun (F.isFunctorial.reindex_naturality g ⟨x.shape, hq⟩ f) b).symm]
+    exact x.2 f (F.reindex g ⟨x.shape, hq⟩ b)⟩
 
 /-- The underlying value of a direction cast along a shape equality is the
 original value, up to the transport of its type along that equality. -/
@@ -444,8 +449,8 @@ to directions with equal underlying indices. -/
 private theorem reindex_val_heq {I : Type uI} [Category.{vI} I] {J : Type uJ} [Category.{vJ} J]
     (F : PresheafPFunctor.{uI, uJ, uA, uB, vI, vJ} I J) ⦃j' j'' : J⦄ (h : j'' ⟶ j')
     {S S' : F.Shape j'} (hSS : S = S')
-    ⦃i i' : I⦄ (b : F.Direction (F.tagRestr h S).1 i) (b' : F.Direction (F.tagRestr h S').1 i')
-    (hb : (b.1 : F.B (F.tagRestr h S).1) ≍ (b'.1 : F.B (F.tagRestr h S').1)) :
+    ⦃i i' : I⦄ (b : F.Direction (F.shapeRestr h S).1 i) (b' : F.Direction (F.shapeRestr h S').1 i')
+    (hb : (b.1 : F.B (F.shapeRestr h S).1) ≍ (b'.1 : F.B (F.shapeRestr h S').1)) :
     (F.reindex h S b).1 ≍ ((F.reindex h S' b').1 : F.B S'.1) := by
   cases hSS
   obtain ⟨bv, rfl⟩ := b
@@ -465,43 +470,44 @@ private theorem heq_fun {α β : Type u} {X : Type v} (h : α = β) {f : α → 
 
 /-- Identity law for the restriction action: `objRestrElt` along `𝟙 j` is the
 identity. -/
-private theorem objRestrElt_id {I : Type uI} [Category.{vI} I] {J : Type uJ} [Category.{vJ} J]
-    (F : PresheafPFunctor.{uI, uJ, uA, uB, vI, vJ} I J) {Z : Iᵒᵖ ⥤ Type uZ} {j : J}
-    (x : F.toSliceDomPFunctor.Obj (PresheafDomPFunctorData.elemProj Z)) (htag : F.t x.1.1 = j) :
-    F.objRestrElt (𝟙 j) x htag = x := by
+theorem objRestrElt_id {I : Type uI} [Category.{vI} I] {J : Type uJ} [Category.{vJ} J]
+    (F : PresheafPFunctor.{uI, uJ, uA, uB, vI, vJ} I J) {X : Type uX} {p : X → I} {j : J}
+    (x : F.toSliceDomPFunctor.Obj p) (hq : F.q x.1.1 = j) :
+    F.objRestrElt (𝟙 j) x hq = x := by
   apply Subtype.ext
   obtain ⟨⟨a, v⟩, hc⟩ := x
   simp only [objRestrElt]
   refine Sigma.ext
-    (congrArg Subtype.val (congrFun (F.isFunctorial.tagRestr_id j) (⟨a, htag⟩ : F.Shape j))) ?_
+    (congrArg Subtype.val (congrFun (F.isFunctorial.shapeRestr_id j) (⟨a, hq⟩ : F.Shape j))) ?_
   refine heq_fun
     (congrArg F.B
-      (congrArg Subtype.val (congrFun (F.isFunctorial.tagRestr_id j) (⟨a, htag⟩ : F.Shape j))))
+      (congrArg Subtype.val (congrFun (F.isFunctorial.shapeRestr_id j) (⟨a, hq⟩ : F.Shape j))))
     ?_
   intro b1 b2 hb
   dsimp only
   rw [F.isFunctorial.reindex_id]
   congr 1
   exact eq_of_heq
-    (HEq.trans (F.cast_val_heq (congrFun (F.isFunctorial.tagRestr_id j) ⟨a, htag⟩) ⟨b1, rfl⟩) hb)
+    (HEq.trans (F.cast_val_heq (congrFun (F.isFunctorial.shapeRestr_id j) ⟨a, hq⟩) ⟨b1, rfl⟩) hb)
 
 /-- Composition law for the restriction action: `objRestrElt` along a composite
 factors as the composite of the actions. -/
-private theorem objRestrElt_comp {I : Type uI} [Category.{vI} I] {J : Type uJ} [Category.{vJ} J]
-    (F : PresheafPFunctor.{uI, uJ, uA, uB, vI, vJ} I J) {Z : Iᵒᵖ ⥤ Type uZ} ⦃j j' j'' : J⦄
+theorem objRestrElt_comp {I : Type uI} [Category.{vI} I] {J : Type uJ} [Category.{vJ} J]
+    (F : PresheafPFunctor.{uI, uJ, uA, uB, vI, vJ} I J) {X : Type uX} {p : X → I} ⦃j j' j'' : J⦄
     (g : j' ⟶ j) (h : j'' ⟶ j')
-    (x : F.toSliceDomPFunctor.Obj (PresheafDomPFunctorData.elemProj Z)) (htag : F.t x.1.1 = j)
-    (htag' : F.t (F.objRestrElt g x htag).1.1 = j') :
-    F.objRestrElt (h ≫ g) x htag = F.objRestrElt h (F.objRestrElt g x htag) htag' := by
+    (x : F.toSliceDomPFunctor.Obj p) (hq : F.q x.1.1 = j)
+    (hq' : F.q (F.objRestrElt g x hq).1.1 = j') :
+    F.objRestrElt (h ≫ g) x hq = F.objRestrElt h (F.objRestrElt g x hq) hq' := by
   apply Subtype.ext
   obtain ⟨⟨a, v⟩, hc⟩ := x
   simp only [objRestrElt]
   refine Sigma.ext
-    (congrArg Subtype.val (congrFun (F.isFunctorial.tagRestr_comp g h) (⟨a, htag⟩ : F.Shape j)))
+    (congrArg Subtype.val (congrFun (F.isFunctorial.shapeRestr_comp g h) (⟨a, hq⟩ : F.Shape j)))
     ?_
   refine heq_fun
     (congrArg F.B
-      (congrArg Subtype.val (congrFun (F.isFunctorial.tagRestr_comp g h) (⟨a, htag⟩ : F.Shape j))))
+      (congrArg Subtype.val
+        (congrFun (F.isFunctorial.shapeRestr_comp g h) (⟨a, hq⟩ : F.Shape j))))
     ?_
   intro b1 b2 hb
   dsimp only
@@ -511,46 +517,48 @@ private theorem objRestrElt_comp {I : Type uI} [Category.{vI} I] {J : Type uJ} [
   refine F.reindex_val_heq g rfl _ _ ?_
   refine F.reindex_val_heq h rfl _ _ ?_
   exact HEq.trans
-    (F.cast_val_heq (congrFun (F.isFunctorial.tagRestr_comp g h) ⟨a, htag⟩) ⟨b1, rfl⟩) hb
+    (F.cast_val_heq (congrFun (F.isFunctorial.shapeRestr_comp g h) ⟨a, hq⟩) ⟨b1, rfl⟩) hb
 
 /-- The output presheaf `T(Z) : Jᵒᵖ ⥤ Type`, built directly as a `Functor`
-value. Its fibre over `j` is the
-`t`-tagged subtype of the dom value `F.obj Z`; its restriction maps are the
-retag-and-reindex action `objRestr`, whose `map_id` / `map_comp` are discharged
+value. Its fibre over `j` is the subtype of the dom value `F.obj Z` whose
+`q`-output index is `j`; its restriction maps are the shape-and-direction
+reindex action `objRestr`, whose `map_id` / `map_comp` are discharged
 from `F.isFunctorial`. -/
 @[expose] def objPresheaf {I : Type uI} [Category.{vI} I] {J : Type uJ} [Category.{vJ} J]
     (F : PresheafPFunctor.{uI, uJ, uA, uB, vI, vJ} I J) (Z : Iᵒᵖ ⥤ Type uZ) :
     Jᵒᵖ ⥤ Type (max uI uZ uA uB) where
-  obj j := { z : F.toPresheafDomPFunctorData.obj Z // F.t z.shape = j.unop }
-  map g := ↾ fun w => ⟨F.objRestr g.unop w.1 w.2, (F.tagRestr g.unop ⟨w.1.shape, w.2⟩).2⟩
+  obj j := { z : F.toPresheafDomPFunctorData.obj Z // F.q z.shape = j.unop }
+  map g := ↾ fun w => ⟨F.objRestr g.unop w.1 w.2, (F.shapeRestr g.unop ⟨w.1.shape, w.2⟩).2⟩
   map_id j := by
     ext w
     exact Subtype.ext (F.objRestrElt_id w.1.1 w.2)
   map_comp g h := by
     ext w
     apply Subtype.ext
-    exact F.objRestrElt_comp g.unop h.unop w.1.1 w.2 (F.tagRestr g.unop ⟨w.1.shape, w.2⟩).2
+    exact F.objRestrElt_comp g.unop h.unop w.1.1 w.2 (F.shapeRestr g.unop ⟨w.1.shape, w.2⟩).2
 
 /-- Naturality of the dom morphism map with respect to `objPresheaf`'s
 `J`-restriction: for `α : NatTrans Z Z'`, the dom `map α` carries the fibre of
 `objPresheaf Z` over `j` into that of `objPresheaf Z'` (it preserves the
-`t`-tag, the shape being fixed by `SliceDomPFunctor.map_fst`) and commutes with
-the retag-and-reindex restriction `objRestr g`. The commutation is the
-interchange of the postcomposition with `α` (the morphism action) and the
-precomposition with `reindex g` (the restriction), needing no functor law. -/
+`q`-output index, the shape being fixed by `SliceDomPFunctor.map_fst`) and
+commutes with the shape-and-direction reindex restriction `objRestr g`. The
+commutation is the interchange of the postcomposition with `α` (the morphism
+action) and the precomposition with `reindex g` (the restriction), needing no
+functor law. -/
 theorem map_objRestr {I : Type uI} [Category.{vI} I] {J : Type uJ} [Category.{vJ} J]
     (F : PresheafPFunctor.{uI, uJ, uA, uB, vI, vJ} I J) {Z Z' : Iᵒᵖ ⥤ Type uZ}
     (α : NatTrans Z Z') ⦃j j' : J⦄ (g : j' ⟶ j)
-    (x : F.toPresheafDomPFunctorData.obj Z) (htag : F.t x.shape = j) :
-    F.toPresheafDomPFunctorData.map α (F.objRestr g x htag) =
-      F.objRestr g (F.toPresheafDomPFunctorData.map α x) htag :=
+    (x : F.toPresheafDomPFunctorData.obj Z) (hq : F.q x.shape = j) :
+    F.toPresheafDomPFunctorData.map α (F.objRestr g x hq) =
+      F.objRestr g (F.toPresheafDomPFunctorData.map α x) hq :=
   Subtype.ext rfl
 
 /-- The natural transformation `objPresheaf Z ⟶ objPresheaf Z'` induced by a
 morphism `α : Z ⟶ Z'` of input presheaves: each component is the dom `map α` on
-the underlying element, restricted to the `t`-tagged fibre (the dom map preserves
-the tag, the shape being fixed by `SliceDomPFunctor.map_fst`); naturality is
-`map_objRestr`. The categorical wrapper `functor.map` reuses it. -/
+the underlying element, restricted to the `q`-indexed fibre (the dom map
+preserves the output index, the shape being fixed by
+`SliceDomPFunctor.map_fst`); naturality is `map_objRestr`. The categorical
+wrapper `functor.map` reuses it. -/
 @[expose] def mapPresheaf {I : Type uI} [Category.{vI} I] {J : Type uJ} [Category.{vJ} J]
     (F : PresheafPFunctor.{uI, uJ, uA, uB, vI, vJ} I J) {Z Z' : Iᵒᵖ ⥤ Type uZ}
     (α : NatTrans Z Z') : NatTrans (F.objPresheaf Z) (F.objPresheaf Z') where

--- a/geb-lean/vendor/geb-mathlib/Geb/Mathlib/Data/PFunctor/Presheaf/Functor.lean
+++ b/geb-lean/vendor/geb-mathlib/Geb/Mathlib/Data/PFunctor/Presheaf/Functor.lean
@@ -36,7 +36,7 @@ the object map of mathlib's `Classical.choice`-dependent
 
 * `PresheafPFunctor.functor_obj` / `functor_map` — the categorical functor's
   object map is the core `objPresheaf`, and its morphism map is the
-  dom `map` retagged onto the `t`-tagged fibre.
+  dom `map` restricted to the `q`-indexed fibre.
 * `PresheafDomPFunctorData.elemMap_eq_categoryOfElements_map` — the core's
   choice-free `elemMap` is the object map of mathlib's
   `Classical.choice`-dependent `CategoryOfElements.map`, across `toElements`.
@@ -53,9 +53,9 @@ shortcut: the codomain is a plain type category, not an `Over` category.
 `functor` assembles directly: its object map is `objPresheaf`, and its morphism
 map is the core `mapPresheaf` — the natural transformation a
 functor-category hom `α` induces, whose component is the dom `map α` restricted
-to the `t`-tagged fibre (the dom map preserves the tag, so it restricts), with
-naturality `map_objRestr`. The outer functor laws come from the dom
-`map_id` / `map_comp`. There is no `Functor.toOver`
+to the `q`-indexed fibre (the dom map preserves the output index, so it
+restricts), with naturality `map_objRestr`. The outer functor laws come from
+the dom `map_id` / `map_comp`. There is no `Functor.toOver`
 analogue for presheaf codomains. The morphism universes of `I` and `J` are
 named (`vI`, `vJ`) so the input presheaf's value universe `uZ` and the
 `PresheafPFunctor` arity universes `uA` / `uB` pin the output presheaf's value
@@ -139,9 +139,9 @@ theorem functor_obj {I : Type uI} [Category.{vI} I] {J : Type uJ} [Category.{vJ}
     F.functor.obj Z = F.objPresheaf Z :=
   rfl
 
-/-- `functor.map`'s component over `j`, applied to a `t`-tagged fibre element,
-retags the dom `map` of the underlying element: its underlying dom value is the
-dom `map α` of the input's. -/
+/-- `functor.map`'s component over `j`, applied to a `q`-indexed fibre element,
+applies the dom `map` to the underlying element: its underlying dom value is
+the dom `map α` of the input's. -/
 theorem functor_map {I : Type uI} [Category.{vI} I] {J : Type uJ} [Category.{vJ} J]
     (F : PresheafPFunctor.{uI, uJ, uA, uB, vI, vJ} I J) {Z Z' : Iᵒᵖ ⥤ Type uZ}
     (α : Z ⟶ Z') (X : Jᵒᵖ) (w : (F.functor.obj Z).obj X) :

--- a/geb-lean/vendor/geb-mathlib/Geb/Mathlib/Data/PFunctor/Presheaf/W.lean
+++ b/geb-lean/vendor/geb-mathlib/Geb/Mathlib/Data/PFunctor/Presheaf/W.lean
@@ -1,0 +1,802 @@
+/-
+Copyright (c) 2026 The geb-mathlib contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The geb-mathlib contributors
+-/
+-- Modified from geb-mathlib by scripts/geb-mathlib-backport.patch.
+module
+
+public import Geb.Mathlib.Data.PFunctor.Slice.W
+public import Geb.Mathlib.Data.PFunctor.Presheaf.Basic
+
+/-!
+# W-types of presheaf polynomial functors: hereditary naturality (constructive core)
+
+For a presheaf polynomial endofunctor `F : PresheafPFunctor I I`, the W-type of
+the underlying slice endofunctor `F.toSlicePFunctor : SlicePFunctor I I` carries
+a tree-level naturality predicate. A slice W-tree assembles a shape with a
+compatible family of child subtrees; the presheaf structure additionally acts on
+directions contravariantly (`directionRestr`) and on the assignment of shapes to
+output indices. A tree is hereditarily natural when, at every node, restricting a
+child subtree along a morphism agrees with selecting the child at the reindexed
+direction, hereditarily through the whole tree.
+
+`wRestrTree` is the root-only restriction of a slice W-tree along a morphism: it
+restricts the root shape and reindexes the direction-assignment via the
+generalized `PresheafPFunctor.objRestrElt`, conjugated by the slice destructor
+and constructor. `IsHereditarilyNatural` folds the local naturality equation
+over the whole tree through the slice W-type's `Prop`-valued paramorphism
+`SlicePFunctor.W.recProp`; `isHereditarilyNatural_mk` is its one-level
+computation rule.
+
+## Main definitions
+
+* `PresheafPFunctor.wRestrTree` — the root-only restriction of a slice W-tree
+  along a morphism, via the generalized `objRestrElt` at `p := windex`.
+* `PresheafPFunctor.IsHereditarilyNatural` — the tree-level naturality predicate
+  on slice W-trees, defined by `SlicePFunctor.W.recProp`.
+* `PresheafPFunctor.wRestr` — restriction on the `ULift`ed carrier fibre,
+  reindexing the underlying tree along a morphism while preserving the index and
+  hereditary naturality.
+* `PresheafPFunctor.W` — the carrier presheaf `Iᵒᵖ ⥤ Type (max uI uA uB)`, whose
+  fibre over `j` is the `ULift` of the hereditarily-natural slice W-trees indexed
+  at `j` and whose restriction maps are `wRestr`.
+* `PresheafPFunctor.W.forgetNode` / `PresheafPFunctor.W.rememberNode` — the
+  mutually inverse translations between a presheaf node over the carrier
+  presheaf `F.W` and the underlying slice node over `windex` together with the
+  hereditary naturality of its children.
+* `PresheafPFunctor.W.mk` / `PresheafPFunctor.W.dest` — the fixed-point
+  constructor and destructor: mutually inverse fibrewise maps between the
+  `objPresheaf`-value at `F.W` and `F.W`, exhibiting `F.W` as a fixed point of
+  the `objPresheaf`-action at `F.W`.
+* `PresheafPFunctor.W.PElimData` / `pelimStep` / `pelimData` — the eliminator's
+  fold carrier, algebra, and fold (a `WType.elim` fold whose value is guarded by
+  hereditary naturality, since the presheaf algebra acts only on natural nodes):
+  the presheaf analogue of the slice `ElimData` machinery.
+* `PresheafPFunctor.W.elimVal` — the eliminator's value on a carrier element,
+  extracted from the fold given the tree's hereditary naturality.
+* `PresheafPFunctor.W.elim` — the eliminator into any presheaf algebra `(Y, α)`,
+  a natural transformation `F.W ⟶ Y`.
+
+## Main statements
+
+* `PresheafPFunctor.isHereditarilyNatural_mk` — the one-level unfolding of
+  `IsHereditarilyNatural` on a constructor `SlicePFunctor.W.mk x`: local
+  naturality at the root, together with hereditary naturality of every child.
+* `PresheafPFunctor.windex_wRestrTree` — the index of a root-restricted tree is
+  the restriction morphism's source.
+* `PresheafPFunctor.isHereditarilyNatural_wRestrTree` — hereditary naturality is
+  preserved by the root-only restriction, a one-level argument.
+* `PresheafPFunctor.wRestrTree_id` / `PresheafPFunctor.wRestrTree_comp` — the
+  functoriality of `wRestrTree`, from which `W`'s functor laws transport.
+* `PresheafPFunctor.W.dest_mk` / `PresheafPFunctor.W.mk_dest` — `mk` and `dest`
+  are mutually inverse, so `F.W` is a fixed point of the `objPresheaf`-action at
+  `F.W`.
+* `PresheafPFunctor.W.isHereditarilyNatural_mk_forgetNode` — hereditary
+  naturality of the slice tree built from a presheaf node over `F.W` is exactly
+  the node's `IsNatural` datum; the correspondence underlying `mk` / `dest` and
+  the eliminator fold.
+* `PresheafPFunctor.W.comp_elim` — `elim` is a morphism of presheaves (its
+  `NatTrans` naturality), from `elimVal_wRestr`.
+* `PresheafPFunctor.W.elim_mk` — the computation rule: `elim` commutes with `mk`,
+  i.e. it is a morphism of presheaf algebras.
+
+## Implementation notes
+
+This is the presheaf endofunctor case, `I = J`, so the slice endofunctor
+`F.toSlicePFunctor : SlicePFunctor I I` has a W-type. `wRestrTree` and
+`IsHereditarilyNatural` act on the un-lifted trees `F.toSlicePFunctor.W` of type
+`Type (max uA uB)`; the carrier presheaf `W` `ULift`s the indexed subtype into
+`Type (max uI uA uB)` so its fibres land in a single universe with the index
+category `I`.
+
+The recursion in `IsHereditarilyNatural` is confined to the slice W-type's
+`Prop`-valued paramorphism `SlicePFunctor.W.recProp`: no explicit self-recursion
+and no `induction` tactic appear. The child-index witness required by
+`wRestrTree` is discharged from the compatibility of the node's
+direction-assignment (`SliceDomPFunctor.compatible_iff`) together with the
+direction's fibre constraint, exactly as `PresheafDomPFunctorData.value` obtains
+its index equality.
+
+The eliminator `elim` folds the underlying slice tree into a target value with a
+bespoke `WType.elim` fold (`pelimData`, carrier `PElimData`, algebra
+`pelimStep`), the presheaf analogue of the slice `elim`'s `ElimData` fold. The
+presheaf algebra `α` acts only on natural nodes, so — unlike the slice `elim`,
+whose algebra is total — the fold's value is a function of the subtree's
+hereditary naturality, and the fold carries a naturality proxy (via the guard
+`P ∧ ∀ hp : P, Q hp`, builtin `And` with `Q` proof-irrelevant in `hp`) letting
+`α` apply at each node. The value fold is
+a non-dependent `WType.elim` (code-generatable); the recursion in the
+accompanying proofs (`pelimData_valid`, `elimVal_wRestr`) stays inside
+`WType.rec` / `SlicePFunctor.W.ind`. Only the existence half of the
+initial-algebra universal property is established — the carrier, its fixed-point
+structure, and `elim` with its computation rule `elim_mk` and over-`I` law
+`comp_elim`; uniqueness of `elim` is not formalized.
+
+## References
+
+* [Weber2007]
+* [GambinoHyland2004]
+* [GambinoKock2013]
+* [AltenkirchGhaniHancockMcBrideMorris2015]
+
+## Tags
+
+W-type, initial algebra, polynomial functor, presheaf, parametric right adjoint,
+naturality, restriction map, PFunctor
+-/
+
+public section
+
+open CategoryTheory
+
+universe uI uA uB vI
+
+namespace PresheafPFunctor
+
+/-- The root-only restriction of a slice W-tree `z` along a morphism `g : j' ⟶ j`
+(where `j` is the index of `z`): restrict the root shape and reindex its
+direction-assignment via the generalized `objRestrElt` at the projection
+`p := F.toSlicePFunctor.windex`, conjugating by the slice destructor and
+constructor. The head-index witness required by `objRestrElt` is the hypothesis
+`hq`, the root's `q`-output index being read from `PFunctor.W.head`. -/
+@[expose] def wRestrTree {I : Type uI} [Category.{vI} I]
+    (F : PresheafPFunctor.{uI, uI, uA, uB, vI, vI} I I) ⦃j j' : I⦄ (g : j' ⟶ j)
+    (z : F.toSlicePFunctor.W) (hq : F.q (PFunctor.W.head z.1) = j) :
+    F.toSlicePFunctor.W :=
+  SlicePFunctor.W.mk (F.objRestrElt g (SlicePFunctor.W.dest z)
+    (by obtain ⟨w, hw⟩ := z; cases w with | mk a f => exact hq))
+
+/-- Hereditary naturality of a slice W-tree: at every node, restricting a child
+subtree along a morphism `g` agrees with selecting the child at the reindexed
+direction, hereditarily. The local conjunct is the tree analogue of
+`PresheafDomPFunctorData.IsNatural`; the fold over the tree is carried by the
+slice W-type's `Prop`-valued paramorphism `SlicePFunctor.W.recProp`. -/
+@[expose] def IsHereditarilyNatural {I : Type uI} [Category.{vI} I]
+    (F : PresheafPFunctor.{uI, uI, uA, uB, vI, vI} I I) : F.toSlicePFunctor.W → Prop :=
+  SlicePFunctor.W.recProp (fun x ih =>
+    (∀ ⦃i i' : I⦄ (g : i' ⟶ i) (b : F.toSliceDomPFunctor.Direction x.1.1 i),
+        x.1.2 (F.directionRestr x.1.1 g b).1
+          = F.wRestrTree g (x.1.2 b.1)
+              (((F.toSliceDomPFunctor.compatible_iff F.toSlicePFunctor.windex x.1.1 x.1.2).mp
+                x.2 b.1).trans b.2)) ∧ ∀ b, ih b)
+
+/-- One-level unfolding of `IsHereditarilyNatural` on a constructor
+`SlicePFunctor.W.mk x`: local naturality at the root together with hereditary
+naturality of every child subtree. From `SlicePFunctor.W.recProp_mk`. -/
+theorem isHereditarilyNatural_mk {I : Type uI} [Category.{vI} I]
+    (F : PresheafPFunctor.{uI, uI, uA, uB, vI, vI} I I)
+    (x : F.toSliceDomPFunctor.Obj F.toSlicePFunctor.windex) :
+    F.IsHereditarilyNatural (SlicePFunctor.W.mk x) ↔
+      (∀ ⦃i i' : I⦄ (g : i' ⟶ i) (b : F.toSliceDomPFunctor.Direction x.1.1 i),
+          x.1.2 (F.directionRestr x.1.1 g b).1
+            = F.wRestrTree g (x.1.2 b.1)
+                (((F.toSliceDomPFunctor.compatible_iff F.toSlicePFunctor.windex x.1.1 x.1.2).mp
+                  x.2 b.1).trans b.2)) ∧
+        ∀ b, F.IsHereditarilyNatural (x.1.2 b) := by
+  unfold IsHereditarilyNatural
+  rw [SlicePFunctor.W.recProp_mk]
+
+/-- The index of a root-restricted tree is `j'`: `wRestrTree g z` rebuilds the
+root with the restricted shape `(shapeRestr g _).1`, whose `q`-output index is
+`j'`. -/
+theorem windex_wRestrTree {I : Type uI} [Category.{vI} I]
+    (F : PresheafPFunctor.{uI, uI, uA, uB, vI, vI} I I) ⦃j j' : I⦄ (g : j' ⟶ j)
+    (z : F.toSlicePFunctor.W) (hq : F.q (PFunctor.W.head z.1) = j) :
+    F.toSlicePFunctor.windex (F.wRestrTree g z hq) = j' := by
+  obtain ⟨tree, hvalid⟩ := z
+  cases tree with
+  | mk a f => exact (F.shapeRestr g ⟨a, hq⟩).2
+
+/-- The child a root-restricted node assigns to a direction is the child the
+original node assigns to the direction's `reindex`. The analogue of
+`value_objRestrElt` for the raw child assignment; `rfl` after destructuring the
+direction, matching `objRestrElt`'s internal `⟨·, rfl⟩` reconstruction. -/
+private theorem snd_objRestrElt {I : Type uI} [Category.{vI} I]
+    (F : PresheafPFunctor.{uI, uI, uA, uB, vI, vI} I I) ⦃j j' : I⦄ (g : j' ⟶ j)
+    (x : F.toSliceDomPFunctor.Obj F.toSlicePFunctor.windex) (hq : F.q x.1.1 = j) ⦃i : I⦄
+    (d : F.toSliceDomPFunctor.Direction (F.objRestrElt g x hq).1.1 i) :
+    (F.objRestrElt g x hq).1.2 d.1 = x.1.2 (F.reindex g ⟨x.1.1, hq⟩ d).1 := by
+  obtain ⟨dv, rfl⟩ := d
+  rfl
+
+/-- Hereditary naturality is preserved by the root-only restriction: the
+children of `wRestrTree g z` are the original subtrees reindexed (each already
+hereditarily natural), and its root's local naturality follows from `z`'s own
+root local naturality and `reindex_naturality`. A one-level argument, not a
+recursion. -/
+theorem isHereditarilyNatural_wRestrTree {I : Type uI} [Category.{vI} I]
+    (F : PresheafPFunctor.{uI, uI, uA, uB, vI, vI} I I) ⦃j j' : I⦄ (g : j' ⟶ j)
+    (z : F.toSlicePFunctor.W) (hq : F.q (PFunctor.W.head z.1) = j)
+    (hz : F.IsHereditarilyNatural z) :
+    F.IsHereditarilyNatural (F.wRestrTree g z hq) := by
+  obtain ⟨tree, hvalid⟩ := z
+  cases tree with
+  | mk a fchild =>
+    obtain ⟨hz_local, hz_children⟩ :=
+      (F.isHereditarilyNatural_mk (SlicePFunctor.W.dest ⟨WType.mk a fchild, hvalid⟩)).mp hz
+    refine (F.isHereditarilyNatural_mk _).mpr ⟨?_, ?_⟩
+    · intro i i' h b
+      obtain ⟨bv, rfl⟩ := b
+      rw [F.snd_objRestrElt]
+      exact (congrArg (fun d => (SlicePFunctor.W.dest ⟨WType.mk a fchild, hvalid⟩).1.2 d.1)
+          (congrFun (F.isFunctorial.reindex_naturality g ⟨a, hq⟩ h) ⟨bv, rfl⟩).symm).trans
+        (hz_local h (F.reindex g ⟨a, hq⟩ ⟨bv, rfl⟩))
+    · intro b
+      exact hz_children (F.reindex g ⟨a, hq⟩ ⟨b, rfl⟩).1
+
+/-- Restriction on the ULifted carrier fibre: apply `wRestrTree` to the
+underlying tree of `w` along `g`, re-establishing the index (`j'`, read from the
+restricted root shape via `shapeRestr`) and hereditary naturality (preserved by
+`wRestrTree`, a one-level consequence of `isHereditarilyNatural_mk` and
+`reindex_naturality`). -/
+@[expose] def wRestr {I : Type uI} [Category.{vI} I]
+    (F : PresheafPFunctor.{uI, uI, uA, uB, vI, vI} I I) ⦃j j' : I⦄ (g : j' ⟶ j) :
+    ULift.{uI} { w : F.toSlicePFunctor.W //
+        F.toSlicePFunctor.windex w = j ∧ F.IsHereditarilyNatural w } →
+      ULift.{uI} { w : F.toSlicePFunctor.W //
+        F.toSlicePFunctor.windex w = j' ∧ F.IsHereditarilyNatural w } :=
+  fun w => ULift.up
+    ⟨F.wRestrTree g w.down.1 w.down.2.1,
+      F.windex_wRestrTree g w.down.1 w.down.2.1,
+      F.isHereditarilyNatural_wRestrTree g w.down.1 w.down.2.1 w.down.2.2⟩
+
+/-- Restriction along an identity fixes the tree: `objRestrElt_id` collapses the
+rebuilt root, and `mk_dest` reassembles the original tree. -/
+theorem wRestrTree_id {I : Type uI} [Category.{vI} I]
+    (F : PresheafPFunctor.{uI, uI, uA, uB, vI, vI} I I) ⦃j : I⦄
+    (z : F.toSlicePFunctor.W) (hq : F.q (PFunctor.W.head z.1) = j) :
+    F.wRestrTree (𝟙 j) z hq = z := by
+  obtain ⟨tree, hvalid⟩ := z
+  cases tree with
+  | mk a fchild =>
+    simp only [wRestrTree]
+    rw [F.objRestrElt_id, SlicePFunctor.W.mk_dest]
+
+/-- Restriction along a composite factors: `dest_mk` exposes the inner
+restriction and `objRestrElt_comp` splits the rebuilt root. -/
+theorem wRestrTree_comp {I : Type uI} [Category.{vI} I]
+    (F : PresheafPFunctor.{uI, uI, uA, uB, vI, vI} I I) ⦃j j' j'' : I⦄ (g : j' ⟶ j)
+    (h : j'' ⟶ j') (z : F.toSlicePFunctor.W) (hq : F.q (PFunctor.W.head z.1) = j)
+    (hq2 : F.q (PFunctor.W.head (F.wRestrTree g z hq).1) = j') :
+    F.wRestrTree (h ≫ g) z hq = F.wRestrTree h (F.wRestrTree g z hq) hq2 := by
+  obtain ⟨tree, hvalid⟩ := z
+  cases tree with
+  | mk a fchild =>
+    simp only [wRestrTree, SlicePFunctor.W.dest_mk]
+    rw [F.objRestrElt_comp g h (SlicePFunctor.W.dest ⟨WType.mk a fchild, hvalid⟩) hq
+      (F.shapeRestr g ⟨a, hq⟩).2]
+
+/-- The carrier presheaf `W : Iᵒᵖ ⥤ Type` of the presheaf polynomial endofunctor
+`F`: its fibre over `j` is the `ULift` of the hereditarily-natural slice W-trees
+indexed at `j`, and its restriction maps are `wRestr`. The functor laws transport
+from `objRestrElt_id` / `objRestrElt_comp` through `wRestrTree`, `ULift`, and
+`Subtype`. -/
+@[expose] def W {I : Type uI} [Category.{vI} I]
+    (F : PresheafPFunctor.{uI, uI, uA, uB, vI, vI} I I) : Iᵒᵖ ⥤ Type (max uI uA uB) where
+  obj j := ULift.{uI} { w : F.toSlicePFunctor.W //
+    F.toSlicePFunctor.windex w = j.unop ∧ F.IsHereditarilyNatural w }
+  map g := ↾ (F.wRestr g.unop)
+  map_id j := by
+    ext w
+    exact F.wRestrTree_id w.down.1 w.down.2.1
+  map_comp g h := by
+    ext w
+    exact F.wRestrTree_comp g.unop h.unop w.down.1 w.down.2.1
+      (F.windex_wRestrTree g.unop w.down.1 w.down.2.1)
+
+namespace W
+
+/-- Casting a carrier fibre element along an index equality leaves its
+underlying slice W-tree unchanged. -/
+private theorem cast_down {I : Type uI} [Category.{vI} I]
+    (F : PresheafPFunctor.{uI, uI, uA, uB, vI, vI} I I) {k k' : I} (e : k = k')
+    (u : (F.W).obj ⟨k⟩) :
+    (cast (congrArg (fun k : I => (F.W).obj ⟨k⟩) e) u).down.1 = u.down.1 := by
+  cases e
+  rfl
+
+/-- Two carrier fibre elements with equal underlying trees are equal. -/
+private theorem obj_ext {I : Type uI} [Category.{vI} I]
+    (F : PresheafPFunctor.{uI, uI, uA, uB, vI, vI} I I) {k : I} {u u' : (F.W).obj ⟨k⟩}
+    (h : u.down.1 = u'.down.1) : u = u' := by
+  obtain ⟨u⟩ := u
+  obtain ⟨u'⟩ := u'
+  exact congrArg ULift.up (Subtype.ext h)
+
+/-- The underlying tree of a restricted fibre element is the root-restriction of
+the underlying tree. -/
+private theorem map_down {I : Type uI} [Category.{vI} I]
+    (F : PresheafPFunctor.{uI, uI, uA, uB, vI, vI} I I) ⦃i i' : I⦄ (f : i' ⟶ i)
+    (u : (F.W).obj ⟨i⟩) :
+    ((F.W).map f.op u).down.1 = F.wRestrTree f u.down.1 u.down.2.1 :=
+  rfl
+
+/-- The underlying tree of the value a presheaf node over `F.W` assigns to a
+direction is the underlying tree of the carried child fibre element. -/
+private theorem value_down {I : Type uI} [Category.{vI} I]
+    (F : PresheafPFunctor.{uI, uI, uA, uB, vI, vI} I I)
+    (n : F.toSliceDomPFunctor.Obj (PresheafDomPFunctorData.elemProj (F.W))) ⦃i : I⦄
+    (b : F.toSliceDomPFunctor.Direction n.1.1 i) :
+    (F.toPresheafDomPFunctorData.value n b).down.1 = (n.1.2 b.1).2.down.1 :=
+  cast_down F
+    (((F.toSliceDomPFunctor.compatible_iff (PresheafDomPFunctorData.elemProj (F.W)) n.1.1 n.1.2).mp
+      n.2 b.1).trans b.2)
+    (n.1.2 b.1).2
+
+/-- Rebuild a carrier fibre element from its underlying tree, its `windex`, and
+its hereditary naturality: a total-space element over `windex w.down.1` equal to
+the original total-space element over `i`. -/
+private theorem sigma_eta {I : Type uI} [Category.{vI} I]
+    (F : PresheafPFunctor.{uI, uI, uA, uB, vI, vI} I I) {i : I} (w : (F.W).obj ⟨i⟩) :
+    (⟨F.toSlicePFunctor.windex w.down.1, ULift.up ⟨w.down.1, rfl, w.down.2.2⟩⟩ :
+      Σ i : I, (F.W).obj ⟨i⟩) = ⟨i, w⟩ := by
+  obtain ⟨⟨t, hi, hh⟩⟩ := w
+  cases hi
+  rfl
+
+/-- Forget a presheaf node over the carrier presheaf `F.W` to the underlying
+slice node over `windex`: retain the shape, and send each direction to the
+underlying slice W-tree of its carried fibre element. -/
+@[expose] def forgetNode {I : Type uI} [Category.{vI} I]
+    (F : PresheafPFunctor.{uI, uI, uA, uB, vI, vI} I I)
+    (n : F.toSliceDomPFunctor.Obj (PresheafDomPFunctorData.elemProj (F.W))) :
+    F.toSliceDomPFunctor.Obj F.toSlicePFunctor.windex :=
+  ⟨⟨n.1.1, fun b => (n.1.2 b).2.down.1⟩,
+    (F.toSliceDomPFunctor.compatible_iff F.toSlicePFunctor.windex _ _).mpr fun b =>
+      ((n.1.2 b).2.down.2.1).trans
+        ((F.toSliceDomPFunctor.compatible_iff (PresheafDomPFunctorData.elemProj (F.W)) _ _).mp
+          n.2 b)⟩
+
+/-- Remember a slice node over `windex` whose children are hereditarily natural
+as a presheaf node over the carrier presheaf `F.W`: retain the shape, and send
+each direction to the carried fibre element built from the child tree, its index
+`windex`, and its hereditary naturality. -/
+@[expose] def rememberNode {I : Type uI} [Category.{vI} I]
+    (F : PresheafPFunctor.{uI, uI, uA, uB, vI, vI} I I)
+    (y : F.toSliceDomPFunctor.Obj F.toSlicePFunctor.windex)
+    (hchildren : ∀ b, F.IsHereditarilyNatural (y.1.2 b)) :
+    F.toSliceDomPFunctor.Obj (PresheafDomPFunctorData.elemProj (F.W)) :=
+  ⟨⟨y.1.1, fun b => ⟨F.toSlicePFunctor.windex (y.1.2 b),
+      ULift.up ⟨y.1.2 b, rfl, hchildren b⟩⟩⟩,
+    (F.toSliceDomPFunctor.compatible_iff (PresheafDomPFunctorData.elemProj (F.W)) _ _).mpr fun b =>
+      (F.toSliceDomPFunctor.compatible_iff F.toSlicePFunctor.windex _ _).mp y.2 b⟩
+
+/-- `rememberNode` depends on the slice node only, not the hereditary-naturality
+data (which occupies a `Prop` position). -/
+private theorem rememberNode_eq {I : Type uI} [Category.{vI} I]
+    (F : PresheafPFunctor.{uI, uI, uA, uB, vI, vI} I I)
+    {y y' : F.toSliceDomPFunctor.Obj F.toSlicePFunctor.windex}
+    (hy : ∀ b, F.IsHereditarilyNatural (y.1.2 b))
+    (hy' : ∀ b, F.IsHereditarilyNatural (y'.1.2 b)) (e : y = y') :
+    rememberNode F y hy = rememberNode F y' hy' := by
+  subst e
+  rfl
+
+/-- `forgetNode` inverts `rememberNode`. -/
+private theorem forgetNode_rememberNode {I : Type uI} [Category.{vI} I]
+    (F : PresheafPFunctor.{uI, uI, uA, uB, vI, vI} I I)
+    (y : F.toSliceDomPFunctor.Obj F.toSlicePFunctor.windex)
+    (hchildren : ∀ b, F.IsHereditarilyNatural (y.1.2 b)) :
+    forgetNode F (rememberNode F y hchildren) = y := by
+  apply Subtype.ext
+  obtain ⟨⟨a, v⟩, hc⟩ := y
+  rfl
+
+/-- `rememberNode` inverts `forgetNode` (with the hereditary-naturality data
+transported through the round trip). -/
+private theorem rememberNode_forgetNode {I : Type uI} [Category.{vI} I]
+    (F : PresheafPFunctor.{uI, uI, uA, uB, vI, vI} I I)
+    (n : F.toSliceDomPFunctor.Obj (PresheafDomPFunctorData.elemProj (F.W)))
+    (hchildren : ∀ b, F.IsHereditarilyNatural ((forgetNode F n).1.2 b)) :
+    rememberNode F (forgetNode F n) hchildren = n := by
+  apply Subtype.ext
+  obtain ⟨⟨a, v⟩, hc⟩ := n
+  exact Sigma.ext rfl (heq_of_eq (funext fun b => sigma_eta F (v b).2))
+
+/-- The hereditary naturality of the slice tree built from a presheaf node over
+`F.W` is exactly the naturality of the node: the recursive conjunct of
+`isHereditarilyNatural_mk` is discharged by the carried hereditary naturality of
+each child, and its local conjunct matches the node's `IsNatural` datum through
+the underlying-tree correspondence. -/
+theorem isHereditarilyNatural_mk_forgetNode {I : Type uI} [Category.{vI} I]
+    (F : PresheafPFunctor.{uI, uI, uA, uB, vI, vI} I I)
+    (n : F.toSliceDomPFunctor.Obj (PresheafDomPFunctorData.elemProj (F.W))) :
+    F.IsHereditarilyNatural (SlicePFunctor.W.mk (forgetNode F n)) ↔
+      F.toPresheafDomPFunctorData.IsNatural n := by
+  rw [F.isHereditarilyNatural_mk]
+  constructor
+  · rintro ⟨hloc, -⟩ i i' f b
+    apply obj_ext F
+    simp only [value_down, map_down]
+    exact hloc f b
+  · intro hnat
+    refine ⟨fun i i' g b => ?_, fun b => (n.1.2 b).2.down.2.2⟩
+    have h := congrArg (fun u => u.down.1) (hnat g b)
+    simp only [value_down, map_down] at h
+    exact h
+
+/-- The fixed-point constructor of the presheaf W-type: the `objPresheaf`-value
+at the carrier presheaf `F.W` maps into `F.W`, fibrewise over `I`. It builds the
+slice W-tree from the node (via `forgetNode` and the slice constructor
+`SlicePFunctor.W.mk`), reads its index from the node's `q`-output index, and
+supplies hereditary naturality via `isHereditarilyNatural_mk_forgetNode`. -/
+@[expose] def mk {I : Type uI} [Category.{vI} I]
+    {F : PresheafPFunctor.{uI, uI, uA, uB, vI, vI} I I} {j : I}
+    (x : (F.objPresheaf F.W).obj ⟨j⟩) : (F.W).obj ⟨j⟩ :=
+  ULift.up ⟨SlicePFunctor.W.mk (forgetNode F x.1.1), x.2,
+    (isHereditarilyNatural_mk_forgetNode F x.1.1).mpr x.1.2⟩
+
+/-- The fixed-point destructor of the presheaf W-type, inverse to `mk`: the
+underlying tree decomposes (via the slice destructor `SlicePFunctor.W.dest`) as
+a shape with a family of hereditarily-natural subtrees, reassembled (via
+`rememberNode`) into a natural node over `F.W`, and re-indexed at the root's
+`q`-output index. -/
+@[expose] def dest {I : Type uI} [Category.{vI} I]
+    {F : PresheafPFunctor.{uI, uI, uA, uB, vI, vI} I I} {j : I}
+    (z : (F.W).obj ⟨j⟩) : (F.objPresheaf F.W).obj ⟨j⟩ := by
+  have hz : F.IsHereditarilyNatural (SlicePFunctor.W.mk (SlicePFunctor.W.dest z.down.1)) := by
+    rw [SlicePFunctor.W.mk_dest]
+    exact z.down.2.2
+  have hchildren := ((F.isHereditarilyNatural_mk (SlicePFunctor.W.dest z.down.1)).mp hz).2
+  exact ⟨⟨rememberNode F (SlicePFunctor.W.dest z.down.1) hchildren,
+      (isHereditarilyNatural_mk_forgetNode F _).mp (by rw [forgetNode_rememberNode F]; exact hz)⟩,
+    calc F.q (SlicePFunctor.W.dest z.down.1).1.1
+        = F.toSlicePFunctor.windex (SlicePFunctor.W.mk (SlicePFunctor.W.dest z.down.1)) :=
+          (SlicePFunctor.W.windex_mk (SlicePFunctor.W.dest z.down.1)).symm
+      _ = F.toSlicePFunctor.windex z.down.1 := by rw [SlicePFunctor.W.mk_dest]
+      _ = j := z.down.2.1⟩
+
+/-- `dest` is a left inverse of `mk`. -/
+@[simp]
+theorem dest_mk {I : Type uI} [Category.{vI} I]
+    {F : PresheafPFunctor.{uI, uI, uA, uB, vI, vI} I I} {j : I}
+    (x : (F.objPresheaf F.W).obj ⟨j⟩) : dest (mk x) = x := by
+  apply Subtype.ext
+  apply Subtype.ext
+  have hz : F.IsHereditarilyNatural (SlicePFunctor.W.mk (F := F.toSlicePFunctor)
+      (SlicePFunctor.W.dest (F := F.toSlicePFunctor)
+        (SlicePFunctor.W.mk (F := F.toSlicePFunctor) (forgetNode F x.1.1)))) := by
+    rw [SlicePFunctor.W.mk_dest]
+    exact (isHereditarilyNatural_mk_forgetNode F x.1.1).mpr x.1.2
+  have hch := ((F.isHereditarilyNatural_mk (SlicePFunctor.W.dest (F := F.toSlicePFunctor)
+    (SlicePFunctor.W.mk (F := F.toSlicePFunctor) (forgetNode F x.1.1)))).mp hz).2
+  change rememberNode F (SlicePFunctor.W.dest (F := F.toSlicePFunctor)
+    (SlicePFunctor.W.mk (F := F.toSlicePFunctor) (forgetNode F x.1.1))) hch = x.1.1
+  have hy' : ∀ b, F.IsHereditarilyNatural ((forgetNode F x.1.1).1.2 b) :=
+    fun b => (x.1.1.1.2 b).2.down.2.2
+  exact (rememberNode_eq F hch hy'
+    (SlicePFunctor.W.dest_mk (F := F.toSlicePFunctor) (forgetNode F x.1.1))).trans
+    (rememberNode_forgetNode F x.1.1 hy')
+
+/-- `mk` is a left inverse of `dest`; with `dest_mk`, `mk` and `dest` are
+mutually inverse, so `F.W` is a fixed point of the `objPresheaf`-action at
+`F.W`. -/
+@[simp]
+theorem mk_dest {I : Type uI} [Category.{vI} I]
+    {F : PresheafPFunctor.{uI, uI, uA, uB, vI, vI} I I} {j : I}
+    (z : (F.W).obj ⟨j⟩) : mk (dest z) = z := by
+  have hz : F.IsHereditarilyNatural (SlicePFunctor.W.mk (SlicePFunctor.W.dest z.down.1)) := by
+    rw [SlicePFunctor.W.mk_dest]
+    exact z.down.2.2
+  have hch := ((F.isHereditarilyNatural_mk (SlicePFunctor.W.dest z.down.1)).mp hz).2
+  apply obj_ext F
+  change SlicePFunctor.W.mk (F := F.toSlicePFunctor) (forgetNode F
+    (rememberNode F (SlicePFunctor.W.dest (F := F.toSlicePFunctor) z.down.1) hch)) = z.down.1
+  rw [forgetNode_rememberNode, SlicePFunctor.W.mk_dest]
+
+/-- The carrier of the presheaf-`W` value fold: the slice `WIndex` (root index
+and admissibility) together with a hereditary-naturality proxy `H`, a value
+function producing a total-space element of `Y` once the subtree is admissible
+and hereditarily natural, and a proof `over` that the value lies over the
+index. -/
+@[ext]
+structure PElimData {I : Type uI} [Category.{vI} I]
+    (F : PresheafPFunctor.{uI, uI, uA, uB, vI, vI} I I)
+    (Y : Iᵒᵖ ⥤ Type (max uI uA uB)) extends SlicePFunctor.WIndex I where
+  /-- Hereditary naturality of the subtree, a fold-level proxy. -/
+  H : valid → Prop
+  /-- The subtree's contributed value, in the total space of `Y`, available once
+  the subtree is admissible and hereditarily natural. -/
+  value : (hv : valid) → H hv → Σ i : I, Y.obj ⟨i⟩
+  /-- The value lies over the index. -/
+  over : ∀ (hv : valid) (hn : H hv), (value hv hn).1 = index
+
+/-- The slice node over `elemProj Y` assembled from a shape `a` and the children
+carriers' values: the direction assignment sends `b` to the child value
+`(c b).value`, compatible with `elemProj Y` by the children's `over` and the
+node's `OverInput`. -/
+@[expose] def pnodeSlice {I : Type uI} [Category.{vI} I]
+    {F : PresheafPFunctor.{uI, uI, uA, uB, vI, vI} I I}
+    {Y : Iᵒᵖ ⥤ Type (max uI uA uB)} {a : F.toPFunctor.A}
+    (c : F.toPFunctor.B a → PElimData F Y)
+    (hv : F.toSlicePFunctor.NodeValid a (fun b => (c b).toWIndex))
+    (hc : ∀ b, (c b).H (hv.1 b)) :
+    F.toSliceDomPFunctor.Obj (PresheafDomPFunctorData.elemProj Y) :=
+  ⟨⟨a, fun b => (c b).value (hv.1 b) (hc b)⟩,
+    (F.toSliceDomPFunctor.compatible_iff (PresheafDomPFunctorData.elemProj Y) a _).mpr
+      fun b => ((c b).over (hv.1 b) (hc b)).trans (congrFun hv.2 b)⟩
+
+/-- The value-fold algebra step: index and admissibility as for `windexStep`; a
+hereditary-naturality proxy `H` combining the children's proxies with the
+naturality of the assembled node (`pnodeSlice`); and a value that applies the
+presheaf algebra `α` to that node, packaged over the shape's `q`-output index. -/
+@[expose] def pelimStep {I : Type uI} [Category.{vI} I]
+    (F : PresheafPFunctor.{uI, uI, uA, uB, vI, vI} I I)
+    (Y : Iᵒᵖ ⥤ Type (max uI uA uB)) (α : NatTrans (F.objPresheaf Y) Y) :
+    F.toPFunctor.Obj (PElimData F Y) → PElimData F Y :=
+  fun x =>
+    { index := F.q x.1
+      valid := F.toSlicePFunctor.NodeValid x.1 (fun b => (x.2 b).toWIndex)
+      H := fun hv => (∀ b, (x.2 b).H (hv.1 b)) ∧
+        (∀ hc : (∀ b, (x.2 b).H (hv.1 b)), F.IsNatural (pnodeSlice x.2 hv hc))
+      value := fun hv hn =>
+        ⟨F.q x.1, α.app ⟨F.q x.1⟩ ⟨⟨pnodeSlice x.2 hv hn.1, hn.2 hn.1⟩, rfl⟩⟩
+      over := fun _ _ => rfl }
+
+/-- The value fold: the `F.toPFunctor`-algebra morphism into
+`(PElimData F Y, pelimStep)` given by `WType.elim`, a single non-dependent fold
+with no explicit recursion. -/
+@[expose] def pelimData {I : Type uI} [Category.{vI} I]
+    (F : PresheafPFunctor.{uI, uI, uA, uB, vI, vI} I I)
+    (Y : Iᵒᵖ ⥤ Type (max uI uA uB)) (α : NatTrans (F.objPresheaf Y) Y) :
+    F.toPFunctor.W → PElimData F Y :=
+  WType.elim (PElimData F Y) (pelimStep F Y α)
+
+/-- The index-and-admissibility projection of `pelimData` agrees with the slice
+fold `windexValid`: the value fold refines the slice fold, so admissibility and
+the root index transport from the slice results. Proved by the dependent
+recursor `WType.rec`. -/
+theorem pelimData_toWIndex {I : Type uI} [Category.{vI} I]
+    (F : PresheafPFunctor.{uI, uI, uA, uB, vI, vI} I I)
+    (Y : Iᵒᵖ ⥤ Type (max uI uA uB)) (α : NatTrans (F.objPresheaf Y) Y) (w : F.toPFunctor.W) :
+    (pelimData F Y α w).toWIndex = F.windexValid w :=
+  WType.rec (motive := fun w => (pelimData F Y α w).toWIndex = F.windexValid w)
+    (fun a f ih => by
+      change F.windexStep ⟨a, fun b => (pelimData F Y α (f b)).toWIndex⟩ =
+        F.windexStep ⟨a, fun b => F.windexValid (f b)⟩
+      rw [funext ih])
+    w
+
+/-- The admissibility component of `pelimData` is `WValid`. -/
+theorem pelimData_valid {I : Type uI} [Category.{vI} I]
+    (F : PresheafPFunctor.{uI, uI, uA, uB, vI, vI} I I)
+    (Y : Iᵒᵖ ⥤ Type (max uI uA uB)) (α : NatTrans (F.objPresheaf Y) Y) (w : F.toPFunctor.W) :
+    (pelimData F Y α w).valid = F.WValid w :=
+  congrArg SlicePFunctor.WIndex.valid (pelimData_toWIndex F Y α w)
+
+/-- The index component of `pelimData` is the root index. -/
+theorem pelimData_index {I : Type uI} [Category.{vI} I]
+    (F : PresheafPFunctor.{uI, uI, uA, uB, vI, vI} I I)
+    (Y : Iᵒᵖ ⥤ Type (max uI uA uB)) (α : NatTrans (F.objPresheaf Y) Y) (w : F.toPFunctor.W) :
+    (pelimData F Y α w).index = F.windexRoot w :=
+  (congrArg SlicePFunctor.WIndex.index (pelimData_toWIndex F Y α w)).trans
+    (F.windexValid_index_eq_windexRoot w)
+
+/-- A natural transformation's components respect heterogeneous equality of
+fibre elements over equal indices. -/
+private theorem app_heq.{w} {I : Type uI} [Category.{vI} I]
+    {Z Z' : Iᵒᵖ ⥤ Type w} (β : NatTrans Z Z') {k k' : I} (hk : k = k')
+    {x : Z.obj ⟨k⟩} {x' : Z.obj ⟨k'⟩} (hx : x ≍ x') :
+    β.app ⟨k⟩ x ≍ β.app ⟨k'⟩ x' := by
+  cases hk
+  cases hx
+  rfl
+
+/-- Two fibre elements of `objPresheaf Y` over equal indices whose underlying
+dom values are equal are heterogeneously equal. -/
+private theorem objPresheaf_obj_heq {I : Type uI} [Category.{vI} I]
+    (F : PresheafPFunctor.{uI, uI, uA, uB, vI, vI} I I) (Y : Iᵒᵖ ⥤ Type (max uI uA uB))
+    {k k' : I} (hk : k = k') {u : (F.objPresheaf Y).obj ⟨k⟩} {u' : (F.objPresheaf Y).obj ⟨k'⟩}
+    (h : u.1 = u'.1) : u ≍ u' := by
+  cases hk
+  exact heq_of_eq (Subtype.ext h)
+
+/-- Value restriction coherence at the fold level: the fold value on the
+root-restriction of a tree is the `Y`-restriction of the fold value. A one-level
+argument: the restricted node's fold node is the `objPresheaf`-restriction of the
+node, so `α`'s naturality relates their `α`-images. -/
+theorem value_wRestrTree {I : Type uI} [Category.{vI} I]
+    (F : PresheafPFunctor.{uI, uI, uA, uB, vI, vI} I I)
+    (Y : Iᵒᵖ ⥤ Type (max uI uA uB)) (α : NatTrans (F.objPresheaf Y) Y)
+    (t : F.toSlicePFunctor.W) ⦃i i' : I⦄ (f : i' ⟶ i)
+    (hqi : F.q (PFunctor.W.head t.1) = i)
+    (hv : (pelimData F Y α t.1).valid) (hn : (pelimData F Y α t.1).H hv)
+    (hv' : (pelimData F Y α (F.wRestrTree f t hqi).1).valid)
+    (hn' : (pelimData F Y α (F.wRestrTree f t hqi).1).H hv') :
+    (pelimData F Y α (F.wRestrTree f t hqi).1).value hv' hn' =
+      ⟨i', Y.map f.op (cast (congrArg (fun k : I => Y.obj ⟨k⟩)
+          (((pelimData F Y α t.1).over hv hn).trans
+            ((pelimData_index F Y α t.1).trans hqi)))
+        ((pelimData F Y α t.1).value hv hn).2)⟩ := by
+  obtain ⟨tree, hval⟩ := t
+  cases tree with
+  | mk a fchild =>
+    refine Sigma.ext (F.shapeRestr f ⟨a, hqi⟩).2 ?_
+    have hqa : F.q a = i := hqi
+    subst hqa
+    have hnat :
+        Y.map f.op (α.app ⟨F.q a⟩ (⟨⟨pnodeSlice (fun b => pelimData F Y α (fchild b)) hv hn.1,
+            hn.2 hn.1⟩, rfl⟩ : (F.objPresheaf Y).obj ⟨F.q a⟩)) =
+          α.app ⟨i'⟩ ((F.objPresheaf Y).map f.op
+            ⟨⟨pnodeSlice (fun b => pelimData F Y α (fchild b)) hv hn.1, hn.2 hn.1⟩, rfl⟩) := by
+      exact (FunctorToTypes.naturality _ _ α f.op _).symm
+    change (α.app ⟨F.q (F.shapeRestr f ⟨a, hqi⟩).1⟩
+          (⟨⟨F.objRestrElt f (pnodeSlice (fun b => pelimData F Y α (fchild b)) hv hn.1) hqi,
+            hn'.2 hn'.1⟩, rfl⟩ : (F.objPresheaf Y).obj ⟨F.q (F.shapeRestr f ⟨a, hqi⟩).1⟩)) ≍
+        Y.map f.op (α.app ⟨F.q a⟩
+          (⟨⟨pnodeSlice (fun b => pelimData F Y α (fchild b)) hv hn.1, hn.2 hn.1⟩, rfl⟩ :
+            (F.objPresheaf Y).obj ⟨F.q a⟩))
+    rw [hnat]
+    exact app_heq α (F.shapeRestr f ⟨a, hqi⟩).2
+      (objPresheaf_obj_heq F Y (F.shapeRestr f ⟨a, hqi⟩).2 (Subtype.ext rfl))
+
+/-- The node the value fold assembles at a slice node whose children are folds of
+hereditarily-natural subtrees is natural: local naturality of the enclosing tree
+(each child restricting to the child at the reindexed direction) transports
+through the fold's value-restriction coherence `value_wRestrTree`. -/
+private theorem isNatural_pnodeSlice {I : Type uI} [Category.{vI} I]
+    (F : PresheafPFunctor.{uI, uI, uA, uB, vI, vI} I I)
+    (Y : Iᵒᵖ ⥤ Type (max uI uA uB)) (α : NatTrans (F.objPresheaf Y) Y)
+    {a : F.toPFunctor.A} (fc : F.toPFunctor.B a → F.toSlicePFunctor.W)
+    (hv : F.toSlicePFunctor.NodeValid a (fun b => (pelimData F Y α (fc b).1).toWIndex))
+    (hc : ∀ b, (pelimData F Y α (fc b).1).H (hv.1 b))
+    (hloc : ∀ ⦃i i' : I⦄ (g : i' ⟶ i) (b : F.toSliceDomPFunctor.Direction a i)
+        (hq : F.q (PFunctor.W.head (fc b.1).1) = i),
+        fc (F.directionRestr a g b).1 = F.wRestrTree g (fc b.1) hq) :
+    F.IsNatural (pnodeSlice (fun b => pelimData F Y α (fc b).1) hv hc) := by
+  intro i i' g b
+  change F.value (pnodeSlice (fun b => pelimData F Y α (fc b).1) hv hc) (F.directionRestr a g b) =
+    Y.map g.op (F.value (pnodeSlice (fun b => pelimData F Y α (fc b).1) hv hc) b)
+  have hqit : F.q (PFunctor.W.head (fc b.1).1) = i :=
+    (pelimData_index F Y α (fc b.1).1).symm.trans ((congrFun hv.2 b.1).trans b.2)
+  have hgen : ∀ (T : F.toSlicePFunctor.W) (hvT : (pelimData F Y α T.1).valid)
+      (hnT : (pelimData F Y α T.1).H hvT), T = F.wRestrTree g (fc b.1) hqit →
+      (pelimData F Y α T.1).value hvT hnT =
+        ⟨i', Y.map g.op (cast (congrArg (fun k : I => Y.obj ⟨k⟩)
+            (((pelimData F Y α (fc b.1).1).over (hv.1 b.1) (hc b.1)).trans
+              ((pelimData_index F Y α (fc b.1).1).trans hqit)))
+          ((pelimData F Y α (fc b.1).1).value (hv.1 b.1) (hc b.1)).2)⟩ := by
+    intro T hvT hnT hT
+    subst hT
+    exact value_wRestrTree F Y α (fc b.1) g hqit (hv.1 b.1) (hc b.1) hvT hnT
+  have hchild :
+      (pnodeSlice (fun b => pelimData F Y α (fc b).1) hv hc).1.2
+          (F.directionRestr a g b).1 =
+        ⟨i', Y.map g.op (cast (congrArg (fun k : I => Y.obj ⟨k⟩)
+            (((pelimData F Y α (fc b.1).1).over (hv.1 b.1) (hc b.1)).trans
+              ((pelimData_index F Y α (fc b.1).1).trans hqit)))
+          ((pelimData F Y α (fc b.1).1).value (hv.1 b.1) (hc b.1)).2)⟩ :=
+    hgen (fc (F.directionRestr a g b).1) (hv.1 (F.directionRestr a g b).1)
+      (hc (F.directionRestr a g b).1) (hloc g b hqit)
+  simp only [PresheafDomPFunctorData.value]
+  apply eq_of_heq
+  refine (cast_heq _ _).trans ?_
+  rw [hchild]
+  rfl
+
+/-- The node the value fold assembles at a validated hereditarily-natural tree,
+as an element of the output presheaf's fibre over the root index: the shape and
+the children's fold values, natural by the tree's hereditary naturality. -/
+theorem pelimData_H_of_isHN {I : Type uI} [Category.{vI} I]
+    (F : PresheafPFunctor.{uI, uI, uA, uB, vI, vI} I I)
+    (Y : Iᵒᵖ ⥤ Type (max uI uA uB)) (α : NatTrans (F.objPresheaf Y) Y)
+    (w : F.toSlicePFunctor.W) (hv : (pelimData F Y α w.1).valid)
+    (hn : F.IsHereditarilyNatural w) : (pelimData F Y α w.1).H hv :=
+  SlicePFunctor.W.ind
+    (motive := fun z => ∀ (hv : (pelimData F Y α z.1).valid),
+      F.IsHereditarilyNatural z → (pelimData F Y α z.1).H hv)
+    (fun x ih hv hHN => by
+      refine ⟨fun b => ih b (hv.1 b) (((F.isHereditarilyNatural_mk x).mp hHN).2 b), fun _ => ?_⟩
+      exact isNatural_pnodeSlice F Y α x.1.2 hv
+        (fun b => ih b (hv.1 b) (((F.isHereditarilyNatural_mk x).mp hHN).2 b))
+        (fun _ _ g b _ => ((F.isHereditarilyNatural_mk x).mp hHN).1 g b))
+    w hv hn
+
+/-- The fibre value the fold contributes to a validated hereditarily-natural
+tree indexed at `j`: the total-space value's `Y`-component, transported to the
+fibre over `j` through the fold's `over` law and root-index agreement. -/
+@[expose] def elimVal {I : Type uI} [Category.{vI} I]
+    (F : PresheafPFunctor.{uI, uI, uA, uB, vI, vI} I I)
+    (Y : Iᵒᵖ ⥤ Type (max uI uA uB)) (α : NatTrans (F.objPresheaf Y) Y) {j : I}
+    (z : (F.W).obj ⟨j⟩) : Y.obj ⟨j⟩ :=
+  cast (congrArg (fun i : I => Y.obj ⟨i⟩)
+      ((((pelimData F Y α z.down.1.1).over
+          ((pelimData_valid F Y α z.down.1.1) ▸ z.down.1.2)
+          (pelimData_H_of_isHN F Y α z.down.1
+            ((pelimData_valid F Y α z.down.1.1) ▸ z.down.1.2) z.down.2.2)).trans
+        (pelimData_index F Y α z.down.1.1)).trans z.down.2.1))
+    ((pelimData F Y α z.down.1.1).value
+      ((pelimData_valid F Y α z.down.1.1) ▸ z.down.1.2)
+      (pelimData_H_of_isHN F Y α z.down.1
+        ((pelimData_valid F Y α z.down.1.1) ▸ z.down.1.2) z.down.2.2)).2
+
+/-- The total-space fold value at a carrier element is `elimVal` paired with the
+index: the `Y`-component is `elimVal` and the base point is the fibre index.
+Proof-irrelevance identifies the fold's internal hereditary-naturality proof with
+any supplied one. -/
+theorem value_eq_elimVal {I : Type uI} [Category.{vI} I]
+    (F : PresheafPFunctor.{uI, uI, uA, uB, vI, vI} I I)
+    (Y : Iᵒᵖ ⥤ Type (max uI uA uB)) (α : NatTrans (F.objPresheaf Y) Y) {j : I}
+    (z : (F.W).obj ⟨j⟩) (hv : (pelimData F Y α z.down.1.1).valid)
+    (hn : (pelimData F Y α z.down.1.1).H hv) :
+    (pelimData F Y α z.down.1.1).value hv hn = ⟨j, elimVal F Y α z⟩ := by
+  refine Sigma.ext (((((pelimData F Y α z.down.1.1).over hv hn).trans
+    (pelimData_index F Y α z.down.1.1)).trans z.down.2.1)) ?_
+  exact (cast_heq _ _).symm
+
+/-- `elimVal` commutes with the restriction maps: the value of a restricted
+carrier element is the `Y`-restriction of the value. It glues the fold-level
+restriction coherence `value_wRestrTree` (the one-level argument, combining the
+fold's one-level computation with `α`'s naturality) with `value_eq_elimVal`,
+which identifies the two total-space fold values' fibre components with the two
+`elimVal`s; the tree recursion is confined to `pelimData_H_of_isHN`. -/
+theorem elimVal_wRestr {I : Type uI} [Category.{vI} I]
+    (F : PresheafPFunctor.{uI, uI, uA, uB, vI, vI} I I)
+    (Y : Iᵒᵖ ⥤ Type (max uI uA uB)) (α : NatTrans (F.objPresheaf Y) Y) ⦃i i' : I⦄
+    (g : i' ⟶ i) (z : (F.W).obj ⟨i⟩) :
+    elimVal F Y α ((F.W).map g.op z) = Y.map g.op (elimVal F Y α z) := by
+  have hvz : (pelimData F Y α z.down.1.1).valid :=
+    (pelimData_valid F Y α z.down.1.1) ▸ z.down.1.2
+  have hnz : (pelimData F Y α z.down.1.1).H hvz :=
+    pelimData_H_of_isHN F Y α z.down.1 hvz z.down.2.2
+  have hvzr : (pelimData F Y α ((F.W).map g.op z).down.1.1).valid :=
+    (pelimData_valid F Y α ((F.W).map g.op z).down.1.1) ▸ ((F.W).map g.op z).down.1.2
+  have hnzr : (pelimData F Y α ((F.W).map g.op z).down.1.1).H hvzr :=
+    pelimData_H_of_isHN F Y α ((F.W).map g.op z).down.1 hvzr ((F.W).map g.op z).down.2.2
+  have eR := value_eq_elimVal F Y α ((F.W).map g.op z) hvzr hnzr
+  have eW := value_wRestrTree F Y α z.down.1 g z.down.2.1 hvz hnz hvzr hnzr
+  have key : (⟨i', elimVal F Y α ((F.W).map g.op z)⟩ : Σ k : I, Y.obj ⟨k⟩)
+      = ⟨i', Y.map g.op (elimVal F Y α z)⟩ := eR.symm.trans eW
+  exact eq_of_heq (Sigma.ext_iff.mp key).2
+
+/-- The eliminator of the presheaf W-type: the natural transformation into any
+presheaf algebra `(Y, α)`. Its component over `j` is the bespoke value fold
+`elimVal`; naturality is `elimVal_wRestr`. The existence half of initiality. -/
+@[expose] def elim {I : Type uI} [Category.{vI} I]
+    (F : PresheafPFunctor.{uI, uI, uA, uB, vI, vI} I I)
+    (Y : Iᵒᵖ ⥤ Type (max uI uA uB)) (α : NatTrans (F.objPresheaf Y) Y) :
+    NatTrans F.W Y where
+  app j := ↾ fun z => elimVal F Y α (j := j.unop) z
+  naturality _ _ g := by
+    ext z
+    exact elimVal_wRestr F Y α g.unop z
+
+/-- `elim` is a genuine presheaf morphism: it commutes with the restriction
+maps of `F.W` and `Y`. The `NatTrans` naturality of `elim`, mirroring the slice
+`comp_elim`. -/
+theorem comp_elim {I : Type uI} [Category.{vI} I]
+    (F : PresheafPFunctor.{uI, uI, uA, uB, vI, vI} I I)
+    (Y : Iᵒᵖ ⥤ Type (max uI uA uB)) (α : NatTrans (F.objPresheaf Y) Y) ⦃i i' : I⦄
+    (g : i' ⟶ i) (z : (F.W).obj ⟨i⟩) :
+    (elim F Y α).app ⟨i'⟩ ((F.W).map g.op z) = Y.map g.op ((elim F Y α).app ⟨i⟩ z) :=
+  elimVal_wRestr F Y α g z
+
+/-- The computation rule for `elim`: it commutes with the constructor `mk`, i.e.
+it is a morphism of presheaf algebras. -/
+theorem elim_mk {I : Type uI} [Category.{vI} I]
+    (F : PresheafPFunctor.{uI, uI, uA, uB, vI, vI} I I)
+    (Y : Iᵒᵖ ⥤ Type (max uI uA uB)) (α : NatTrans (F.objPresheaf Y) Y) {j : I}
+    (x : (F.objPresheaf F.W).obj ⟨j⟩) :
+    (elim F Y α).app ⟨j⟩ (mk x) =
+      α.app ⟨j⟩ ((F.mapPresheaf (elim F Y α)).app ⟨j⟩ x) := by
+  have hv : (pelimData F Y α (mk x).down.1.1).valid :=
+    (pelimData_valid F Y α (mk x).down.1.1) ▸ (mk x).down.1.2
+  have hn : (pelimData F Y α (mk x).down.1.1).H hv :=
+    pelimData_H_of_isHN F Y α (mk x).down.1 hv (mk x).down.2.2
+  have hq : F.q x.1.1.1.1 = j := x.2
+  have hchild : ∀ b, (pelimData F Y α (x.1.1.1.2 b).2.down.1.1).value (hv.1 b) (hn.1 b)
+      = (⟨(x.1.1.1.2 b).1, elimVal F Y α (x.1.1.1.2 b).2⟩ : Σ i : I, Y.obj ⟨i⟩) :=
+    fun b => value_eq_elimVal F Y α (x.1.1.1.2 b).2 (hv.1 b) (hn.1 b)
+  have hval := value_eq_elimVal F Y α (mk x) hv hn
+  apply eq_of_heq
+  refine ((Sigma.ext_iff.mp hval).2.symm).trans ?_
+  refine app_heq α hq ?_
+  refine objPresheaf_obj_heq F Y hq ?_
+  apply Subtype.ext
+  apply Subtype.ext
+  exact Sigma.ext rfl (heq_of_eq (funext fun b => hchild b))
+
+end W
+
+end PresheafPFunctor

--- a/geb-lean/vendor/geb-mathlib/Geb/Mathlib/Data/PFunctor/Slice.lean
+++ b/geb-lean/vendor/geb-mathlib/Geb/Mathlib/Data/PFunctor/Slice.lean
@@ -7,6 +7,7 @@ module
 
 public import Geb.Mathlib.Data.PFunctor.Slice.Basic
 public import Geb.Mathlib.Data.PFunctor.Slice.Functor
+public import Geb.Mathlib.Data.PFunctor.Slice.W
 
 /-!
 # Slice — index

--- a/geb-lean/vendor/geb-mathlib/Geb/Mathlib/Data/PFunctor/Slice/Basic.lean
+++ b/geb-lean/vendor/geb-mathlib/Geb/Mathlib/Data/PFunctor/Slice/Basic.lean
@@ -11,11 +11,20 @@ public import Mathlib.Data.PFunctor.Univariate.Basic
 /-!
 # Slice polynomial functors on `Type` (constructive core)
 
-A `PFunctor` is the middle leg of a Gambino–Hyland polynomial diagram
-`dom ◀ s ─ Idx ─ fst ▶ A ─ t ▶ cod`. Adding `s : Idx → dom` and
-`t : A → cod` yields a polynomial functor `Type/dom → Type/cod`,
+A `PFunctor` is the middle map of a Gambino–Hyland polynomial diagram
+`dom ◀ r ─ Idx ─ fst ▶ A ─ q ▶ cod`. Adding `r : Idx → dom` and
+`q : A → cod` yields a polynomial functor `Type/dom → Type/cod`,
 defined as a restriction of the interpretation `P.Obj X = Σ a, B a → X`
-to `s`-compatible direction assignments, tagged by `t`.
+to `r`-compatible direction assignments, each shape carrying an output
+index via `q`. This is a dependent polynomial functor
+[GambinoHyland2004], [GambinoKock2013], equivalently an indexed
+container [AltenkirchGhaniHancockMcBrideMorris2015]; that reference
+presents it as a two-field `(shapes, positions)` record with the
+indices folded into dependent types, whereas here the index
+assignments are the explicit maps `q` and `r`. The letters `q`
+(shape-output) and `r` (direction-input) are this development's; the
+polynomial-diagram sources letter the map into `cod` as `t` and the
+map into `dom` as `s`.
 
 This file is the constructive core: the structures, the compatibility
 predicate, the curried constructor, and the object/morphism maps with
@@ -27,10 +36,10 @@ categorical packaging is in the sibling `Slice.Functor` module.
 
 * `SliceDomPFunctor`, `SlicePFunctor` — the structures.
 * `SliceDomPFunctor.Compatible` — the direction-compatibility predicate.
-* `SliceDomPFunctor.ofCurried` / `sCurried` — the curried constructor and
-  the constraint leg in dependently-curried form.
-* `SliceDomPFunctor.DirectionOver` / `Direction` — the constraint-leg
-  condition on a direction of shape `a`, and the fibre of `sCurried a`
+* `SliceDomPFunctor.ofCurried` / `rCurried` — the curried constructor and
+  the direction-input map in dependently-curried form.
+* `SliceDomPFunctor.DirectionOver` / `Direction` — the direction-input-map
+  condition on a direction of shape `a`, and the fibre of `rCurried a`
   over `i`.
 * `SliceDomPFunctor.Obj` / `map` — the domain-restricted functor's
   object and morphism maps; `map_id` / `map_comp` its functoriality.
@@ -38,8 +47,8 @@ categorical packaging is in the sibling `Slice.Functor` module.
   `obj` is the output object's structure map into `cod`, `map` the
   underlying function; `map_w` that it lies over `cod`, `map_id` /
   `map_comp` its functoriality.
-* `SlicePFunctor.ShapeOver` / `Shape` — the tag-leg condition and the
-  fibre of `t` over `j`.
+* `SlicePFunctor.ShapeOver` / `Shape` — the shape-output-map condition and
+  the fibre of `q` over `j`.
 
 ## Main statements
 
@@ -56,16 +65,18 @@ categorical packaging is in the sibling `Slice.Functor` module.
 `PFunctor.map` restricted; functoriality reuses
 `PFunctor.id_map` / `PFunctor.map_map`. The `SlicePFunctor` interpretation
 reuses these — its carrier is `SliceDomPFunctor.Obj` and its `map` the
-`SliceDomPFunctor` map — adding only the `t`-tag (`obj`) and the
-tag-compatibility (`map_w`); `map_id` / `map_comp` delegate to the
-domain-side ones. `SliceDomPFunctor.Obj` and `SlicePFunctor.obj`, both
+`SliceDomPFunctor` map — adding only the `q`-assigned output index
+(`obj`) and the output-index compatibility (`map_w`); `map_id` /
+`map_comp` delegate to the domain-side ones. `SliceDomPFunctor.Obj` and
+`SlicePFunctor.obj`, both
 namespaces' `map`,
-`SliceDomPFunctor.ofCurried` / `sCurried` / `DirectionOver` / `Direction`,
+`SliceDomPFunctor.ofCurried` / `rCurried` / `DirectionOver` / `Direction`,
 and `SlicePFunctor.ShapeOver` / `Shape` are `@[expose]` so the
 wrapper and tests can unfold them across the module boundary.
 
 ## References
 
+* [AltenkirchGhaniHancockMcBrideMorris2015]
 * [GambinoHyland2004]
 * [GambinoKock2013]
 
@@ -79,59 +90,59 @@ public section
 
 universe uA uB uD uC uX uX' uY uZ
 
-/-- A polynomial functor with a constraint leg `s` assigning each
+/-- A polynomial functor with a direction-input map `r` assigning each
 `(shape, direction)` pair (an element of `PFunctor.Idx`) a `dom`-index. -/
 @[nolint checkUnivs]
 structure SliceDomPFunctor (dom : Type uD) : Type (max (uA + 1) (uB + 1) uD)
     extends PFunctor.{uA, uB} where
-  /-- The constraint leg: each direction is assigned a `dom`-index. -/
-  s : toPFunctor.Idx → dom
+  /-- The direction-input map: each direction is assigned a `dom`-index. -/
+  r : toPFunctor.Idx → dom
 
-/-- A `SliceDomPFunctor` with a tag leg `t` assigning each shape a
+/-- A `SliceDomPFunctor` with a shape-output map `q` assigning each shape a
 `cod`-index. -/
 @[nolint checkUnivs]
 structure SlicePFunctor (dom : Type uD) (cod : Type uC) : Type (max (uA + 1) (uB + 1) uC uD)
     extends SliceDomPFunctor.{uA, uB, uD} dom where
-  /-- The tag leg: each shape is assigned a `cod`-index. -/
-  t : toPFunctor.A → cod
+  /-- The shape-output map: each shape is assigned a `cod`-index. -/
+  q : toPFunctor.A → cod
 
 attribute [ext] SliceDomPFunctor SlicePFunctor
 
 namespace SliceDomPFunctor
 
-/-- A direction assignment `v : F.B a → X` is compatible with a base map
+/-- A direction assignment `v : F.B a → X` is compatible with a projection
 `p : X → dom` when, as functions `F.B a → dom`, `p ∘ v` equals the
-constraint leg restricted to shape `a`. Pointwise: `p (v b) = s ⟨a, b⟩`. -/
+direction-input map restricted to shape `a`. Pointwise: `p (v b) = r ⟨a, b⟩`. -/
 def Compatible {dom : Type uD} (F : SliceDomPFunctor.{uA, uB} dom) {X : Type uX}
     (p : X → dom) (a : F.A) (v : F.B a → X) : Prop :=
-  p ∘ v = F.s ∘ Sigma.mk a
+  p ∘ v = F.r ∘ Sigma.mk a
 
 /-- `Compatible` stated pointwise. -/
 theorem compatible_iff {dom : Type uD} (F : SliceDomPFunctor.{uA, uB} dom)
     {X : Type uX} (p : X → dom) (a : F.A) (v : F.B a → X) :
-    F.Compatible p a v ↔ ∀ b, p (v b) = F.s ⟨a, b⟩ :=
+    F.Compatible p a v ↔ ∀ b, p (v b) = F.r ⟨a, b⟩ :=
   funext_iff
 
-/-- Build a `SliceDomPFunctor` from the dependently-curried constraint
-leg. -/
+/-- Build a `SliceDomPFunctor` from the dependently-curried
+direction-input map. -/
 @[expose] def ofCurried (P : PFunctor.{uA, uB}) (dom : Type uD)
     (sc : (a : P.A) → P.B a → dom) : SliceDomPFunctor dom where
   toPFunctor := P
-  s := fun x => sc x.1 x.2
+  r := fun x => sc x.1 x.2
 
-/-- The constraint leg in dependently-curried form. -/
-@[expose] def sCurried {dom : Type uD} (F : SliceDomPFunctor.{uA, uB} dom) (a : F.A)
+/-- The direction-input map in dependently-curried form. -/
+@[expose] def rCurried {dom : Type uD} (F : SliceDomPFunctor.{uA, uB} dom) (a : F.A)
     (b : F.B a) : dom :=
-  F.s ⟨a, b⟩
+  F.r ⟨a, b⟩
 
-/-- The constraint-leg condition on a direction of shape `a`: that its
-image under `sCurried a` is `i`. Point-free as `(· = i) ∘ sCurried a`. -/
+/-- The direction-input-map condition on a direction of shape `a`: that its
+image under `rCurried a` is `i`. Point-free as `(· = i) ∘ rCurried a`. -/
 @[expose] def DirectionOver {dom : Type uD} (F : SliceDomPFunctor.{uA, uB} dom)
     (a : F.A) (i : dom) : F.B a → Prop :=
-  (· = i) ∘ F.sCurried a
+  (· = i) ∘ F.rCurried a
 
 /-- The directions of shape `a` lying over the base point `i`: the fibre
-of `sCurried a` over `i`. -/
+of `rCurried a` over `i`. -/
 @[expose] def Direction {dom : Type uD} (F : SliceDomPFunctor.{uA, uB} dom)
     (a : F.A) (i : dom) : Type uB :=
   Subtype (F.DirectionOver a i)
@@ -150,7 +161,7 @@ restricted to the compatibility subtype. -/
     F.Obj p → F.Obj p' :=
   fun x => ⟨F.toPFunctor.map f x.1, by
     obtain ⟨⟨a, v⟩, hx⟩ := x
-    change p' ∘ (f ∘ v) = F.s ∘ Sigma.mk a
+    change p' ∘ (f ∘ v) = F.r ∘ Sigma.mk a
     rw [← Function.comp_assoc, hf]
     exact hx⟩
 
@@ -168,8 +179,8 @@ theorem map_id {dom : Type uD} (F : SliceDomPFunctor.{uA, uB} dom) {X : Type uX}
 /-- Functoriality: composition. -/
 theorem map_comp {dom : Type uD} (F : SliceDomPFunctor.{uA, uB} dom)
     {X : Type uX} {Y : Type uY} {Z : Type uZ}
-    {p : X → dom} {q : Y → dom} {r : Z → dom} (f : X → Y) (g : Y → Z)
-    (hf : q ∘ f = p) (hg : r ∘ g = q) :
+    {p : X → dom} {p' : Y → dom} {p'' : Z → dom} (f : X → Y) (g : Y → Z)
+    (hf : p' ∘ f = p) (hg : p'' ∘ g = p') :
     F.map (g ∘ f) (by rw [← hf, ← hg, Function.comp_assoc]) =
       F.map g hg ∘ F.map f hf :=
   funext fun x => Subtype.ext (F.toPFunctor.map_map f g x.1).symm
@@ -179,11 +190,11 @@ end SliceDomPFunctor
 namespace SlicePFunctor
 
 /-- The slice functor's value on `(X, p)`, as an object of `Type/cod`: its
-structure map into `cod`, the tag leg applied to each shape. The carrier is
-the `SliceDomPFunctor` value `F.toSliceDomPFunctor.Obj p`. -/
+structure map into `cod`, the shape-output map applied to each shape. The
+carrier is the `SliceDomPFunctor` value `F.toSliceDomPFunctor.Obj p`. -/
 @[expose] def obj {dom : Type uD} {cod : Type uC} (F : SlicePFunctor.{uA, uB, uD, uC} dom cod)
     {X : Type uX} (p : X → dom) : F.toSliceDomPFunctor.Obj p → cod :=
-  fun z => F.t z.1.1
+  fun z => F.q z.1.1
 
 /-- The slice functor's action on a morphism: the `SliceDomPFunctor` morphism
 map underlying it. -/
@@ -196,7 +207,7 @@ map underlying it. -/
 theorem map_w {dom : Type uD} {cod : Type uC} (F : SlicePFunctor.{uA, uB, uD, uC} dom cod)
     {X : Type uX} {X' : Type uX'} {p : X → dom} {p' : X' → dom} (f : X → X') (hf : p' ∘ f = p) :
     F.obj p' ∘ F.map f hf = F.obj p :=
-  funext fun z => congrArg F.t (F.toSliceDomPFunctor.map_fst f hf z)
+  funext fun z => congrArg F.q (F.toSliceDomPFunctor.map_fst f hf z)
 
 /-- Functoriality: identity. -/
 theorem map_id {dom : Type uD} {cod : Type uC} (F : SlicePFunctor.{uA, uB, uD, uC} dom cod)
@@ -207,18 +218,18 @@ theorem map_id {dom : Type uD} {cod : Type uC} (F : SlicePFunctor.{uA, uB, uD, u
 /-- Functoriality: composition. -/
 theorem map_comp {dom : Type uD} {cod : Type uC} (F : SlicePFunctor.{uA, uB, uD, uC} dom cod)
     {X : Type uX} {Y : Type uY} {Z : Type uZ}
-    {p : X → dom} {q : Y → dom} {r : Z → dom} (f : X → Y) (g : Y → Z)
-    (hf : q ∘ f = p) (hg : r ∘ g = q) :
+    {p : X → dom} {p' : Y → dom} {p'' : Z → dom} (f : X → Y) (g : Y → Z)
+    (hf : p' ∘ f = p) (hg : p'' ∘ g = p') :
     F.map (g ∘ f) (by rw [← hf, ← hg, Function.comp_assoc]) = F.map g hg ∘ F.map f hf :=
   F.toSliceDomPFunctor.map_comp f g hf hg
 
-/-- The tag-leg condition on a shape: that its image under `t` is `j`.
-Point-free as `(· = j) ∘ t`. -/
+/-- The shape-output-map condition on a shape: that its image under `q`
+is `j`. Point-free as `(· = j) ∘ q`. -/
 @[expose] def ShapeOver {dom : Type uD} {cod : Type uC}
     (F : SlicePFunctor.{uA, uB, uD, uC} dom cod) (j : cod) : F.A → Prop :=
-  (· = j) ∘ F.t
+  (· = j) ∘ F.q
 
-/-- The shapes lying over `j`: the fibre of `t` over `j`. -/
+/-- The shapes lying over `j`: the fibre of `q` over `j`. -/
 @[expose] def Shape {dom : Type uD} {cod : Type uC}
     (F : SlicePFunctor.{uA, uB, uD, uC} dom cod) (j : cod) : Type uA :=
   Subtype (F.ShapeOver j)

--- a/geb-lean/vendor/geb-mathlib/Geb/Mathlib/Data/PFunctor/Slice/Functor.lean
+++ b/geb-lean/vendor/geb-mathlib/Geb/Mathlib/Data/PFunctor/Slice/Functor.lean
@@ -37,10 +37,11 @@ read as functions, the slice-morphism hypothesis is
 `SliceDomPFunctor.over_hom_comp` (the function-level form of `Over.w`),
 results promoted with `↾`, the identity law discharged by `ext` and the
 core `map_id`, and the composition law by `ext` and `rfl`. `functor` is
-the `Functor.toOver` lift along the tag `t`; it is `@[expose]` so
-`functor_obj` / `functor_map` can state the definitional equalities as
-exported `rfl` theorems. `cod` is pinned to `domFunctor`'s codomain
-universe `max uA uB uD` because `Functor.toOver` requires its over-base
+the `Functor.toOver` lift along the shape-output map `q`; it is
+`@[expose]` so `functor_obj` / `functor_map` can state the definitional
+equalities as exported `rfl` theorems. `cod` is pinned to `domFunctor`'s
+codomain universe `max uA uB uD` because `Functor.toOver` requires its
+over-base
 object to inhabit the codomain category of the lifted functor, so the
 core's `cod`-universe polymorphism cannot survive into the categorical
 layer.
@@ -64,14 +65,14 @@ open CategoryTheory
 namespace SliceDomPFunctor
 
 /-- The function-level form of `Over.w`: a slice morphism `g : Y ⟶ Z`
-commutes with the base maps, `Z.hom ∘ g.left = Y.hom`, read as functions. -/
+commutes with the projections, `Z.hom ∘ g.left = Y.hom`, read as functions. -/
 theorem over_hom_comp {dom : Type uD} {Y Z : Over dom} (g : Y ⟶ Z) :
     Z.hom ∘ g.left = Y.hom := by
   funext z
   exact congrFun (Over.w g) z
 
 /-- The functor `Over dom ⥤ Type` restricting the `PFunctor`
-interpretation to `s`-compatible assignments; the core maps packaged
+interpretation to `r`-compatible assignments; the core maps packaged
 over `Over dom`. -/
 @[expose] def domFunctor {dom : Type uD} (F : SliceDomPFunctor.{uA, uB} dom) :
     CategoryTheory.Functor (Over dom) (Type (max uA uB uD)) where
@@ -86,34 +87,34 @@ end SliceDomPFunctor
 
 namespace SlicePFunctor
 
-/-- Tag naturality: `domFunctor.map g` fixes the shape component, so
-post-composing with the `t`-tag is preserved. This is the
-`Functor.toOver` triangle obligation for `functor`, shared with
+/-- Output-index naturality: `domFunctor.map g` fixes the shape component,
+so post-composing with the shape-output map `q` is preserved. This is
+the `Functor.toOver` triangle obligation for `functor`, shared with
 `functor_comp_forget`. -/
-private theorem tag_triangle {dom : Type uD} {cod : Type (max uA uB uD)}
+private theorem output_triangle {dom : Type uD} {cod : Type (max uA uB uD)}
     (F : SlicePFunctor.{uA, uB, uD, max uA uB uD} dom cod)
     {Y Z : Over dom} (g : Y ⟶ Z) :
-    F.toSliceDomPFunctor.domFunctor.map g ≫ (↾fun z => F.t z.1.1) =
-      (↾fun z => F.t z.1.1) := by
+    F.toSliceDomPFunctor.domFunctor.map g ≫ (↾fun z => F.q z.1.1) =
+      (↾fun z => F.q z.1.1) := by
   ext z
-  exact congrArg F.t (F.toSliceDomPFunctor.map_fst (g.left)
+  exact congrArg F.q (F.toSliceDomPFunctor.map_fst (g.left)
     (SliceDomPFunctor.over_hom_comp g) z)
 
 /-- The slice polynomial functor `Over dom ⥤ Over cod`: the
-`Functor.toOver` lift of `domFunctor` along the tag leg `t`. -/
+`Functor.toOver` lift of `domFunctor` along the shape-output map `q`. -/
 @[expose] def functor {dom : Type uD} {cod : Type (max uA uB uD)}
     (F : SlicePFunctor.{uA, uB, uD, max uA uB uD} dom cod) :
     CategoryTheory.Functor (Over dom) (Over cod) :=
   Functor.toOver F.toSliceDomPFunctor.domFunctor cod
-    (fun _ => ↾(fun z => F.t z.1.1))
-    (by intro Y Z g; exact F.tag_triangle g)
+    (fun _ => ↾(fun z => F.q z.1.1))
+    (by intro Y Z g; exact F.output_triangle g)
 
 /-- The wrapper forgets back to `domFunctor`. -/
 theorem functor_comp_forget {dom : Type uD} {cod : Type (max uA uB uD)}
     (F : SlicePFunctor.{uA, uB, uD, max uA uB uD} dom cod) :
     F.functor ⋙ Over.forget cod = F.toSliceDomPFunctor.domFunctor := by
   rw [functor]
-  exact Functor.toOver_comp_forget _ _ _ fun g => F.tag_triangle g
+  exact Functor.toOver_comp_forget _ _ _ fun g => F.output_triangle g
 
 /-- `functor.obj` is the core `obj`, packaged with `Over.mk`. The
 categorical object map carries no data beyond the core. -/

--- a/geb-lean/vendor/geb-mathlib/Geb/Mathlib/Data/PFunctor/Slice/W.lean
+++ b/geb-lean/vendor/geb-mathlib/Geb/Mathlib/Data/PFunctor/Slice/W.lean
@@ -1,0 +1,413 @@
+/-
+Copyright (c) 2026 The geb-mathlib contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The geb-mathlib contributors
+-/
+-- Modified from geb-mathlib by scripts/geb-mathlib-backport.patch.
+module
+
+public import Geb.Mathlib.Data.PFunctor.Slice.Basic
+
+/-!
+# W-types of slice polynomial functors (constructive core)
+
+When `dom = cod = I`, a `SlicePFunctor I I` is a slice endofunctor
+`Type/I → Type/I`. Its W-type (initial algebra) is obtained as a subtype of the
+`PFunctor` W-type `P.W`: a tree is admitted when every node's children sit
+over the direction-input indices prescribed by `r`, and it is indexed by the
+`q`-assigned output index of its root shape.
+
+The index (codomain-assignment) and the admissibility predicate
+(domain-restriction) are not written by explicit recursion. The index of a
+tree is the output index of its root, so it is not recursive at all; the
+predicate is recursive, but is obtained from mathlib's non-dependent W-type
+eliminator `WType.elim`, folding the index and the predicate together into
+the structure `WIndex` via the algebra `windexStep`. Carrying the index
+inside the fold is what lets the algebra state the direction-input-map
+condition `OverInput` — the children's index family, as a function of
+direction, equals `rCurried a`, the shape of `SliceDomPFunctor.Compatible`:
+the plain `Prop`-valued fold discards the children, so the condition would
+be inexpressible without either this
+pairing or the dependent recursor.
+
+The carrier `W` is the admissible trees, with structure map `windex`. Its
+constructor `mk` and destructor `dest` are mutually inverse (`W` is a fixed
+point of the slice endofunctor), and `elim` is the morphism into any slice
+algebra over `I`. Only the existence half of the initial-algebra universal
+property is established here — the carrier, its fixed-point structure
+(`mk`/`dest`), and `elim` with its computation rule `elim_mk` and over-`I` law
+`comp_elim`; uniqueness of `elim` is not formalized. The value of `elim` is
+computed by a single non-dependent `WType.elim` (the fold `elimData`, with
+algebra `elimStep`) into the carrier `ElimData` — each subtree's index, its
+admissibility, and (given admissibility) its image value with the witness that
+the value lies over the index, i.e. a slice morphism
+`(valid, const index) → (Y, p)`; carrying the value in the fold keeps `elim`'s
+computational layer independent of the dependent recursor: `elim` uses
+`WType.rec` only in the proof `elimData_valid`, relating the fold's
+admissibility component to `WValid`. A direct `WType.rec` definition of a
+`Type`-valued datum (such as `elim`'s value) would be `noncomputable` — the
+code generator does not compile recursor applications — which the project's
+constructive discipline forbids; a `Prop`-valued recursor definition such as
+`recProp` is exempt, its content being erased. All of this stays
+`Classical.choice`-free.
+
+The single index type is forced: the constraint compares a child's
+codomain-index against the parent's domain-index, so it typechecks only when
+`dom = cod`. That is the endofunctor condition an initial algebra requires.
+
+## Main definitions
+
+* `SlicePFunctor.windexRoot` — the index of a slice W-tree: the output index
+  of its root shape. Not recursive.
+* `SlicePFunctor.WIndex` / `SlicePFunctor.windexStep` / `SlicePFunctor.windexValid`
+  — the index-and-admissibility carrier, the algebra computing it, and the fold.
+  `SlicePFunctor.ForAll` / `SlicePFunctor.AllValid` / `SlicePFunctor.OverInput` /
+  `SlicePFunctor.NodeValid` are the direction-quantifier, the
+  all-children-admissible condition (`ForAll` of the children's `valid`), the
+  direction-input-map condition, and the node-admissibility predicate
+  combining the latter two.
+* `SlicePFunctor.WValid` — the domain-restriction predicate: the admissibility
+  component of `windexValid`.
+* `SlicePFunctor.W` — the carrier of the slice W-type: the admissible trees.
+* `SlicePFunctor.windex` — the slice W-type's structure map into `I`.
+* `SlicePFunctor.W.mk` / `SlicePFunctor.W.dest` — the constructor and
+  destructor of the slice W-type.
+* `SlicePFunctor.W.ElimData` / `SlicePFunctor.W.elimStep` /
+  `SlicePFunctor.W.elimData` — the `elim` carrier, algebra, and fold.
+* `SlicePFunctor.W.elim` — the morphism from the slice W-type into any slice
+  algebra over `I`.
+* `SlicePFunctor.W.recProp` — the paramorphism from the slice W-type into
+  `Prop`: a predicate whose step sees each node and its child subtrees together
+  with the children's predicate values.
+
+## Main statements
+
+* `SlicePFunctor.windexValid_index_eq_windexRoot` — the index component of the
+  fold agrees with the non-recursive root index; one non-recursive case split.
+* `SlicePFunctor.wValid_mk` — admissibility unfolded one level.
+* `SlicePFunctor.W.dest_mk` / `SlicePFunctor.W.mk_dest` — `mk` and `dest` are
+  mutually inverse.
+* `SlicePFunctor.W.windex_mk` / `SlicePFunctor.W.comp_elim` — `mk` and `elim`
+  lie over `I`.
+* `SlicePFunctor.W.elim_mk` — the computation rule for `elim`: it is a morphism
+  of slice algebras.
+* `SlicePFunctor.W.elimData_valid` — the fold's admissibility component agrees
+  with `WValid`; a use of the dependent recursor `WType.rec`.
+* `SlicePFunctor.W.ind` — structural induction for the slice W-type, the wrapped
+  form of `WType.rec` on the admissibility subtype.
+* `SlicePFunctor.W.recProp_mk` — the one-level computation rule for `recProp`.
+
+## Implementation notes
+
+`windexValid` folds into the structure `WIndex` (`index`, `valid`) via
+`windexStep`; a node's `valid` is `NodeValid` — `AllValid` (every child
+admissible) and `OverInput` (the children's index family equal to `rCurried a`,
+the `Compatible` shape). Its index component is the depth-1 root output
+index, so `windexValid_index_eq_windexRoot` needs only `cases`. `elim`'s
+value is computed by `elimData`, a single non-dependent `WType.elim` with
+algebra `elimStep` into
+the structure `ElimData` (extending `WIndex` with a `value` function and an
+`over` law, a slice morphism); within `elim`'s construction the dependent
+recursor is used only in the proof `elimData_valid` (a `WType.rec` application
+showing the fold's admissibility component agrees with `WValid`). A direct
+`WType.rec` *definition* of a `Type`-valued datum (such as `elim`'s value) would
+be rejected by the code generator as `noncomputable`; a `WType.rec` application
+in a proof, or a `Prop`-valued `WType.rec` definition such as `recProp`, is
+unproblematic. `windexRoot`, `ForAll`, `AllValid`, `OverInput`,
+`NodeValid`, `windexStep`,
+`windexValid`, `WValid`, `W`, `windex`, `W.mk`, `W.dest`, `W.elimStep`,
+`W.elimData`, `W.elim`, and `W.recProp` are `@[expose]` so a wrapper module and
+the tests can unfold them across the module boundary.
+
+## References
+
+* [GambinoHyland2004]
+* [GambinoKock2013]
+
+## Tags
+
+W-type, initial algebra, polynomial functor, dependent polynomial functor,
+slice category, container, PFunctor
+-/
+
+public section
+
+universe uA uB uI uY
+
+namespace SlicePFunctor
+
+/-- The index of a slice W-tree: the `q`-assigned output index of its root
+shape. Not recursive — it reads only the root node, via `PFunctor.W.head`. -/
+@[expose] def windexRoot {I : Type uI} (F : SlicePFunctor.{uA, uB, uI, uI} I I) :
+    F.toPFunctor.W → I :=
+  F.q ∘ PFunctor.W.head
+
+/-- The index and admissibility of a slice W-tree, the two components folded
+together by `windexValid`. -/
+@[ext]
+structure WIndex (I : Type uI) where
+  /-- The tree's index: the output index of its root shape. -/
+  index : I
+  /-- The tree's admissibility. -/
+  valid : Prop
+
+/-- Every direction satisfies the predicate `P`. Parallels `OverInput`, over
+`F.B a`. -/
+@[expose] def ForAll {I : Type uI} (F : SlicePFunctor.{uA, uB, uI, uI} I I)
+    (a : F.toPFunctor.A) (P : F.toPFunctor.B a → Prop) : Prop :=
+  ∀ b, P b
+
+/-- Every child of `c` is admissible: `ForAll` of the children's `valid`. -/
+@[expose] def AllValid {I : Type uI} (F : SlicePFunctor.{uA, uB, uI, uI} I I)
+    (a : F.toPFunctor.A) (c : F.toPFunctor.B a → WIndex I) : Prop :=
+  F.ForAll a (WIndex.valid ∘ c)
+
+/-- The direction-input-map condition on a node's children: their index
+family, as a function of direction, equals the direction-input map
+`rCurried a`. Point-free — the shape of `SliceDomPFunctor.Compatible` for
+the identity projection. -/
+@[expose] def OverInput {I : Type uI} (F : SlicePFunctor.{uA, uB, uI, uI} I I)
+    (a : F.toPFunctor.A) (idx : F.toPFunctor.B a → I) : Prop :=
+  idx = F.rCurried a
+
+/-- A node with shape `a` and children `c` is admissible when every child is
+admissible (`AllValid`) and the children's index family lies over the
+direction-input map (`OverInput`). -/
+@[expose] def NodeValid {I : Type uI} (F : SlicePFunctor.{uA, uB, uI, uI} I I)
+    (a : F.toPFunctor.A) (c : F.toPFunctor.B a → WIndex I) : Prop :=
+  F.AllValid a c ∧ F.OverInput a (WIndex.index ∘ c)
+
+/-- The algebra computing a node's index and admissibility from its children's:
+the index is the `q`-assigned output index of the shape, and the node is
+`NodeValid`. -/
+@[expose] def windexStep {I : Type uI} (F : SlicePFunctor.{uA, uB, uI, uI} I I) :
+    F.toPFunctor.Obj (WIndex I) → WIndex I :=
+  fun ⟨a, c⟩ => { index := F.q a, valid := F.NodeValid a c }
+
+/-- The index paired with admissibility: the `F.toPFunctor`-algebra morphism
+into `(WIndex I, windexStep)` given by `WType.elim`. -/
+@[expose] def windexValid {I : Type uI} (F : SlicePFunctor.{uA, uB, uI, uI} I I) :
+    F.toPFunctor.W → WIndex I :=
+  WType.elim (WIndex I) F.windexStep
+
+/-- The domain-restriction predicate on slice W-trees: a tree is admitted when
+every node's children sit over the direction-input indices prescribed by
+`r`. The admissibility component of `windexValid`. -/
+@[expose] def WValid {I : Type uI} (F : SlicePFunctor.{uA, uB, uI, uI} I I) :
+    F.toPFunctor.W → Prop :=
+  WIndex.valid ∘ F.windexValid
+
+/-- The index component of `windexValid` agrees with the non-recursive root
+index. A depth-1 fact: proved by a single non-recursive case split. -/
+@[simp]
+theorem windexValid_index_eq_windexRoot {I : Type uI}
+    (F : SlicePFunctor.{uA, uB, uI, uI} I I) (w : F.toPFunctor.W) :
+    (F.windexValid w).index = F.windexRoot w := by
+  cases w with
+  | mk a f => rfl
+
+/-- Admissibility unfolded one level: `WType.mk a f` is admitted exactly when
+every child `f b` is admitted and the children's index family lies over the
+direction-input map. -/
+theorem wValid_mk {I : Type uI} (F : SlicePFunctor.{uA, uB, uI, uI} I I)
+    (a : F.toPFunctor.A) (f : F.toPFunctor.B a → F.toPFunctor.W) :
+    F.WValid (WType.mk a f) ↔
+      F.ForAll a (F.WValid ∘ f) ∧ F.OverInput a (F.windexRoot ∘ f) := by
+  have h : WIndex.index ∘ F.windexValid ∘ f = F.windexRoot ∘ f :=
+    funext fun b => F.windexValid_index_eq_windexRoot (f b)
+  change (F.ForAll a (F.WValid ∘ f) ∧ F.OverInput a (WIndex.index ∘ F.windexValid ∘ f)) ↔ _
+  rw [h]
+
+/-- The carrier of the slice W-type: the admissible `PFunctor` W-trees. -/
+@[expose] def W {I : Type uI} (F : SlicePFunctor.{uA, uB, uI, uI} I I) : Type (max uA uB) :=
+  { w : F.toPFunctor.W // F.WValid w }
+
+/-- The slice W-type's structure map as an object of `Type/I`: the index of the
+underlying tree. -/
+@[expose] def windex {I : Type uI} (F : SlicePFunctor.{uA, uB, uI, uI} I I) : F.W → I :=
+  F.windexRoot ∘ Subtype.val
+
+namespace W
+
+/-- The constructor of the slice W-type: the slice endofunctor's value at
+`(W, windex)` maps into `W`. The algebra structure map. -/
+@[expose] def mk {I : Type uI} {F : SlicePFunctor.{uA, uB, uI, uI} I I}
+    (x : F.toSliceDomPFunctor.Obj F.windex) : F.W :=
+  ⟨WType.mk x.1.1 (Subtype.val ∘ x.1.2),
+    (F.wValid_mk _ _).mpr ⟨fun b => (x.1.2 b).property,
+      funext ((F.toSliceDomPFunctor.compatible_iff F.windex x.1.1 x.1.2).mp x.2)⟩⟩
+
+/-- The destructor of the slice W-type: every admissible tree decomposes as a
+shape together with a compatible family of admissible subtrees. Inverse to
+`mk`. -/
+@[expose] def dest {I : Type uI} {F : SlicePFunctor.{uA, uB, uI, uI} I I}
+    (z : F.W) : F.toSliceDomPFunctor.Obj F.windex :=
+  match z with
+  | ⟨WType.mk a f, hw⟩ =>
+      ⟨⟨a, fun b => ⟨f b, ((F.wValid_mk a f).mp hw).1 b⟩⟩,
+        (F.toSliceDomPFunctor.compatible_iff F.windex a _).mpr
+          fun b => congrFun ((F.wValid_mk a f).mp hw).2 b⟩
+
+/-- `dest` is a left inverse of `mk`. -/
+@[simp]
+theorem dest_mk {I : Type uI} {F : SlicePFunctor.{uA, uB, uI, uI} I I}
+    (x : F.toSliceDomPFunctor.Obj F.windex) : dest (mk x) = x := by
+  obtain ⟨⟨a, v⟩, hv⟩ := x
+  apply Subtype.ext
+  exact Sigma.ext rfl (heq_of_eq (funext fun b => Subtype.ext rfl))
+
+/-- `mk` is a left inverse of `dest`; with `dest_mk`, `mk` and `dest` are
+mutually inverse, so `W` is a fixed point of the slice endofunctor. -/
+@[simp]
+theorem mk_dest {I : Type uI} {F : SlicePFunctor.{uA, uB, uI, uI} I I}
+    (z : F.W) : mk (dest z) = z := by
+  obtain ⟨w, hw⟩ := z
+  cases w with
+  | mk a f => rfl
+
+/-- `mk` lies over `I`: its index is the output index assigned by `F.obj`. -/
+@[simp]
+theorem windex_mk {I : Type uI} {F : SlicePFunctor.{uA, uB, uI, uI} I I}
+    (x : F.toSliceDomPFunctor.Obj F.windex) : F.windex (mk x) = F.obj F.windex x :=
+  rfl
+
+/-- The `elim` fold carrier: extends `WIndex` to a slice morphism
+`(valid, const index) → (Y, p)` — a value function defined once the subtree is
+admissible, together with the proof that it lies over the index. -/
+@[ext]
+structure ElimData {I : Type uI} (Y : Type uY) (p : Y → I) extends WIndex I where
+  /-- The image value, available once the subtree is admissible. -/
+  value : valid → Y
+  /-- The value lies over the index: `p ∘ value` is constant at `index`. -/
+  over : p ∘ value = Function.const valid index
+
+/-- The slice-algebra step of the `elim` fold: index and admissibility
+(`NodeValid`) as for `windexStep`, and a value function that, given a node's
+admissibility, applies the target algebra `g` to the compatible family of its
+children's values, with `over` recording that the result lies over the index. -/
+@[expose] def elimStep {I : Type uI} (F : SlicePFunctor.{uA, uB, uI, uI} I I)
+    (Y : Type uY) (p : Y → I) (g : F.toSliceDomPFunctor.Obj p → Y) (hg : p ∘ g = F.obj p) :
+    F.toPFunctor.Obj (ElimData Y p) → ElimData Y p :=
+  fun ⟨a, c⟩ =>
+    { index := F.q a
+      valid := F.NodeValid a (ElimData.toWIndex ∘ c)
+      value := fun hv => g ⟨⟨a, fun b => (c b).value (hv.1 b)⟩,
+        (F.toSliceDomPFunctor.compatible_iff p a _).mpr fun b =>
+          (congrFun (c b).over (hv.1 b)).trans (congrFun hv.2 b)⟩
+      over := funext fun _ => congrFun hg _ }
+
+/-- The `elim` fold: the `F.toPFunctor`-algebra morphism into
+`(ElimData Y p, elimStep)` given by `WType.elim`, a single non-dependent fold
+with no explicit recursion. -/
+@[expose] def elimData {I : Type uI} (F : SlicePFunctor.{uA, uB, uI, uI} I I)
+    (Y : Type uY) (p : Y → I) (g : F.toSliceDomPFunctor.Obj p → Y) (hg : p ∘ g = F.obj p) :
+    F.toPFunctor.W → ElimData Y p :=
+  WType.elim (ElimData Y p) (elimStep F Y p g hg)
+
+/-- The index component of `elimData` is the root index. -/
+@[simp]
+theorem elimData_index {I : Type uI} (F : SlicePFunctor.{uA, uB, uI, uI} I I)
+    (Y : Type uY) (p : Y → I) (g : F.toSliceDomPFunctor.Obj p → Y) (hg : p ∘ g = F.obj p)
+    (w : F.toPFunctor.W) : (elimData F Y p g hg w).index = F.windexRoot w := by
+  cases w with
+  | mk a f => rfl
+
+/-- The admissibility component of `elimData`, unfolded one level. -/
+theorem elimData_valid_mk {I : Type uI} (F : SlicePFunctor.{uA, uB, uI, uI} I I)
+    (Y : Type uY) (p : Y → I) (g : F.toSliceDomPFunctor.Obj p → Y) (hg : p ∘ g = F.obj p)
+    (a : F.toPFunctor.A) (f : F.toPFunctor.B a → F.toPFunctor.W) :
+    (elimData F Y p g hg (WType.mk a f)).valid =
+      (F.ForAll a (fun b => (elimData F Y p g hg (f b)).valid) ∧
+        F.OverInput a (fun b => (elimData F Y p g hg (f b)).index)) :=
+  rfl
+
+/-- The admissibility component of `elimData` agrees with `WValid`. An
+inductive step: it applies the dependent recursor `WType.rec` (the initial
+algebra's induction principle, consulting the hypothesis `ih`), unlike the
+non-recursive `cases`/`casesOn` splits elsewhere. It is in a proof, where
+non-computability is immaterial. -/
+theorem elimData_valid {I : Type uI} (F : SlicePFunctor.{uA, uB, uI, uI} I I)
+    (Y : Type uY) (p : Y → I) (g : F.toSliceDomPFunctor.Obj p → Y) (hg : p ∘ g = F.obj p)
+    (w : F.toPFunctor.W) : (elimData F Y p g hg w).valid ↔ F.WValid w :=
+  WType.rec (motive := fun w => (elimData F Y p g hg w).valid ↔ F.WValid w)
+    (fun a f ih => by
+      beta_reduce
+      rw [F.wValid_mk, elimData_valid_mk]
+      exact and_congr (forall_congr' ih) (by simp only [OverInput, elimData_index]; rfl))
+    w
+
+/-- The eliminator of the slice W-type: the morphism into any slice algebra
+`(Y, p, g)` over `I`. The existence half of initiality. The value is computed by
+the non-dependent fold `elimData`; the tree's admissibility supplies the
+argument to the fold's `value` function. -/
+@[expose] def elim {I : Type uI} (F : SlicePFunctor.{uA, uB, uI, uI} I I)
+    (Y : Type uY) (p : Y → I) (g : F.toSliceDomPFunctor.Obj p → Y) (hg : p ∘ g = F.obj p) :
+    F.W → Y :=
+  fun z =>
+    (elimData F Y p g hg z.val).value
+      ((elimData_valid F Y p g hg z.val).mpr z.property)
+
+/-- `elim` lies over `I`: composing with the target structure map recovers
+`windex`. -/
+theorem comp_elim {I : Type uI} (F : SlicePFunctor.{uA, uB, uI, uI} I I)
+    (Y : Type uY) (p : Y → I) (g : F.toSliceDomPFunctor.Obj p → Y) (hg : p ∘ g = F.obj p) :
+    p ∘ elim F Y p g hg = F.windex :=
+  funext fun z =>
+    (congrFun (elimData F Y p g hg z.val).over
+      ((elimData_valid F Y p g hg z.val).mpr z.property)).trans
+      (elimData_index F Y p g hg z.val)
+
+/-- The computation rule for `elim`: it commutes with the constructors, i.e. it
+is a morphism of slice algebras. -/
+theorem elim_mk {I : Type uI} (F : SlicePFunctor.{uA, uB, uI, uI} I I)
+    (Y : Type uY) (p : Y → I) (g : F.toSliceDomPFunctor.Obj p → Y) (hg : p ∘ g = F.obj p)
+    (x : F.toSliceDomPFunctor.Obj F.windex) :
+    elim F Y p g hg (mk x) =
+      g (F.toSliceDomPFunctor.map (elim F Y p g hg) (comp_elim F Y p g hg) x) :=
+  rfl
+
+/-- Structural induction for the slice W-type: a predicate holds of every
+admissible tree once it holds of `mk x` whenever it holds of each child
+`x.1.2 b`. The wrapped form of the dependent recursor `WType.rec` on the
+admissibility subtype. -/
+theorem ind {I : Type uI} {F : SlicePFunctor.{uA, uB, uI, uI} I I}
+    {motive : F.W → Prop}
+    (mk : ∀ (x : F.toSliceDomPFunctor.Obj F.windex),
+        (∀ b, motive (x.1.2 b)) → motive (W.mk x)) :
+    ∀ z, motive z :=
+  fun z =>
+    WType.rec (motive := fun w => ∀ (hw : F.WValid w), motive ⟨w, hw⟩)
+      (fun a f ih hw' => by
+        rw [← mk_dest ⟨WType.mk a f, hw'⟩]
+        exact mk _ fun b => ih b (((F.wValid_mk a f).mp hw').1 b))
+      z.1 z.2
+
+/-- Paramorphism from the slice W-type into `Prop`: `step` sees the node `x`,
+hence its child subtrees `x.1.2 b`, together with the children's predicate
+values. The value is computed by `WType.rec` with a `Prop` motive, so no
+`noncomputable` flag arises. `@[expose]` so the presheaf layer can unfold it. -/
+@[expose] def recProp {I : Type uI} {F : SlicePFunctor.{uA, uB, uI, uI} I I}
+    (step : (x : F.toSliceDomPFunctor.Obj F.windex) →
+      (F.toPFunctor.B x.1.1 → Prop) → Prop) :
+    F.W → Prop :=
+  fun z =>
+    WType.rec (motive := fun w => F.WValid w → Prop)
+      (fun a f ih hv =>
+        step (dest ⟨WType.mk a f, hv⟩)
+          (fun b => ih b (((F.wValid_mk a f).mp hv).1 b)))
+      z.1 z.2
+
+/-- The one-level computation rule for `recProp`: on `mk x` it applies `step`
+to the node `x` and the family of child values. Definitional; stated for
+downstream unfolding. -/
+theorem recProp_mk {I : Type uI} {F : SlicePFunctor.{uA, uB, uI, uI} I I}
+    (step : (x : F.toSliceDomPFunctor.Obj F.windex) →
+      (F.toPFunctor.B x.1.1 → Prop) → Prop)
+    (x : F.toSliceDomPFunctor.Obj F.windex) :
+    W.recProp step (W.mk x) = step x (fun b => W.recProp step (x.1.2 b)) := by
+  obtain ⟨⟨a, v⟩, hc⟩ := x
+  rfl
+
+end W
+
+end SlicePFunctor

--- a/geb-lean/vendor/geb-mathlib/PROVENANCE.md
+++ b/geb-lean/vendor/geb-mathlib/PROVENANCE.md
@@ -1,6 +1,6 @@
 # Vendored geb-mathlib provenance
 
 - Source: https://github.com/rokopt/geb-mathlib.git
-- Source commit: c6c59d7e865feeb251b0735ab416779493fed4bd
-- Back-port patch: scripts/geb-mathlib-backport.patch (commit a0a8fb58168deb4af5ee61f4767e7a3010eb5a36)
+- Source commit: a2f7b18fd1ca0eacd9f31d581f02d8b660706653
+- Back-port patch: scripts/geb-mathlib-backport.patch (commit 90d986b17e90e78745137fd6507013615b93b6d6)
 - The files under `Geb/` are an unmodified mirror of the source commit except where the back-port patch changes them; modified files carry a change notice in their header comment.


### PR DESCRIPTION
Re-anchor scripts/geb-mathlib-backport.patch onto geb-mathlib main a2f7b18 (mathlib v4.32.0-rc1). Upstream renamed the leg/tag terminology (s to r, t to q, tag_triangle to output_triangle) and added the slice and presheaf W-type modules, drifting the category-2 and category-3 hunk context so git apply rejected the patch.

Regenerate the patch from the pristine-vs-adapted diff so a further refresh at the same revision is a no-op. Extend the back-port categories: reword the Presheaf/Basic checkUnivs docstring (category 2); adapt the Presheaf/W naturality step (category 3); add category 4 for the WType.rec motive beta-redex in Slice/W. Update the vendored smoke test for the s-to-r rename.