### PR TITLE
Update vendored `geb-mathlib`

### DIFF
--- a/geb-lean/vendor/geb-mathlib/PROVENANCE.md
+++ b/geb-lean/vendor/geb-mathlib/PROVENANCE.md
@@ -2,5 +2,5 @@
 
 - Source: https://github.com/rokopt/geb-mathlib.git
 - Source commit: a2f7b18fd1ca0eacd9f31d581f02d8b660706653
-- Back-port patch: scripts/geb-mathlib-backport.patch (commit 90d986b17e90e78745137fd6507013615b93b6d6)
+- Back-port patch: scripts/geb-mathlib-backport.patch (commit c626b7cba87cb8cd31d297ff8d776b8107c59603)
 - The files under `Geb/` are an unmodified mirror of the source commit except where the back-port patch changes them; modified files carry a change notice in their header comment.


### PR DESCRIPTION
Bump commit hash for vendored `geb-mathlib`.