### PR TITLE
fix(geb-mathlib): make contentless refresh a no-op

### DIFF
--- a/geb-lean/docs/geb-mathlib-backport-notes.md
+++ b/geb-lean/docs/geb-mathlib-backport-notes.md
@@ -138,10 +138,13 @@ the same upstream revision is a no-op: the regenerated vendored source
 is byte-identical to what the update produced. After the patch and the
 regenerated vendored tree are committed together,
 `scripts/refresh-geb-mathlib.sh <rev>` followed by
-`git diff -- vendor/geb-mathlib` must leave every `.lean` file and
-`LICENSE` unchanged. `PROVENANCE.md` is excluded from the check: it
-records the upstream and patch commit SHAs, which change when the patch
-is committed.
+`git diff -- vendor/geb-mathlib` must leave the tree unchanged.
+`PROVENANCE.md` participates in the check: it records the upstream
+commit SHA and a content checksum of the patch, both of which are
+stable under a same-inputs re-run. When a refresh changes nothing but
+`PROVENANCE.md` (for example, a new upstream revision touching none of
+the mirrored files), the script restores `PROVENANCE.md` so the
+refresh workflow opens no pull request.
 
 ## The hard wall
 

--- a/geb-lean/scripts/refresh-geb-mathlib.sh
+++ b/geb-lean/scripts/refresh-geb-mathlib.sh
@@ -16,8 +16,11 @@ TMP="$(mktemp -d)"
 trap 'rm -rf "$TMP"' EXIT
 git clone --quiet "$REPO_URL" "$TMP/gm"
 git -C "$TMP/gm" checkout --quiet "$SRC_REV"
+# A content checksum, not a commit hash: the commit that last touched
+# the patch is unavailable in a shallow CI checkout and cannot name
+# itself when the patch and PROVENANCE.md change in the same commit.
 SRC_SHA="$(git -C "$TMP/gm" rev-parse HEAD)"
-PATCH_SHA="$(git -C "$ROOT" log -1 --format=%H -- "$PATCH" 2>/dev/null || echo unknown)"
+PATCH_SHA256="$(sha256sum "$PATCH" | cut -d' ' -f1)"
 
 # Complete overwrite of the Geb namespace (no orphaned files).
 rm -f "$VENDOR/Geb.lean"; rm -rf "$VENDOR/Geb"
@@ -30,7 +33,7 @@ cat > "$VENDOR/PROVENANCE.md" <<EOF
 
 - Source: $REPO_URL
 - Source commit: $SRC_SHA
-- Back-port patch: scripts/geb-mathlib-backport.patch (commit $PATCH_SHA)
+- Back-port patch: scripts/geb-mathlib-backport.patch (sha256 $PATCH_SHA256)
 - The files under \`Geb/\` are an unmodified mirror of the source commit except where the back-port patch changes them; modified files carry a change notice in their header comment.
 EOF
 
@@ -41,4 +44,15 @@ EOF
 GIT_ROOT="$(git -C "$ROOT" rev-parse --show-toplevel)"
 REL="$(realpath --relative-to="$GIT_ROOT" "$ROOT")"
 ( cd "$GIT_ROOT" && git apply -p1 --directory="$REL" "$PATCH" )
-echo "Refreshed vendor/geb-mathlib to $SRC_SHA and applied back-port patch."
+
+# A refresh that changes no vendored content (an upstream revision
+# touching none of the mirrored files) leaves at most PROVENANCE.md
+# modified. Restore it in that case so the tree is byte-clean and the
+# CI workflow's create-pull-request step opens no pull request.
+if ! git -C "$GIT_ROOT" status --porcelain -- "$REL/vendor/geb-mathlib" \
+    | grep -qv 'PROVENANCE\.md$'; then
+  git -C "$GIT_ROOT" checkout -- "$REL/vendor/geb-mathlib/PROVENANCE.md"
+  echo "No vendored content changed; refresh is a no-op."
+else
+  echo "Refreshed vendor/geb-mathlib to $SRC_SHA and applied back-port patch."
+fi

--- a/geb-lean/vendor/geb-mathlib/PROVENANCE.md
+++ b/geb-lean/vendor/geb-mathlib/PROVENANCE.md
@@ -2,5 +2,5 @@
 
 - Source: https://github.com/rokopt/geb-mathlib.git
 - Source commit: 0a772c26a8f83278c28e6a388953f55f8beef7dd
-- Back-port patch: scripts/geb-mathlib-backport.patch (commit a14a19561b95849560c032d760a63c2374928941)
+- Back-port patch: scripts/geb-mathlib-backport.patch (sha256 2574fc92ed0a5996910eaefde560dd1b0d88fd8fc10b99865c11abedd5a67f72)
 - The files under `Geb/` are an unmodified mirror of the source commit except where the back-port patch changes them; modified files carry a change notice in their header comment.


### PR DESCRIPTION
Record the back-port patch provenance as a content checksum rather than the commit that last touched the patch: that commit is unavailable in the refresh workflow shallow checkout (where the lookup degraded to the tip of main, changing on every push and producing a hash-only pull request per run) and cannot name itself when the patch and PROVENANCE.md change in the same commit. Restore PROVENANCE.md when it is the only path a refresh changes, so a refresh that changes no vendored content leaves the tree clean and the workflow opens no pull request.