### PR TITLE
fix(geb-mathlib): regenerate back-port patch onto 0d54381

### DIFF
--- a/geb-lean/scripts/geb-mathlib-backport.patch
+++ b/geb-lean/scripts/geb-mathlib-backport.patch
@@ -1,5 +1,5 @@
 diff --git a/vendor/geb-mathlib/Geb/Mathlib/Data/PFunctor/Presheaf/Basic.lean b/vendor/geb-mathlib/Geb/Mathlib/Data/PFunctor/Presheaf/Basic.lean
-index 4d9e638..e4a8b30 100644
+index 429483f..8754442 100644
 --- a/vendor/geb-mathlib/Geb/Mathlib/Data/PFunctor/Presheaf/Basic.lean
 +++ b/vendor/geb-mathlib/Geb/Mathlib/Data/PFunctor/Presheaf/Basic.lean
 @@ -3,6 +3,7 @@ Copyright (c) 2026 The geb-mathlib contributors. All rights reserved.
@@ -34,7 +34,7 @@ index 4d9e638..e4a8b30 100644
 @@ -247,8 +248,7 @@ private theorem value_map {I : Type uI} [Category.{vI} I]
      intro i i' f b
      simp only [value_map]
-     refine (congrArg (fun w => α.app ⟨i'⟩ w) (x.2 f b)).trans ?_
+     refine (congrArg (fun w ↦ α.app ⟨i'⟩ w) (x.2 f b)).trans ?_
 -    simp only [← ConcreteCategory.comp_apply]
 -    rw [α.naturality f.op]⟩
 +    exact FunctorToTypes.naturality _ _ α f.op _⟩
@@ -77,7 +77,7 @@ index 4d9e638..e4a8b30 100644
      (J : Type uJ) [Category.{vJ} J] : Type (max (uA + 1) (uB + 1) uI uJ vI vJ)
      extends PresheafPFunctorData.{uI, uJ, uA, uB, vI, vJ} I J where
 diff --git a/vendor/geb-mathlib/Geb/Mathlib/Data/PFunctor/Presheaf/W.lean b/vendor/geb-mathlib/Geb/Mathlib/Data/PFunctor/Presheaf/W.lean
-index 9adfe8d..1c48437 100644
+index cab3559..1b78d18 100644
 --- a/vendor/geb-mathlib/Geb/Mathlib/Data/PFunctor/Presheaf/W.lean
 +++ b/vendor/geb-mathlib/Geb/Mathlib/Data/PFunctor/Presheaf/W.lean
 @@ -3,6 +3,7 @@ Copyright (c) 2026 The geb-mathlib contributors. All rights reserved.
@@ -91,14 +91,14 @@ index 9adfe8d..1c48437 100644
 @@ -619,7 +620,7 @@ theorem value_wRestrTree {I : Type uI} [Category.{vI} I]
              hn.2 hn.1⟩, rfl⟩ : (F.objPresheaf Y).obj ⟨F.q a⟩)) =
            α.app ⟨i'⟩ ((F.objPresheaf Y).map f.op
-             ⟨⟨pnodeSlice (fun b => pelimData F Y α (fchild b)) hv hn.1, hn.2 hn.1⟩, rfl⟩) := by
+             ⟨⟨pnodeSlice (fun b ↦ pelimData F Y α (fchild b)) hv hn.1, hn.2 hn.1⟩, rfl⟩) := by
 -      rw [← ConcreteCategory.comp_apply, ← α.naturality f.op, ConcreteCategory.comp_apply]
 +      exact (FunctorToTypes.naturality _ _ α f.op _).symm
      change (α.app ⟨F.q (F.shapeRestr f ⟨a, hqi⟩).1⟩
-           (⟨⟨F.objRestrElt f (pnodeSlice (fun b => pelimData F Y α (fchild b)) hv hn.1) hqi,
+           (⟨⟨F.objRestrElt f (pnodeSlice (fun b ↦ pelimData F Y α (fchild b)) hv hn.1) hqi,
              hn'.2 hn'.1⟩, rfl⟩ : (F.objPresheaf Y).obj ⟨F.q (F.shapeRestr f ⟨a, hqi⟩).1⟩)) ≍
 diff --git a/vendor/geb-mathlib/Geb/Mathlib/Data/PFunctor/Slice/Basic.lean b/vendor/geb-mathlib/Geb/Mathlib/Data/PFunctor/Slice/Basic.lean
-index 3126bdd..dcca284 100644
+index 579e42f..568164a 100644
 --- a/vendor/geb-mathlib/Geb/Mathlib/Data/PFunctor/Slice/Basic.lean
 +++ b/vendor/geb-mathlib/Geb/Mathlib/Data/PFunctor/Slice/Basic.lean
 @@ -3,6 +3,7 @@ Copyright (c) 2026 The geb-mathlib contributors. All rights reserved.
@@ -130,7 +130,7 @@ index 3126bdd..dcca284 100644
      extends SliceDomPFunctor.{uA, uB, uD} dom where
    /-- The shape-output map: each shape is assigned a `cod`-index. -/
 diff --git a/vendor/geb-mathlib/Geb/Mathlib/Data/PFunctor/Slice/Functor.lean b/vendor/geb-mathlib/Geb/Mathlib/Data/PFunctor/Slice/Functor.lean
-index 5c048ee..f1e06ab 100644
+index ff11455..9d14602 100644
 --- a/vendor/geb-mathlib/Geb/Mathlib/Data/PFunctor/Slice/Functor.lean
 +++ b/vendor/geb-mathlib/Geb/Mathlib/Data/PFunctor/Slice/Functor.lean
 @@ -3,6 +3,7 @@ Copyright (c) 2026 The geb-mathlib contributors. All rights reserved.
@@ -178,8 +178,8 @@ index 5c048ee..f1e06ab 100644
      ext z
      exact congrFun (F.map_id _) z
 @@ -98,7 +97,7 @@ private theorem output_triangle {dom : Type uD} {cod : Type (max uA uB uD)}
-     F.toSliceDomPFunctor.domFunctor.map g ≫ (↾fun z => F.q z.1.1) =
-       (↾fun z => F.q z.1.1) := by
+     F.toSliceDomPFunctor.domFunctor.map g ≫ (↾fun z ↦ F.q z.1.1) =
+       (↾fun z ↦ F.q z.1.1) := by
    ext z
 -  exact congrArg F.q (F.toSliceDomPFunctor.map_fst (ConcreteCategory.hom g.left)
 +  exact congrArg F.q (F.toSliceDomPFunctor.map_fst (g.left)
@@ -205,7 +205,7 @@ index 5c048ee..f1e06ab 100644
  
  end SlicePFunctor
 diff --git a/vendor/geb-mathlib/Geb/Mathlib/Data/PFunctor/Slice/W.lean b/vendor/geb-mathlib/Geb/Mathlib/Data/PFunctor/Slice/W.lean
-index ca0f572..47e3658 100644
+index afbc314..533b3ed 100644
 --- a/vendor/geb-mathlib/Geb/Mathlib/Data/PFunctor/Slice/W.lean
 +++ b/vendor/geb-mathlib/Geb/Mathlib/Data/PFunctor/Slice/W.lean
 @@ -3,6 +3,7 @@ Copyright (c) 2026 The geb-mathlib contributors. All rights reserved.
@@ -218,8 +218,8 @@ index ca0f572..47e3658 100644
  public import Geb.Mathlib.Data.PFunctor.Slice.Basic
 @@ -330,6 +331,7 @@ theorem elimData_valid {I : Type uI} (F : SlicePFunctor.{uA, uB, uI, uI} I I)
      (w : F.toPFunctor.W) : (elimData F Y p g hg w).valid ↔ F.WValid w :=
-   WType.rec (motive := fun w => (elimData F Y p g hg w).valid ↔ F.WValid w)
-     (fun a f ih => by
+   WType.rec (motive := fun w ↦ (elimData F Y p g hg w).valid ↔ F.WValid w)
+     (fun a f ih ↦ by
 +      beta_reduce
        rw [F.wValid_mk, elimData_valid_mk]
        exact and_congr (forall_congr' ih) (by simp only [OverInput, elimData_index]; rfl))

--- a/geb-lean/vendor/geb-mathlib/Geb/Mathlib/CategoryTheory/FreeCoprodCompDisc.lean
+++ b/geb-lean/vendor/geb-mathlib/Geb/Mathlib/CategoryTheory/FreeCoprodCompDisc.lean
@@ -92,7 +92,7 @@ index universe `max u uI`, which is the original completion — making
 the result an in-category coproduct — exactly when `uI ≤ u`. -/
 def copr.{uI} (I : Type uI) (fi : I → FreeCoprodCompDisc.{u, v} D) :
     FreeCoprodCompDisc.{max u uI} D :=
-  ⟨(Σ i : I, (fi i).1), Sigma.uncurry (fun i => (fi i).2)⟩
+  ⟨(Σ i : I, (fi i).1), Sigma.uncurry (fun i ↦ (fi i).2)⟩
 
 /-- The functorial action of `FreeCoprodCompDisc.copr` on morphisms: a
 reindexing function together with a componentwise family of morphisms
@@ -102,8 +102,8 @@ def coprMor.{uI} (I J : Type uI) (r : I → J)
     (gj : J → FreeCoprodCompDisc.{u, v} D)
     (hom : (i : I) → Hom D (fi i) (gj (r i))) :
     Hom D (copr D I fi) (copr D J gj) :=
-  ⟨Sigma.map r (fun i => (hom i).1),
-    funext (fun p => congrFun (hom p.1).2 p.2)⟩
+  ⟨Sigma.map r (fun i ↦ (hom i).1),
+    funext (fun p ↦ congrFun (hom p.1).2 p.2)⟩
 
 end FreeCoprodCompDisc
 

--- a/geb-lean/vendor/geb-mathlib/Geb/Mathlib/CategoryTheory/Grothendieck.lean
+++ b/geb-lean/vendor/geb-mathlib/Geb/Mathlib/CategoryTheory/Grothendieck.lean
@@ -284,7 +284,7 @@ theorem homFiber_map_map {F F' : C ⥤ Cat.{v₂, u₂}} (α : F ⟶ F')
     homFiber ((map α).map f) =
       (α.app Y.base).toFunctor.map (homFiber f) ≫
         eqToHom (congrArg
-          (fun p : F.obj X.base ⟶ F'.obj Y.base =>
+          (fun p : F.obj X.base ⟶ F'.obj Y.base ↦
             p.toFunctor.obj X.fiber)
           (α.naturality (homBase f))) := by
   simp only [map, homBase, homFiber, Grothendieck.map_map_fiber, Functor.comp_map,
@@ -518,7 +518,7 @@ theorem homFiber_map_map {G G' : Cᵒᵖ ⥤ Cat.{v₂, u₂}} (α : G ⟶ G')
       (α.app (Opposite.op X.base)).toFunctor.map (homFiber f) ≫
         eqToHom (congrArg
           (fun p : G.obj (Opposite.op Y.base) ⟶
-              G'.obj (Opposite.op X.base) =>
+              G'.obj (Opposite.op X.base) ↦
             p.toFunctor.obj Y.fiber)
           (α.naturality ((homBase f).op))) :=
   GrothendieckOp.homFiber_map_map α (Quiver.Hom.unop f)

--- a/geb-lean/vendor/geb-mathlib/Geb/Mathlib/Data/PFunctor/IndRec/Basic.lean
+++ b/geb-lean/vendor/geb-mathlib/Geb/Mathlib/Data/PFunctor/IndRec/Basic.lean
@@ -106,8 +106,8 @@ def Shape : Type (max (uA + 1) uD) :=
 /-- The direction type of the polynomial functor whose W-type defines
 codes for positive inductive-recursive types. -/
 def Dir : Shape.{uA, uD} D → Type (max uA uD) :=
-  Sum.elim (fun _ => PEmpty)
-    (Sum.elim (fun A => ULift.{uD} A) (fun A => A → D))
+  Sum.elim (fun _ ↦ PEmpty)
+    (Sum.elim (fun A ↦ ULift.{uD} A) (fun A ↦ A → D))
 
 /-- Simplification for the constant (`iota`) case of `IR.Dir`. -/
 @[simp]
@@ -150,7 +150,7 @@ def ObjFst : Type (max (uA + 1) uD) :=
 
 /-- The second component of `IR.Obj`. -/
 def ObjSnd.{v} (V : Type v) : ObjFst D → Type (max uA uD v) :=
-  fun s => Dir.{uA, uD} D s → V
+  fun s ↦ Dir.{uA, uD} D s → V
 
 /-- Rewrite the second component of `IR.Obj` along a shape-type
 equality. -/
@@ -182,7 +182,7 @@ type are all equal. -/
 theorem objIota_eq_mk.{v} (V : Type v) (d : D)
     (ds : Dir.{uA, uD} D (Sum.inl d) → V) :
     objIota D V d = (⟨Sum.inl d, ds⟩ : Obj.{uA, uD, v} D V) :=
-  congrArg (Sigma.mk (Sum.inl d)) (funext (fun x => PEmpty.elim x))
+  congrArg (Sigma.mk (Sum.inl d)) (funext (fun x ↦ PEmpty.elim x))
 
 /-- A destructor for `IR.Obj` — a pattern-matched form of
 elimination. -/
@@ -192,7 +192,7 @@ def Dest.{v, w} (V : Type v) (W : Type w) : Type (max (uA + 1) uD v w) :=
 /-- Convert `IR.Dest` to a morphism out of `IR.Obj` (an eliminator). -/
 def Dest.elim.{v, w} (V : Type v) (W : Type w)
     (dest : Dest.{uA, uD, v, w} D V W) : Obj D V → W :=
-  fun ⟨s, ds⟩ => match s with
+  fun ⟨s, ds⟩ ↦ match s with
   | Sum.inl d => dest.1 d
   | Sum.inr (Sum.inl (A : Type uA)) => dest.2.1 A (ds ∘ ULift.up)
   | Sum.inr (Sum.inr (A : Type uA)) => dest.2.2 A ds
@@ -200,9 +200,9 @@ def Dest.elim.{v, w} (V : Type v) (W : Type w)
 /-- The inverse of `IR.Dest.elim`. -/
 def Dest.elimInv.{v, w} (V : Type v) (W : Type w) (m : Obj D V → W) :
     Dest.{uA, uD, v, w} D V W :=
-  ⟨fun d => m (objIota D V d),
-    fun A f => m (objSigma D V A f),
-    fun A f => m (objDelta D V A f)⟩
+  ⟨fun d ↦ m (objIota D V d),
+    fun A f ↦ m (objSigma D V A f),
+    fun A f ↦ m (objDelta D V A f)⟩
 
 /-- `IR.Dest.elimInv` is a left inverse of `IR.Dest.elim`. -/
 theorem Dest.elimInv_elim.{v, w} (V : Type v) (W : Type w)
@@ -215,7 +215,7 @@ theorem Dest.elimInv_elim.{v, w} (V : Type v) (W : Type w)
 theorem Dest.elim_elimInv.{v, w} (V : Type v) (W : Type w)
     (m : Obj D V → W) :
     Dest.elim.{uA, uD, v, w} D V W (Dest.elimInv.{uA, uD, v, w} D V W m) = m :=
-  funext <| fun ⟨s, ds⟩ => match s with
+  funext <| fun ⟨s, ds⟩ ↦ match s with
   | Sum.inl d => congrArg m (objIota_eq_mk.{uA, uD, v} D V d ds)
   | Sum.inr (Sum.inl _) => rfl
   | Sum.inr (Sum.inr _) => rfl
@@ -240,10 +240,10 @@ def DepDest.{v, w} (V : Type v) (W : Obj D V → Type w) :
 def sigmaDest.{v, w} (V : Type v) (W : Obj D V → Type w) :
     DepDest.{uA, uD, v, w} D V W →
       Dest.{uA, uD, v, max (uA + 1) uD v w} D V (Σ e, W e) :=
-  fun dest =>
-    ⟨fun d => ⟨objIota D V d, dest.1 d⟩,
-      fun A f => ⟨objSigma D V A f, dest.2.1 A f⟩,
-      fun A f => ⟨objDelta D V A f, dest.2.2 A f⟩⟩
+  fun dest ↦
+    ⟨fun d ↦ ⟨objIota D V d, dest.1 d⟩,
+      fun A f ↦ ⟨objSigma D V A f, dest.2.1 A f⟩,
+      fun A f ↦ ⟨objDelta D V A f, dest.2.2 A f⟩⟩
 
 /-- Convert `IR.DepDest` to a morphism into a sigma type. -/
 def sigmaElim.{v, w} (V : Type v) (W : Obj D V → Type w) :
@@ -264,16 +264,16 @@ theorem sigmaElim_fst.{v, w} (V : Type v) (W : Obj D V → Type w)
 /-- Convert `IR.DepDest` to a dependent eliminator for `IR.Obj`. -/
 def DepDest.elim.{v, w} (V : Type v) (W : Obj D V → Type w) :
     DepDest.{uA, uD, v, w} D V W → (e : Obj D V) → W e :=
-  fun dest =>
+  fun dest ↦
     sigmaFstSectionElim (sigmaElim D V W dest) (sigmaElim_fst D V W dest)
 
 /-- The inverse of `IR.DepDest.elim`. -/
 def DepDest.elimInv.{v, w} (V : Type v) (W : Obj D V → Type w) :
     ((e : Obj D V) → W e) → DepDest.{uA, uD, v, w} D V W :=
-  fun m =>
-    ⟨fun d => m (objIota D V d),
-      fun A f => m (objSigma D V A f),
-      fun A f => m (objDelta D V A f)⟩
+  fun m ↦
+    ⟨fun d ↦ m (objIota D V d),
+      fun A f ↦ m (objSigma D V A f),
+      fun A f ↦ m (objDelta D V A f)⟩
 
 /-- `IR.DepDest.elimInv` is a left inverse of `IR.DepDest.elim`. -/
 theorem DepDest.elimInv_elim.{v, w} (V : Type v) (W : Obj D V → Type w)
@@ -287,7 +287,7 @@ theorem DepDest.elim_elimInv.{v, w} (V : Type v) (W : Obj D V → Type w)
     (m : (e : Obj D V) → W e) :
     DepDest.elim.{uA, uD, v, w} D V W
       (DepDest.elimInv.{uA, uD, v, w} D V W m) = m :=
-  funext <| fun ⟨s, ds⟩ => match s with
+  funext <| fun ⟨s, ds⟩ ↦ match s with
   | Sum.inl d => objIota_eq_mk.{uA, uD, v} D V d ds ▸ rfl
   | Sum.inr (Sum.inl _) => rfl
   | Sum.inr (Sum.inr _) => rfl
@@ -357,13 +357,13 @@ theorem ext {ir ir' : IR.{uA, uD} D} (eq1 : ir.1 = ir'.1)
     (eq2 : ir.2 = ir'.2 ∘ dirOfEq D eq1) : ir = ir' :=
   match ir, ir' with
   | ⟨s, d⟩, ⟨_, d'⟩ =>
-      Eq.rec (motive := ExtMotive D s d) (fun _ => mk_congr D s) eq1 d' eq2
+      Eq.rec (motive := ExtMotive D s d) (fun _ ↦ mk_congr D s) eq1 d' eq2
 
 /-- The converse of `IR.ext`: an equality in `IR` determines a
 pointwise equality of directions (transported along the shape equality
 induced by the first projection). -/
 theorem snd_eq_of_eq {ir ir' : IR.{uA, uD} D} :
-    (eq : ir = ir') → ir.2 = ir'.2 ∘ dirOfEq D (congrArg (fun t => t.1) eq)
+    (eq : ir = ir') → ir.2 = ir'.2 ∘ dirOfEq D (congrArg (fun t ↦ t.1) eq)
   | rfl => rfl
 
 /-- The eliminator (the algebra morphism from the initial algebra) for
@@ -409,8 +409,8 @@ recursor step. -/
 def sigmaRecAlg.{v} (motive : IR D → Type v)
     (mk' : RecStep.{uA, uD, v} D motive) :
     Obj D (Σ e, motive e) → Σ e, motive e :=
-  fun ⟨s, f⟩ =>
-    ⟨mk D s (Sigma.fst ∘ f), mk' s (Sigma.fst ∘ f) (fun d => (f d).2)⟩
+  fun ⟨s, f⟩ ↦
+    ⟨mk D s (Sigma.fst ∘ f), mk' s (Sigma.fst ∘ f) (fun d ↦ (f d).2)⟩
 
 /-- `IR.sigmaRecAlg` preserves the shape component. -/
 theorem sigmaRecAlg_fst_fst.{v} (motive : IR D → Type v)
@@ -433,14 +433,14 @@ def sigmaRec.{v} (motive : IR D → Type v)
 the first projection. -/
 theorem sigmaRec_fst_step.{v} (motive : IR D → Type v)
     (mk' : RecStep.{uA, uD, v} D motive) :
-    IndStep.{uA, uD} D (fun t => (sigmaRec D motive mk' t).1 = t) :=
-  fun _ _ ih => ext D rfl (funext ih)
+    IndStep.{uA, uD} D (fun t ↦ (sigmaRec D motive mk' t).1 = t) :=
+  fun _ _ ih ↦ ext D rfl (funext ih)
 
 /-- `IR.sigmaRec` is a section of the first projection. -/
 theorem sigmaRec_fst.{v} (motive : IR D → Type v)
     (mk' : RecStep.{uA, uD, v} D motive) :
     ∀ t : IR D, (sigmaRec D motive mk' t).1 = t :=
-  ind D (motive := fun t => (sigmaRec D motive mk' t).1 = t)
+  ind D (motive := fun t ↦ (sigmaRec D motive mk' t).1 = t)
     (sigmaRec_fst_step D motive mk')
 
 /-- The shape component of `IR.sigmaRec` agrees with the shape
@@ -472,7 +472,7 @@ namespace IR
 on `FreeCoprodCompDisc`: the constant object map at the one-direction
 object over `d`. -/
 def interpObjIota (d : D) : FreeCoprodCompDisc.Endo.{uA, uD} D :=
-  fun _ => ⟨ULift Unit, fun _ => d⟩
+  fun _ ↦ ⟨ULift Unit, fun _ ↦ d⟩
 
 /-- The dependent sum (`sigma`) case of the interpretation of an `IR`
 code on `FreeCoprodCompDisc`: the pointwise indexed coproduct over `A`
@@ -480,7 +480,7 @@ of the interpretations `α` of the subcodes. -/
 def interpObjSigma (A : Type uA)
     (α : A → FreeCoprodCompDisc.Endo.{uA, uD} D) :
     FreeCoprodCompDisc.Endo.{uA, uD} D :=
-  fun X => FreeCoprodCompDisc.copr.{uA, uD, uA} D A (fun a => α a X)
+  fun X ↦ FreeCoprodCompDisc.copr.{uA, uD, uA} D A (fun a ↦ α a X)
 
 /-- The dependent product (`delta`) case of the interpretation of an
 `IR` code on `FreeCoprodCompDisc`: at an object `X`, the indexed
@@ -489,8 +489,8 @@ the directions induced by `X`. -/
 def interpObjDelta (A : Type uA)
     (α : (A → D) → FreeCoprodCompDisc.Endo.{uA, uD} D) :
     FreeCoprodCompDisc.Endo.{uA, uD} D :=
-  fun X =>
-    FreeCoprodCompDisc.copr.{uA, uD, uA} D (A → X.1) (fun g => α (X.2 ∘ g) X)
+  fun X ↦
+    FreeCoprodCompDisc.copr.{uA, uD, uA} D (A → X.1) (fun g ↦ α (X.2 ∘ g) X)
 
 /-- The algebra which computes one step of the interpretation of an
 `IR` code on `FreeCoprodCompDisc`. -/
@@ -511,7 +511,7 @@ def MorMapSig (ir : IR.{uA, uD} D) : Type (max (uA + 1) uD) :=
 `IR.interpObjIota`: every morphism maps to the identity. -/
 def interpMorIota (d : D) :
     FreeCoprodCompDisc.EndoMor D (interpObjIota.{uA, uD} D d) :=
-  fun _ _ _ => ⟨id, rfl⟩
+  fun _ _ _ ↦ ⟨id, rfl⟩
 
 /-- The morphism-map component of the dependent sum (`sigma`)
 interpretation `IR.interpObjSigma`: the indexed coproduct of the
@@ -520,11 +520,11 @@ def interpMorSigma (A : Type uA)
     (α : A → FreeCoprodCompDisc.Endo.{uA, uD} D)
     (μ : (a : A) → FreeCoprodCompDisc.EndoMor D (α a)) :
     FreeCoprodCompDisc.EndoMor D (interpObjSigma D A α) :=
-  fun X Y h =>
+  fun X Y h ↦
     FreeCoprodCompDisc.coprMor D A A id
-      (fun a => α a X)
-      (fun a => α a Y)
-      (fun a => μ a X Y h)
+      (fun a ↦ α a X)
+      (fun a ↦ α a Y)
+      (fun a ↦ μ a X Y h)
 
 /-- The morphism-map component of the dependent product (`delta`)
 interpretation `IR.interpObjDelta`: reindex along postcomposition with
@@ -534,28 +534,28 @@ def interpMorDelta (A : Type uA)
     (α : (A → D) → FreeCoprodCompDisc.Endo.{uA, uD} D)
     (μ : (f : A → D) → FreeCoprodCompDisc.EndoMor D (α f)) :
     FreeCoprodCompDisc.EndoMor D (interpObjDelta D A α) :=
-  fun X Y h =>
-    FreeCoprodCompDisc.coprMor D (A → X.1) (A → Y.1) (fun g => h.1 ∘ g)
-      (fun g => α (X.2 ∘ g) X)
-      (fun g => α (Y.2 ∘ g) Y)
-      (fun g =>
+  fun X Y h ↦
+    FreeCoprodCompDisc.coprMor D (A → X.1) (A → Y.1) (fun g ↦ h.1 ∘ g)
+      (fun g ↦ α (X.2 ∘ g) X)
+      (fun g ↦ α (Y.2 ∘ g) Y)
+      (fun g ↦
         FreeCoprodCompDisc.homOfEq D
-          (congrArg (fun t => α (t ∘ g) Y) h.2.symm)
+          (congrArg (fun t ↦ α (t ∘ g) Y) h.2.symm)
           (μ (X.2 ∘ g) X Y h))
 
 /-- The step argument to the recursor which generates the morphism map
 of the interpretation of an `IR` code on `FreeCoprodCompDisc` (the
 object map is `IR.interpObj`). -/
 def interpMorStep : RecStep.{uA, uD, max (uA + 1) uD} D (MorMapSig D) :=
-  fun s c m => match s with
+  fun s c m ↦ match s with
   | Sum.inl d => interpMorIota D d
   | Sum.inr (Sum.inl A) =>
       interpMorSigma D A
-        (fun a => interpObj D (c (ULift.up a)))
-        (fun a => m (ULift.up a))
+        (fun a ↦ interpObj D (c (ULift.up a)))
+        (fun a ↦ m (ULift.up a))
   | Sum.inr (Sum.inr A) =>
       interpMorDelta D A
-        (fun f => interpObj D (c f))
+        (fun f ↦ interpObj D (c f))
         m
 
 /-- The morphism map of the interpretation of an `IR` code on
@@ -586,17 +586,17 @@ arguments indexed by its decoding (the family of types under the
 binder), decoding to `former` applied to the decodings. -/
 def univBinder.{v} (former : (X : Type v) → (X → Type v) → Type v) :
     IR.{v, v + 1} (Type v) :=
-  IR.delta (Type v) PUnit.{v + 1} (fun f =>
-    IR.delta (Type v) (f PUnit.unit) (fun q =>
+  IR.delta (Type v) PUnit.{v + 1} (fun f ↦
+    IR.delta (Type v) (f PUnit.unit) (fun q ↦
       IR.iota (Type v) (former (f PUnit.unit) q)))
 
 /-- The dependent-sum-former subcode of a universe code. -/
 def univSigma.{v} : IR.{v, v + 1} (Type v) :=
-  univBinder (fun X q => Σ x : X, q x)
+  univBinder (fun X q ↦ Σ x : X, q x)
 
 /-- The dependent-product-former subcode of a universe code. -/
 def univPi.{v} : IR.{v, v + 1} (Type v) :=
-  univBinder (fun X q => (x : X) → q x)
+  univBinder (fun X q ↦ (x : X) → q x)
 
 variable (K : Type uK) (T : K → Type uT)
 
@@ -616,7 +616,7 @@ def univConstructorCode :
     UnivConstructor.{uK, uT} K →
       IR.{max uK uT, max uK uT + 1} (Type (max uK uT)) :=
   Sum.elim (univIota K T)
-    (Sum.elim (fun _ => univSigma.{max uK uT}) (fun _ => univPi.{max uK uT}))
+    (Sum.elim (fun _ ↦ univSigma.{max uK uT}) (fun _ ↦ univPi.{max uK uT}))
 
 /-- The code of the universe generated by the starting types `T`: the
 coproduct, over `UnivConstructor`, of the subcodes. The universe
@@ -626,7 +626,7 @@ code's interpretation; this file provides the code and the
 interpretation, not the initial algebra. -/
 def univCode : IR.{max uK uT, max uK uT + 1} (Type (max uK uT)) :=
   IR.sigma (Type (max uK uT)) (UnivConstructor.{uK, uT} K)
-    (fun i => univConstructorCode K T i.down)
+    (fun i ↦ univConstructorCode K T i.down)
 
 /-- The object map of the interpretation of `univCode`. -/
 def univEndo :

--- a/geb-lean/vendor/geb-mathlib/Geb/Mathlib/Data/PFunctor/Presheaf/Basic.lean
+++ b/geb-lean/vendor/geb-mathlib/Geb/Mathlib/Data/PFunctor/Presheaf/Basic.lean
@@ -187,7 +187,7 @@ compatibility of `x` and the constraint condition on `b` to `Z.obj ⟨i⟩`. -/
     (F : PresheafDomPFunctorData.{uI, uA, uB, vI} I)
     {Z : Iᵒᵖ ⥤ Type uZ} (x : F.toSliceDomPFunctor.Obj (elemProj Z)) ⦃i : I⦄
     (b : F.toSliceDomPFunctor.Direction x.1.1 i) : Z.obj ⟨i⟩ :=
-  cast (congrArg (fun k : I => Z.obj ⟨k⟩)
+  cast (congrArg (fun k : I ↦ Z.obj ⟨k⟩)
     (((F.compatible_iff (elemProj Z) x.1.1 x.1.2).mp x.2 b.1).trans b.2)) (x.1.2 b.1).2
 
 /-- The direction-assignment of `x` is a natural transformation `E_T(a) ⟶ Z`,
@@ -214,8 +214,8 @@ of the slice object on the total-space projection `elemProj Z`. -/
 `cast` along an equality of base points. -/
 private theorem app_cast {I : Type uI} [Category.{vI} I] {Z Z' : Iᵒᵖ ⥤ Type uZ}
     (α : NatTrans Z Z') {k i : I} (e : k = i) (z : Z.obj ⟨k⟩) :
-    cast (congrArg (fun k : I => Z'.obj ⟨k⟩) e) (α.app ⟨k⟩ z) =
-      α.app ⟨i⟩ (cast (congrArg (fun k : I => Z.obj ⟨k⟩) e) z) := by
+    cast (congrArg (fun k : I ↦ Z'.obj ⟨k⟩) e) (α.app ⟨k⟩ z) =
+      α.app ⟨i⟩ (cast (congrArg (fun k : I ↦ Z.obj ⟨k⟩) e) z) := by
   cases e
   rfl
 
@@ -224,7 +224,7 @@ elements, `el(Z) ⟶ el(Z')`: `⟨i, z⟩ ↦ ⟨i, α.app ⟨i⟩ z⟩`. It pre
 base-point projection `elemProj`, so it is a slice morphism over `elemProj`. -/
 @[expose] def elemMap {I : Type uI} [Category.{vI} I] {Z Z' : Iᵒᵖ ⥤ Type uZ}
     (α : NatTrans Z Z') : (Σ i : I, Z.obj ⟨i⟩) → (Σ i : I, Z'.obj ⟨i⟩) :=
-  fun p => ⟨p.1, α.app ⟨p.1⟩ p.2⟩
+  fun p ↦ ⟨p.1, α.app ⟨p.1⟩ p.2⟩
 
 /-- The `Z'`-component the image under `α` of a slice element assigns to a
 direction is `α.app` of the `Z`-component the original assigns to it. -/
@@ -243,18 +243,18 @@ private theorem value_map {I : Type uI} [Category.{vI} I]
 @[expose] def map {I : Type uI} [Category.{vI} I] (F : PresheafDomPFunctorData.{uI, uA, uB, vI} I)
     {Z Z' : Iᵒᵖ ⥤ Type uZ} (α : NatTrans Z Z') :
     F.obj Z → F.obj Z' :=
-  fun x => ⟨F.toSliceDomPFunctor.map
+  fun x ↦ ⟨F.toSliceDomPFunctor.map
     (elemMap α) rfl x.1, by
     intro i i' f b
     simp only [value_map]
-    refine (congrArg (fun w => α.app ⟨i'⟩ w) (x.2 f b)).trans ?_
+    refine (congrArg (fun w ↦ α.app ⟨i'⟩ w) (x.2 f b)).trans ?_
     exact FunctorToTypes.naturality _ _ α f.op _⟩
 
 /-- Functoriality in the input presheaf: the identity transformation acts as
 the identity. -/
 theorem map_id {I : Type uI} [Category.{vI} I] (F : PresheafDomPFunctorData.{uI, uA, uB, vI} I)
     (Z : Iᵒᵖ ⥤ Type uZ) :
-    F.map { app := fun i => 𝟙 (Z.obj i), naturality := fun _ _ _ => rfl } =
+    F.map { app := fun i ↦ 𝟙 (Z.obj i), naturality := fun _ _ _ ↦ rfl } =
       (id : F.obj Z → F.obj Z) := by
   funext x
   exact Subtype.ext (congrFun (F.toSliceDomPFunctor.map_id (elemProj Z)) x.1)
@@ -264,7 +264,7 @@ transformations acts as the composite of the actions. -/
 theorem map_comp {I : Type uI} [Category.{vI} I] (F : PresheafDomPFunctorData.{uI, uA, uB, vI} I)
     {Z Z' Z'' : Iᵒᵖ ⥤ Type uZ} (α : NatTrans Z Z')
     (β : NatTrans Z' Z'') :
-    F.map { app := fun i => α.app i ≫ β.app i, naturality := fun _ _ g =>
+    F.map { app := fun i ↦ α.app i ≫ β.app i, naturality := fun _ _ g ↦
         (by rw [← Category.assoc, α.naturality, Category.assoc, β.naturality,
           ← Category.assoc]) } =
       F.map β ∘ F.map α := by
@@ -337,20 +337,20 @@ Ordinary fibre maps only; no `shapeRestr` transport. -/
 
 /-- `reindex (𝟙 j) a` is the identity, modulo the transport of its source
 along `ShapeRestrId` at `j` (`shapeRestr (𝟙 j) a = a`). The transport is the
-`cast` of `b` along `congrArg (fun s => Direction s.1 i) (congrFun (hti j) a)`.
+`cast` of `b` along `congrArg (fun s ↦ Direction s.1 i) (congrFun (hti j) a)`.
 Parameterized on the identity law `hti` because that source-type equality is
 not definitional. -/
 @[expose] def ReindexId {I : Type uI} [Category.{vI} I] {J : Type uJ} [Category.{vJ} J]
     (F : PresheafPFunctorData.{uI, uJ, uA, uB, vI, vJ} I J) (hti : F.ShapeRestrId) : Prop :=
   ∀ ⦃j : J⦄ (a : F.Shape j) ⦃i : I⦄ (b : F.Direction (F.shapeRestr (𝟙 j) a).1 i),
     F.reindex (𝟙 j) a b =
-      cast (congrArg (fun s : F.Shape j => F.Direction s.1 i) (congrFun (hti j) a)) b
+      cast (congrArg (fun s : F.Shape j ↦ F.Direction s.1 i) (congrFun (hti j) a)) b
 
 /-- For `g : j' ⟶ j`, `h : j'' ⟶ j'`,
 `reindex (h ≫ g) a = reindex g a ∘ reindex h (shapeRestr g a)` (`g` is the
 outer factor), modulo the transport of the source along `ShapeRestrComp`
 (`shapeRestr (h ≫ g) a = shapeRestr h (shapeRestr g a)`). The transport is the `cast`
-of `b` along `congrArg (fun s => Direction s.1 i) (congrFun (htc g h) a)`.
+of `b` along `congrArg (fun s ↦ Direction s.1 i) (congrFun (htc g h) a)`.
 Parameterized on the composition law `htc` because that source-type equality is
 not definitional. -/
 @[expose] def ReindexComp {I : Type uI} [Category.{vI} I] {J : Type uJ} [Category.{vJ} J]
@@ -359,7 +359,7 @@ not definitional. -/
     (b : F.Direction (F.shapeRestr (h ≫ g) a).1 i),
     F.reindex (h ≫ g) a b =
       F.reindex g a (F.reindex h (F.shapeRestr g a)
-        (cast (congrArg (fun s : F.Shape j'' => F.Direction s.1 i)
+        (cast (congrArg (fun s : F.Shape j'' ↦ F.Direction s.1 i)
           (congrFun (htc g h) a)) b))
 
 /-- All functor laws: the dom laws plus the `J`-side laws making `T1` a
@@ -405,8 +405,8 @@ namespace PresheafPFunctor
     (x : F.toSliceDomPFunctor.Obj p) (hq : F.q x.1.1 = j) :
     F.toSliceDomPFunctor.Obj p :=
   ⟨⟨(F.shapeRestr g ⟨x.1.1, hq⟩).1,
-      fun b' => x.1.2 (F.reindex g ⟨x.1.1, hq⟩ (i := F.rCurried _ b') ⟨b', rfl⟩).1⟩,
-    (F.compatible_iff _ _ _).mpr fun b' =>
+      fun b' ↦ x.1.2 (F.reindex g ⟨x.1.1, hq⟩ (i := F.rCurried _ b') ⟨b', rfl⟩).1⟩,
+    (F.compatible_iff _ _ _).mpr fun b' ↦
       ((F.compatible_iff _ _ _).mp x.2
         (F.reindex g ⟨x.1.1, hq⟩ (i := F.rCurried _ b') ⟨b', rfl⟩).1).trans
         (F.reindex g ⟨x.1.1, hq⟩ (i := F.rCurried _ b') ⟨b', rfl⟩).2⟩
@@ -440,7 +440,7 @@ original value, up to the transport of its type along that equality. -/
 private theorem cast_val_heq {I : Type uI} [Category.{vI} I] {J : Type uJ} [Category.{vJ} J]
     (F : PresheafPFunctor.{uI, uJ, uA, uB, vI, vJ} I J) {j : J} {s s' : F.Shape j} (h : s = s')
     {i : I} (p : F.Direction s.1 i) :
-    (cast (congrArg (fun t : F.Shape j => F.Direction t.1 i) h) p).1 ≍ (p.1 : F.B s.1) := by
+    (cast (congrArg (fun t : F.Shape j ↦ F.Direction t.1 i) h) p).1 ≍ (p.1 : F.B s.1) := by
   cases h
   rfl
 
@@ -528,7 +528,7 @@ from `F.isFunctorial`. -/
     (F : PresheafPFunctor.{uI, uJ, uA, uB, vI, vJ} I J) (Z : Iᵒᵖ ⥤ Type uZ) :
     Jᵒᵖ ⥤ Type (max uI uZ uA uB) where
   obj j := { z : F.toPresheafDomPFunctorData.obj Z // F.q z.shape = j.unop }
-  map g := ↾ fun w => ⟨F.objRestr g.unop w.1 w.2, (F.shapeRestr g.unop ⟨w.1.shape, w.2⟩).2⟩
+  map g := ↾ fun w ↦ ⟨F.objRestr g.unop w.1 w.2, (F.shapeRestr g.unop ⟨w.1.shape, w.2⟩).2⟩
   map_id j := by
     ext w
     exact Subtype.ext (F.objRestrElt_id w.1.1 w.2)
@@ -562,7 +562,7 @@ wrapper `functor.map` reuses it. -/
 @[expose] def mapPresheaf {I : Type uI} [Category.{vI} I] {J : Type uJ} [Category.{vJ} J]
     (F : PresheafPFunctor.{uI, uJ, uA, uB, vI, vJ} I J) {Z Z' : Iᵒᵖ ⥤ Type uZ}
     (α : NatTrans Z Z') : NatTrans (F.objPresheaf Z) (F.objPresheaf Z') where
-  app X := ↾fun w => (⟨F.toPresheafDomPFunctorData.map α w.1, w.2⟩ : (F.objPresheaf Z').obj X)
+  app X := ↾fun w ↦ (⟨F.toPresheafDomPFunctorData.map α w.1, w.2⟩ : (F.objPresheaf Z').obj X)
   naturality _ _ g := by
     ext w
     exact Subtype.ext (F.map_objRestr α g.unop w.1 w.2)

--- a/geb-lean/vendor/geb-mathlib/Geb/Mathlib/Data/PFunctor/Presheaf/Functor.lean
+++ b/geb-lean/vendor/geb-mathlib/Geb/Mathlib/Data/PFunctor/Presheaf/Functor.lean
@@ -100,7 +100,7 @@ by `rfl`. -/
 mathlib's `Iᵒᵖ`-indexed category of elements `Z.Elements`, sending `⟨i, z⟩` to
 `⟨op i, z⟩`. -/
 @[expose] def toElements {I : Type uI} [Category.{vI} I] (Z : Iᵒᵖ ⥤ Type uZ) :
-    (Σ i : I, Z.obj ⟨i⟩) → Z.Elements := fun p => ⟨⟨p.1⟩, p.2⟩
+    (Σ i : I, Z.obj ⟨i⟩) → Z.Elements := fun p ↦ ⟨⟨p.1⟩, p.2⟩
 
 /-- The core's `elemMap` is the object map of the functor on categories of
 elements that `α` induces — mathlib's `CategoryOfElements.map` — across the

--- a/geb-lean/vendor/geb-mathlib/Geb/Mathlib/Data/PFunctor/Presheaf/W.lean
+++ b/geb-lean/vendor/geb-mathlib/Geb/Mathlib/Data/PFunctor/Presheaf/W.lean
@@ -154,7 +154,7 @@ direction, hereditarily. The local conjunct is the tree analogue of
 slice W-type's `Prop`-valued paramorphism `SlicePFunctor.W.recProp`. -/
 @[expose] def IsHereditarilyNatural {I : Type uI} [Category.{vI} I]
     (F : PresheafPFunctor.{uI, uI, uA, uB, vI, vI} I I) : F.toSlicePFunctor.W → Prop :=
-  SlicePFunctor.W.recProp (fun x ih =>
+  SlicePFunctor.W.recProp (fun x ih ↦
     (∀ ⦃i i' : I⦄ (g : i' ⟶ i) (b : F.toSliceDomPFunctor.Direction x.1.1 i),
         x.1.2 (F.directionRestr x.1.1 g b).1
           = F.wRestrTree g (x.1.2 b.1)
@@ -219,7 +219,7 @@ theorem isHereditarilyNatural_wRestrTree {I : Type uI} [Category.{vI} I]
     · intro i i' h b
       obtain ⟨bv, rfl⟩ := b
       rw [F.snd_objRestrElt]
-      exact (congrArg (fun d => (SlicePFunctor.W.dest ⟨WType.mk a fchild, hvalid⟩).1.2 d.1)
+      exact (congrArg (fun d ↦ (SlicePFunctor.W.dest ⟨WType.mk a fchild, hvalid⟩).1.2 d.1)
           (congrFun (F.isFunctorial.reindex_naturality g ⟨a, hq⟩ h) ⟨bv, rfl⟩).symm).trans
         (hz_local h (F.reindex g ⟨a, hq⟩ ⟨bv, rfl⟩))
     · intro b
@@ -236,7 +236,7 @@ restricted root shape via `shapeRestr`) and hereditary naturality (preserved by
         F.toSlicePFunctor.windex w = j ∧ F.IsHereditarilyNatural w } →
       ULift.{uI} { w : F.toSlicePFunctor.W //
         F.toSlicePFunctor.windex w = j' ∧ F.IsHereditarilyNatural w } :=
-  fun w => ULift.up
+  fun w ↦ ULift.up
     ⟨F.wRestrTree g w.down.1 w.down.2.1,
       F.windex_wRestrTree g w.down.1 w.down.2.1,
       F.isHereditarilyNatural_wRestrTree g w.down.1 w.down.2.1 w.down.2.2⟩
@@ -292,7 +292,7 @@ underlying slice W-tree unchanged. -/
 private theorem cast_down {I : Type uI} [Category.{vI} I]
     (F : PresheafPFunctor.{uI, uI, uA, uB, vI, vI} I I) {k k' : I} (e : k = k')
     (u : (F.W).obj ⟨k⟩) :
-    (cast (congrArg (fun k : I => (F.W).obj ⟨k⟩) e) u).down.1 = u.down.1 := by
+    (cast (congrArg (fun k : I ↦ (F.W).obj ⟨k⟩) e) u).down.1 = u.down.1 := by
   cases e
   rfl
 
@@ -342,8 +342,8 @@ underlying slice W-tree of its carried fibre element. -/
     (F : PresheafPFunctor.{uI, uI, uA, uB, vI, vI} I I)
     (n : F.toSliceDomPFunctor.Obj (PresheafDomPFunctorData.elemProj (F.W))) :
     F.toSliceDomPFunctor.Obj F.toSlicePFunctor.windex :=
-  ⟨⟨n.1.1, fun b => (n.1.2 b).2.down.1⟩,
-    (F.toSliceDomPFunctor.compatible_iff F.toSlicePFunctor.windex _ _).mpr fun b =>
+  ⟨⟨n.1.1, fun b ↦ (n.1.2 b).2.down.1⟩,
+    (F.toSliceDomPFunctor.compatible_iff F.toSlicePFunctor.windex _ _).mpr fun b ↦
       ((n.1.2 b).2.down.2.1).trans
         ((F.toSliceDomPFunctor.compatible_iff (PresheafDomPFunctorData.elemProj (F.W)) _ _).mp
           n.2 b)⟩
@@ -357,9 +357,9 @@ each direction to the carried fibre element built from the child tree, its index
     (y : F.toSliceDomPFunctor.Obj F.toSlicePFunctor.windex)
     (hchildren : ∀ b, F.IsHereditarilyNatural (y.1.2 b)) :
     F.toSliceDomPFunctor.Obj (PresheafDomPFunctorData.elemProj (F.W)) :=
-  ⟨⟨y.1.1, fun b => ⟨F.toSlicePFunctor.windex (y.1.2 b),
+  ⟨⟨y.1.1, fun b ↦ ⟨F.toSlicePFunctor.windex (y.1.2 b),
       ULift.up ⟨y.1.2 b, rfl, hchildren b⟩⟩⟩,
-    (F.toSliceDomPFunctor.compatible_iff (PresheafDomPFunctorData.elemProj (F.W)) _ _).mpr fun b =>
+    (F.toSliceDomPFunctor.compatible_iff (PresheafDomPFunctorData.elemProj (F.W)) _ _).mpr fun b ↦
       (F.toSliceDomPFunctor.compatible_iff F.toSlicePFunctor.windex _ _).mp y.2 b⟩
 
 /-- `rememberNode` depends on the slice node only, not the hereditary-naturality
@@ -392,7 +392,7 @@ private theorem rememberNode_forgetNode {I : Type uI} [Category.{vI} I]
     rememberNode F (forgetNode F n) hchildren = n := by
   apply Subtype.ext
   obtain ⟨⟨a, v⟩, hc⟩ := n
-  exact Sigma.ext rfl (heq_of_eq (funext fun b => sigma_eta F (v b).2))
+  exact Sigma.ext rfl (heq_of_eq (funext fun b ↦ sigma_eta F (v b).2))
 
 /-- The hereditary naturality of the slice tree built from a presheaf node over
 `F.W` is exactly the naturality of the node: the recursive conjunct of
@@ -411,8 +411,8 @@ theorem isHereditarilyNatural_mk_forgetNode {I : Type uI} [Category.{vI} I]
     simp only [value_down, map_down]
     exact hloc f b
   · intro hnat
-    refine ⟨fun i i' g b => ?_, fun b => (n.1.2 b).2.down.2.2⟩
-    have h := congrArg (fun u => u.down.1) (hnat g b)
+    refine ⟨fun i i' g b ↦ ?_, fun b ↦ (n.1.2 b).2.down.2.2⟩
+    have h := congrArg (fun u ↦ u.down.1) (hnat g b)
     simp only [value_down, map_down] at h
     exact h
 
@@ -464,7 +464,7 @@ theorem dest_mk {I : Type uI} [Category.{vI} I]
   change rememberNode F (SlicePFunctor.W.dest (F := F.toSlicePFunctor)
     (SlicePFunctor.W.mk (F := F.toSlicePFunctor) (forgetNode F x.1.1))) hch = x.1.1
   have hy' : ∀ b, F.IsHereditarilyNatural ((forgetNode F x.1.1).1.2 b) :=
-    fun b => (x.1.1.1.2 b).2.down.2.2
+    fun b ↦ (x.1.1.1.2 b).2.down.2.2
   exact (rememberNode_eq F hch hy'
     (SlicePFunctor.W.dest_mk (F := F.toSlicePFunctor) (forgetNode F x.1.1))).trans
     (rememberNode_forgetNode F x.1.1 hy')
@@ -510,12 +510,12 @@ node's `OverInput`. -/
     {F : PresheafPFunctor.{uI, uI, uA, uB, vI, vI} I I}
     {Y : Iᵒᵖ ⥤ Type (max uI uA uB)} {a : F.toPFunctor.A}
     (c : F.toPFunctor.B a → PElimData F Y)
-    (hv : F.toSlicePFunctor.NodeValid a (fun b => (c b).toWIndex))
+    (hv : F.toSlicePFunctor.NodeValid a (fun b ↦ (c b).toWIndex))
     (hc : ∀ b, (c b).H (hv.1 b)) :
     F.toSliceDomPFunctor.Obj (PresheafDomPFunctorData.elemProj Y) :=
-  ⟨⟨a, fun b => (c b).value (hv.1 b) (hc b)⟩,
+  ⟨⟨a, fun b ↦ (c b).value (hv.1 b) (hc b)⟩,
     (F.toSliceDomPFunctor.compatible_iff (PresheafDomPFunctorData.elemProj Y) a _).mpr
-      fun b => ((c b).over (hv.1 b) (hc b)).trans (congrFun hv.2 b)⟩
+      fun b ↦ ((c b).over (hv.1 b) (hc b)).trans (congrFun hv.2 b)⟩
 
 /-- The value-fold algebra step: index and admissibility as for `windexStep`; a
 hereditary-naturality proxy `H` combining the children's proxies with the
@@ -525,14 +525,14 @@ presheaf algebra `α` to that node, packaged over the shape's `q`-output index. 
     (F : PresheafPFunctor.{uI, uI, uA, uB, vI, vI} I I)
     (Y : Iᵒᵖ ⥤ Type (max uI uA uB)) (α : NatTrans (F.objPresheaf Y) Y) :
     F.toPFunctor.Obj (PElimData F Y) → PElimData F Y :=
-  fun x =>
+  fun x ↦
     { index := F.q x.1
-      valid := F.toSlicePFunctor.NodeValid x.1 (fun b => (x.2 b).toWIndex)
-      H := fun hv => (∀ b, (x.2 b).H (hv.1 b)) ∧
+      valid := F.toSlicePFunctor.NodeValid x.1 (fun b ↦ (x.2 b).toWIndex)
+      H := fun hv ↦ (∀ b, (x.2 b).H (hv.1 b)) ∧
         (∀ hc : (∀ b, (x.2 b).H (hv.1 b)), F.IsNatural (pnodeSlice x.2 hv hc))
-      value := fun hv hn =>
+      value := fun hv hn ↦
         ⟨F.q x.1, α.app ⟨F.q x.1⟩ ⟨⟨pnodeSlice x.2 hv hn.1, hn.2 hn.1⟩, rfl⟩⟩
-      over := fun _ _ => rfl }
+      over := fun _ _ ↦ rfl }
 
 /-- The value fold: the `F.toPFunctor`-algebra morphism into
 `(PElimData F Y, pelimStep)` given by `WType.elim`, a single non-dependent fold
@@ -551,10 +551,10 @@ theorem pelimData_toWIndex {I : Type uI} [Category.{vI} I]
     (F : PresheafPFunctor.{uI, uI, uA, uB, vI, vI} I I)
     (Y : Iᵒᵖ ⥤ Type (max uI uA uB)) (α : NatTrans (F.objPresheaf Y) Y) (w : F.toPFunctor.W) :
     (pelimData F Y α w).toWIndex = F.windexValid w :=
-  WType.rec (motive := fun w => (pelimData F Y α w).toWIndex = F.windexValid w)
-    (fun a f ih => by
-      change F.windexStep ⟨a, fun b => (pelimData F Y α (f b)).toWIndex⟩ =
-        F.windexStep ⟨a, fun b => F.windexValid (f b)⟩
+  WType.rec (motive := fun w ↦ (pelimData F Y α w).toWIndex = F.windexValid w)
+    (fun a f ih ↦ by
+      change F.windexStep ⟨a, fun b ↦ (pelimData F Y α (f b)).toWIndex⟩ =
+        F.windexStep ⟨a, fun b ↦ F.windexValid (f b)⟩
       rw [funext ih])
     w
 
@@ -605,7 +605,7 @@ theorem value_wRestrTree {I : Type uI} [Category.{vI} I]
     (hv' : (pelimData F Y α (F.wRestrTree f t hqi).1).valid)
     (hn' : (pelimData F Y α (F.wRestrTree f t hqi).1).H hv') :
     (pelimData F Y α (F.wRestrTree f t hqi).1).value hv' hn' =
-      ⟨i', Y.map f.op (cast (congrArg (fun k : I => Y.obj ⟨k⟩)
+      ⟨i', Y.map f.op (cast (congrArg (fun k : I ↦ Y.obj ⟨k⟩)
           (((pelimData F Y α t.1).over hv hn).trans
             ((pelimData_index F Y α t.1).trans hqi)))
         ((pelimData F Y α t.1).value hv hn).2)⟩ := by
@@ -616,16 +616,16 @@ theorem value_wRestrTree {I : Type uI} [Category.{vI} I]
     have hqa : F.q a = i := hqi
     subst hqa
     have hnat :
-        Y.map f.op (α.app ⟨F.q a⟩ (⟨⟨pnodeSlice (fun b => pelimData F Y α (fchild b)) hv hn.1,
+        Y.map f.op (α.app ⟨F.q a⟩ (⟨⟨pnodeSlice (fun b ↦ pelimData F Y α (fchild b)) hv hn.1,
             hn.2 hn.1⟩, rfl⟩ : (F.objPresheaf Y).obj ⟨F.q a⟩)) =
           α.app ⟨i'⟩ ((F.objPresheaf Y).map f.op
-            ⟨⟨pnodeSlice (fun b => pelimData F Y α (fchild b)) hv hn.1, hn.2 hn.1⟩, rfl⟩) := by
+            ⟨⟨pnodeSlice (fun b ↦ pelimData F Y α (fchild b)) hv hn.1, hn.2 hn.1⟩, rfl⟩) := by
       exact (FunctorToTypes.naturality _ _ α f.op _).symm
     change (α.app ⟨F.q (F.shapeRestr f ⟨a, hqi⟩).1⟩
-          (⟨⟨F.objRestrElt f (pnodeSlice (fun b => pelimData F Y α (fchild b)) hv hn.1) hqi,
+          (⟨⟨F.objRestrElt f (pnodeSlice (fun b ↦ pelimData F Y α (fchild b)) hv hn.1) hqi,
             hn'.2 hn'.1⟩, rfl⟩ : (F.objPresheaf Y).obj ⟨F.q (F.shapeRestr f ⟨a, hqi⟩).1⟩)) ≍
         Y.map f.op (α.app ⟨F.q a⟩
-          (⟨⟨pnodeSlice (fun b => pelimData F Y α (fchild b)) hv hn.1, hn.2 hn.1⟩, rfl⟩ :
+          (⟨⟨pnodeSlice (fun b ↦ pelimData F Y α (fchild b)) hv hn.1, hn.2 hn.1⟩, rfl⟩ :
             (F.objPresheaf Y).obj ⟨F.q a⟩))
     rw [hnat]
     exact app_heq α (F.shapeRestr f ⟨a, hqi⟩).2
@@ -639,21 +639,21 @@ private theorem isNatural_pnodeSlice {I : Type uI} [Category.{vI} I]
     (F : PresheafPFunctor.{uI, uI, uA, uB, vI, vI} I I)
     (Y : Iᵒᵖ ⥤ Type (max uI uA uB)) (α : NatTrans (F.objPresheaf Y) Y)
     {a : F.toPFunctor.A} (fc : F.toPFunctor.B a → F.toSlicePFunctor.W)
-    (hv : F.toSlicePFunctor.NodeValid a (fun b => (pelimData F Y α (fc b).1).toWIndex))
+    (hv : F.toSlicePFunctor.NodeValid a (fun b ↦ (pelimData F Y α (fc b).1).toWIndex))
     (hc : ∀ b, (pelimData F Y α (fc b).1).H (hv.1 b))
     (hloc : ∀ ⦃i i' : I⦄ (g : i' ⟶ i) (b : F.toSliceDomPFunctor.Direction a i)
         (hq : F.q (PFunctor.W.head (fc b.1).1) = i),
         fc (F.directionRestr a g b).1 = F.wRestrTree g (fc b.1) hq) :
-    F.IsNatural (pnodeSlice (fun b => pelimData F Y α (fc b).1) hv hc) := by
+    F.IsNatural (pnodeSlice (fun b ↦ pelimData F Y α (fc b).1) hv hc) := by
   intro i i' g b
-  change F.value (pnodeSlice (fun b => pelimData F Y α (fc b).1) hv hc) (F.directionRestr a g b) =
-    Y.map g.op (F.value (pnodeSlice (fun b => pelimData F Y α (fc b).1) hv hc) b)
+  change F.value (pnodeSlice (fun b ↦ pelimData F Y α (fc b).1) hv hc) (F.directionRestr a g b) =
+    Y.map g.op (F.value (pnodeSlice (fun b ↦ pelimData F Y α (fc b).1) hv hc) b)
   have hqit : F.q (PFunctor.W.head (fc b.1).1) = i :=
     (pelimData_index F Y α (fc b.1).1).symm.trans ((congrFun hv.2 b.1).trans b.2)
   have hgen : ∀ (T : F.toSlicePFunctor.W) (hvT : (pelimData F Y α T.1).valid)
       (hnT : (pelimData F Y α T.1).H hvT), T = F.wRestrTree g (fc b.1) hqit →
       (pelimData F Y α T.1).value hvT hnT =
-        ⟨i', Y.map g.op (cast (congrArg (fun k : I => Y.obj ⟨k⟩)
+        ⟨i', Y.map g.op (cast (congrArg (fun k : I ↦ Y.obj ⟨k⟩)
             (((pelimData F Y α (fc b.1).1).over (hv.1 b.1) (hc b.1)).trans
               ((pelimData_index F Y α (fc b.1).1).trans hqit)))
           ((pelimData F Y α (fc b.1).1).value (hv.1 b.1) (hc b.1)).2)⟩ := by
@@ -661,9 +661,9 @@ private theorem isNatural_pnodeSlice {I : Type uI} [Category.{vI} I]
     subst hT
     exact value_wRestrTree F Y α (fc b.1) g hqit (hv.1 b.1) (hc b.1) hvT hnT
   have hchild :
-      (pnodeSlice (fun b => pelimData F Y α (fc b).1) hv hc).1.2
+      (pnodeSlice (fun b ↦ pelimData F Y α (fc b).1) hv hc).1.2
           (F.directionRestr a g b).1 =
-        ⟨i', Y.map g.op (cast (congrArg (fun k : I => Y.obj ⟨k⟩)
+        ⟨i', Y.map g.op (cast (congrArg (fun k : I ↦ Y.obj ⟨k⟩)
             (((pelimData F Y α (fc b.1).1).over (hv.1 b.1) (hc b.1)).trans
               ((pelimData_index F Y α (fc b.1).1).trans hqit)))
           ((pelimData F Y α (fc b.1).1).value (hv.1 b.1) (hc b.1)).2)⟩ :=
@@ -684,13 +684,13 @@ theorem pelimData_H_of_isHN {I : Type uI} [Category.{vI} I]
     (w : F.toSlicePFunctor.W) (hv : (pelimData F Y α w.1).valid)
     (hn : F.IsHereditarilyNatural w) : (pelimData F Y α w.1).H hv :=
   SlicePFunctor.W.ind
-    (motive := fun z => ∀ (hv : (pelimData F Y α z.1).valid),
+    (motive := fun z ↦ ∀ (hv : (pelimData F Y α z.1).valid),
       F.IsHereditarilyNatural z → (pelimData F Y α z.1).H hv)
-    (fun x ih hv hHN => by
-      refine ⟨fun b => ih b (hv.1 b) (((F.isHereditarilyNatural_mk x).mp hHN).2 b), fun _ => ?_⟩
+    (fun x ih hv hHN ↦ by
+      refine ⟨fun b ↦ ih b (hv.1 b) (((F.isHereditarilyNatural_mk x).mp hHN).2 b), fun _ ↦ ?_⟩
       exact isNatural_pnodeSlice F Y α x.1.2 hv
-        (fun b => ih b (hv.1 b) (((F.isHereditarilyNatural_mk x).mp hHN).2 b))
-        (fun _ _ g b _ => ((F.isHereditarilyNatural_mk x).mp hHN).1 g b))
+        (fun b ↦ ih b (hv.1 b) (((F.isHereditarilyNatural_mk x).mp hHN).2 b))
+        (fun _ _ g b _ ↦ ((F.isHereditarilyNatural_mk x).mp hHN).1 g b))
     w hv hn
 
 /-- The fibre value the fold contributes to a validated hereditarily-natural
@@ -700,7 +700,7 @@ fibre over `j` through the fold's `over` law and root-index agreement. -/
     (F : PresheafPFunctor.{uI, uI, uA, uB, vI, vI} I I)
     (Y : Iᵒᵖ ⥤ Type (max uI uA uB)) (α : NatTrans (F.objPresheaf Y) Y) {j : I}
     (z : (F.W).obj ⟨j⟩) : Y.obj ⟨j⟩ :=
-  cast (congrArg (fun i : I => Y.obj ⟨i⟩)
+  cast (congrArg (fun i : I ↦ Y.obj ⟨i⟩)
       ((((pelimData F Y α z.down.1.1).over
           ((pelimData_valid F Y α z.down.1.1) ▸ z.down.1.2)
           (pelimData_H_of_isHN F Y α z.down.1
@@ -757,7 +757,7 @@ presheaf algebra `(Y, α)`. Its component over `j` is the bespoke value fold
     (F : PresheafPFunctor.{uI, uI, uA, uB, vI, vI} I I)
     (Y : Iᵒᵖ ⥤ Type (max uI uA uB)) (α : NatTrans (F.objPresheaf Y) Y) :
     NatTrans F.W Y where
-  app j := ↾ fun z => elimVal F Y α (j := j.unop) z
+  app j := ↾ fun z ↦ elimVal F Y α (j := j.unop) z
   naturality _ _ g := by
     ext z
     exact elimVal_wRestr F Y α g.unop z
@@ -787,7 +787,7 @@ theorem elim_mk {I : Type uI} [Category.{vI} I]
   have hq : F.q x.1.1.1.1 = j := x.2
   have hchild : ∀ b, (pelimData F Y α (x.1.1.1.2 b).2.down.1.1).value (hv.1 b) (hn.1 b)
       = (⟨(x.1.1.1.2 b).1, elimVal F Y α (x.1.1.1.2 b).2⟩ : Σ i : I, Y.obj ⟨i⟩) :=
-    fun b => value_eq_elimVal F Y α (x.1.1.1.2 b).2 (hv.1 b) (hn.1 b)
+    fun b ↦ value_eq_elimVal F Y α (x.1.1.1.2 b).2 (hv.1 b) (hn.1 b)
   have hval := value_eq_elimVal F Y α (mk x) hv hn
   apply eq_of_heq
   refine ((Sigma.ext_iff.mp hval).2.symm).trans ?_
@@ -795,7 +795,7 @@ theorem elim_mk {I : Type uI} [Category.{vI} I]
   refine objPresheaf_obj_heq F Y hq ?_
   apply Subtype.ext
   apply Subtype.ext
-  exact Sigma.ext rfl (heq_of_eq (funext fun b => hchild b))
+  exact Sigma.ext rfl (heq_of_eq (funext fun b ↦ hchild b))
 
 end W
 

--- a/geb-lean/vendor/geb-mathlib/Geb/Mathlib/Data/PFunctor/Slice/Basic.lean
+++ b/geb-lean/vendor/geb-mathlib/Geb/Mathlib/Data/PFunctor/Slice/Basic.lean
@@ -128,7 +128,7 @@ direction-input map. -/
 @[expose] def ofCurried (P : PFunctor.{uA, uB}) (dom : Type uD)
     (sc : (a : P.A) → P.B a → dom) : SliceDomPFunctor dom where
   toPFunctor := P
-  r := fun x => sc x.1 x.2
+  r := fun x ↦ sc x.1 x.2
 
 /-- The direction-input map in dependently-curried form. -/
 @[expose] def rCurried {dom : Type uD} (F : SliceDomPFunctor.{uA, uB} dom) (a : F.A)
@@ -159,7 +159,7 @@ restricted to the compatibility subtype. -/
     {X : Type uX} {X' : Type uX'}
     {p : X → dom} {p' : X' → dom} (f : X → X') (hf : p' ∘ f = p) :
     F.Obj p → F.Obj p' :=
-  fun x => ⟨F.toPFunctor.map f x.1, by
+  fun x ↦ ⟨F.toPFunctor.map f x.1, by
     obtain ⟨⟨a, v⟩, hx⟩ := x
     change p' ∘ (f ∘ v) = F.r ∘ Sigma.mk a
     rw [← Function.comp_assoc, hf]
@@ -174,7 +174,7 @@ theorem map_fst {dom : Type uD} (F : SliceDomPFunctor.{uA, uB} dom)
 /-- Functoriality: identity. -/
 theorem map_id {dom : Type uD} (F : SliceDomPFunctor.{uA, uB} dom) {X : Type uX}
     (p : X → dom) : F.map id (by simp) = (id : F.Obj p → F.Obj p) :=
-  funext fun x => Subtype.ext (F.toPFunctor.id_map x.1)
+  funext fun x ↦ Subtype.ext (F.toPFunctor.id_map x.1)
 
 /-- Functoriality: composition. -/
 theorem map_comp {dom : Type uD} (F : SliceDomPFunctor.{uA, uB} dom)
@@ -183,7 +183,7 @@ theorem map_comp {dom : Type uD} (F : SliceDomPFunctor.{uA, uB} dom)
     (hf : p' ∘ f = p) (hg : p'' ∘ g = p') :
     F.map (g ∘ f) (by rw [← hf, ← hg, Function.comp_assoc]) =
       F.map g hg ∘ F.map f hf :=
-  funext fun x => Subtype.ext (F.toPFunctor.map_map f g x.1).symm
+  funext fun x ↦ Subtype.ext (F.toPFunctor.map_map f g x.1).symm
 
 end SliceDomPFunctor
 
@@ -194,7 +194,7 @@ structure map into `cod`, the shape-output map applied to each shape. The
 carrier is the `SliceDomPFunctor` value `F.toSliceDomPFunctor.Obj p`. -/
 @[expose] def obj {dom : Type uD} {cod : Type uC} (F : SlicePFunctor.{uA, uB, uD, uC} dom cod)
     {X : Type uX} (p : X → dom) : F.toSliceDomPFunctor.Obj p → cod :=
-  fun z => F.q z.1.1
+  fun z ↦ F.q z.1.1
 
 /-- The slice functor's action on a morphism: the `SliceDomPFunctor` morphism
 map underlying it. -/
@@ -207,7 +207,7 @@ map underlying it. -/
 theorem map_w {dom : Type uD} {cod : Type uC} (F : SlicePFunctor.{uA, uB, uD, uC} dom cod)
     {X : Type uX} {X' : Type uX'} {p : X → dom} {p' : X' → dom} (f : X → X') (hf : p' ∘ f = p) :
     F.obj p' ∘ F.map f hf = F.obj p :=
-  funext fun z => congrArg F.q (F.toSliceDomPFunctor.map_fst f hf z)
+  funext fun z ↦ congrArg F.q (F.toSliceDomPFunctor.map_fst f hf z)
 
 /-- Functoriality: identity. -/
 theorem map_id {dom : Type uD} {cod : Type uC} (F : SlicePFunctor.{uA, uB, uD, uC} dom cod)

--- a/geb-lean/vendor/geb-mathlib/Geb/Mathlib/Data/PFunctor/Slice/Functor.lean
+++ b/geb-lean/vendor/geb-mathlib/Geb/Mathlib/Data/PFunctor/Slice/Functor.lean
@@ -94,8 +94,8 @@ the `Functor.toOver` triangle obligation for `functor`, shared with
 private theorem output_triangle {dom : Type uD} {cod : Type (max uA uB uD)}
     (F : SlicePFunctor.{uA, uB, uD, max uA uB uD} dom cod)
     {Y Z : Over dom} (g : Y ⟶ Z) :
-    F.toSliceDomPFunctor.domFunctor.map g ≫ (↾fun z => F.q z.1.1) =
-      (↾fun z => F.q z.1.1) := by
+    F.toSliceDomPFunctor.domFunctor.map g ≫ (↾fun z ↦ F.q z.1.1) =
+      (↾fun z ↦ F.q z.1.1) := by
   ext z
   exact congrArg F.q (F.toSliceDomPFunctor.map_fst (g.left)
     (SliceDomPFunctor.over_hom_comp g) z)
@@ -106,7 +106,7 @@ private theorem output_triangle {dom : Type uD} {cod : Type (max uA uB uD)}
     (F : SlicePFunctor.{uA, uB, uD, max uA uB uD} dom cod) :
     CategoryTheory.Functor (Over dom) (Over cod) :=
   Functor.toOver F.toSliceDomPFunctor.domFunctor cod
-    (fun _ => ↾(fun z => F.q z.1.1))
+    (fun _ ↦ ↾(fun z ↦ F.q z.1.1))
     (by intro Y Z g; exact F.output_triangle g)
 
 /-- The wrapper forgets back to `domFunctor`. -/
@@ -114,7 +114,7 @@ theorem functor_comp_forget {dom : Type uD} {cod : Type (max uA uB uD)}
     (F : SlicePFunctor.{uA, uB, uD, max uA uB uD} dom cod) :
     F.functor ⋙ Over.forget cod = F.toSliceDomPFunctor.domFunctor := by
   rw [functor]
-  exact Functor.toOver_comp_forget _ _ _ fun g => F.output_triangle g
+  exact Functor.toOver_comp_forget _ _ _ fun g ↦ F.output_triangle g
 
 /-- `functor.obj` is the core `obj`, packaged with `Over.mk`. The
 categorical object map carries no data beyond the core. -/

--- a/geb-lean/vendor/geb-mathlib/Geb/Mathlib/Data/PFunctor/Slice/W.lean
+++ b/geb-lean/vendor/geb-mathlib/Geb/Mathlib/Data/PFunctor/Slice/W.lean
@@ -182,7 +182,7 @@ the index is the `q`-assigned output index of the shape, and the node is
 `NodeValid`. -/
 @[expose] def windexStep {I : Type uI} (F : SlicePFunctor.{uA, uB, uI, uI} I I) :
     F.toPFunctor.Obj (WIndex I) → WIndex I :=
-  fun ⟨a, c⟩ => { index := F.q a, valid := F.NodeValid a c }
+  fun ⟨a, c⟩ ↦ { index := F.q a, valid := F.NodeValid a c }
 
 /-- The index paired with admissibility: the `F.toPFunctor`-algebra morphism
 into `(WIndex I, windexStep)` given by `WType.elim`. -/
@@ -214,7 +214,7 @@ theorem wValid_mk {I : Type uI} (F : SlicePFunctor.{uA, uB, uI, uI} I I)
     F.WValid (WType.mk a f) ↔
       F.ForAll a (F.WValid ∘ f) ∧ F.OverInput a (F.windexRoot ∘ f) := by
   have h : WIndex.index ∘ F.windexValid ∘ f = F.windexRoot ∘ f :=
-    funext fun b => F.windexValid_index_eq_windexRoot (f b)
+    funext fun b ↦ F.windexValid_index_eq_windexRoot (f b)
   change (F.ForAll a (F.WValid ∘ f) ∧ F.OverInput a (WIndex.index ∘ F.windexValid ∘ f)) ↔ _
   rw [h]
 
@@ -234,7 +234,7 @@ namespace W
 @[expose] def mk {I : Type uI} {F : SlicePFunctor.{uA, uB, uI, uI} I I}
     (x : F.toSliceDomPFunctor.Obj F.windex) : F.W :=
   ⟨WType.mk x.1.1 (Subtype.val ∘ x.1.2),
-    (F.wValid_mk _ _).mpr ⟨fun b => (x.1.2 b).property,
+    (F.wValid_mk _ _).mpr ⟨fun b ↦ (x.1.2 b).property,
       funext ((F.toSliceDomPFunctor.compatible_iff F.windex x.1.1 x.1.2).mp x.2)⟩⟩
 
 /-- The destructor of the slice W-type: every admissible tree decomposes as a
@@ -244,9 +244,9 @@ shape together with a compatible family of admissible subtrees. Inverse to
     (z : F.W) : F.toSliceDomPFunctor.Obj F.windex :=
   match z with
   | ⟨WType.mk a f, hw⟩ =>
-      ⟨⟨a, fun b => ⟨f b, ((F.wValid_mk a f).mp hw).1 b⟩⟩,
+      ⟨⟨a, fun b ↦ ⟨f b, ((F.wValid_mk a f).mp hw).1 b⟩⟩,
         (F.toSliceDomPFunctor.compatible_iff F.windex a _).mpr
-          fun b => congrFun ((F.wValid_mk a f).mp hw).2 b⟩
+          fun b ↦ congrFun ((F.wValid_mk a f).mp hw).2 b⟩
 
 /-- `dest` is a left inverse of `mk`. -/
 @[simp]
@@ -254,7 +254,7 @@ theorem dest_mk {I : Type uI} {F : SlicePFunctor.{uA, uB, uI, uI} I I}
     (x : F.toSliceDomPFunctor.Obj F.windex) : dest (mk x) = x := by
   obtain ⟨⟨a, v⟩, hv⟩ := x
   apply Subtype.ext
-  exact Sigma.ext rfl (heq_of_eq (funext fun b => Subtype.ext rfl))
+  exact Sigma.ext rfl (heq_of_eq (funext fun b ↦ Subtype.ext rfl))
 
 /-- `mk` is a left inverse of `dest`; with `dest_mk`, `mk` and `dest` are
 mutually inverse, so `W` is a fixed point of the slice endofunctor. -/
@@ -288,13 +288,13 @@ children's values, with `over` recording that the result lies over the index. -/
 @[expose] def elimStep {I : Type uI} (F : SlicePFunctor.{uA, uB, uI, uI} I I)
     (Y : Type uY) (p : Y → I) (g : F.toSliceDomPFunctor.Obj p → Y) (hg : p ∘ g = F.obj p) :
     F.toPFunctor.Obj (ElimData Y p) → ElimData Y p :=
-  fun ⟨a, c⟩ =>
+  fun ⟨a, c⟩ ↦
     { index := F.q a
       valid := F.NodeValid a (ElimData.toWIndex ∘ c)
-      value := fun hv => g ⟨⟨a, fun b => (c b).value (hv.1 b)⟩,
-        (F.toSliceDomPFunctor.compatible_iff p a _).mpr fun b =>
+      value := fun hv ↦ g ⟨⟨a, fun b ↦ (c b).value (hv.1 b)⟩,
+        (F.toSliceDomPFunctor.compatible_iff p a _).mpr fun b ↦
           (congrFun (c b).over (hv.1 b)).trans (congrFun hv.2 b)⟩
-      over := funext fun _ => congrFun hg _ }
+      over := funext fun _ ↦ congrFun hg _ }
 
 /-- The `elim` fold: the `F.toPFunctor`-algebra morphism into
 `(ElimData Y p, elimStep)` given by `WType.elim`, a single non-dependent fold
@@ -317,8 +317,8 @@ theorem elimData_valid_mk {I : Type uI} (F : SlicePFunctor.{uA, uB, uI, uI} I I)
     (Y : Type uY) (p : Y → I) (g : F.toSliceDomPFunctor.Obj p → Y) (hg : p ∘ g = F.obj p)
     (a : F.toPFunctor.A) (f : F.toPFunctor.B a → F.toPFunctor.W) :
     (elimData F Y p g hg (WType.mk a f)).valid =
-      (F.ForAll a (fun b => (elimData F Y p g hg (f b)).valid) ∧
-        F.OverInput a (fun b => (elimData F Y p g hg (f b)).index)) :=
+      (F.ForAll a (fun b ↦ (elimData F Y p g hg (f b)).valid) ∧
+        F.OverInput a (fun b ↦ (elimData F Y p g hg (f b)).index)) :=
   rfl
 
 /-- The admissibility component of `elimData` agrees with `WValid`. An
@@ -329,8 +329,8 @@ non-computability is immaterial. -/
 theorem elimData_valid {I : Type uI} (F : SlicePFunctor.{uA, uB, uI, uI} I I)
     (Y : Type uY) (p : Y → I) (g : F.toSliceDomPFunctor.Obj p → Y) (hg : p ∘ g = F.obj p)
     (w : F.toPFunctor.W) : (elimData F Y p g hg w).valid ↔ F.WValid w :=
-  WType.rec (motive := fun w => (elimData F Y p g hg w).valid ↔ F.WValid w)
-    (fun a f ih => by
+  WType.rec (motive := fun w ↦ (elimData F Y p g hg w).valid ↔ F.WValid w)
+    (fun a f ih ↦ by
       beta_reduce
       rw [F.wValid_mk, elimData_valid_mk]
       exact and_congr (forall_congr' ih) (by simp only [OverInput, elimData_index]; rfl))
@@ -343,7 +343,7 @@ argument to the fold's `value` function. -/
 @[expose] def elim {I : Type uI} (F : SlicePFunctor.{uA, uB, uI, uI} I I)
     (Y : Type uY) (p : Y → I) (g : F.toSliceDomPFunctor.Obj p → Y) (hg : p ∘ g = F.obj p) :
     F.W → Y :=
-  fun z =>
+  fun z ↦
     (elimData F Y p g hg z.val).value
       ((elimData_valid F Y p g hg z.val).mpr z.property)
 
@@ -352,7 +352,7 @@ argument to the fold's `value` function. -/
 theorem comp_elim {I : Type uI} (F : SlicePFunctor.{uA, uB, uI, uI} I I)
     (Y : Type uY) (p : Y → I) (g : F.toSliceDomPFunctor.Obj p → Y) (hg : p ∘ g = F.obj p) :
     p ∘ elim F Y p g hg = F.windex :=
-  funext fun z =>
+  funext fun z ↦
     (congrFun (elimData F Y p g hg z.val).over
       ((elimData_valid F Y p g hg z.val).mpr z.property)).trans
       (elimData_index F Y p g hg z.val)
@@ -375,11 +375,11 @@ theorem ind {I : Type uI} {F : SlicePFunctor.{uA, uB, uI, uI} I I}
     (mk : ∀ (x : F.toSliceDomPFunctor.Obj F.windex),
         (∀ b, motive (x.1.2 b)) → motive (W.mk x)) :
     ∀ z, motive z :=
-  fun z =>
-    WType.rec (motive := fun w => ∀ (hw : F.WValid w), motive ⟨w, hw⟩)
-      (fun a f ih hw' => by
+  fun z ↦
+    WType.rec (motive := fun w ↦ ∀ (hw : F.WValid w), motive ⟨w, hw⟩)
+      (fun a f ih hw' ↦ by
         rw [← mk_dest ⟨WType.mk a f, hw'⟩]
-        exact mk _ fun b => ih b (((F.wValid_mk a f).mp hw').1 b))
+        exact mk _ fun b ↦ ih b (((F.wValid_mk a f).mp hw').1 b))
       z.1 z.2
 
 /-- Paramorphism from the slice W-type into `Prop`: `step` sees the node `x`,
@@ -390,11 +390,11 @@ values. The value is computed by `WType.rec` with a `Prop` motive, so no
     (step : (x : F.toSliceDomPFunctor.Obj F.windex) →
       (F.toPFunctor.B x.1.1 → Prop) → Prop) :
     F.W → Prop :=
-  fun z =>
-    WType.rec (motive := fun w => F.WValid w → Prop)
-      (fun a f ih hv =>
+  fun z ↦
+    WType.rec (motive := fun w ↦ F.WValid w → Prop)
+      (fun a f ih hv ↦
         step (dest ⟨WType.mk a f, hv⟩)
-          (fun b => ih b (((F.wValid_mk a f).mp hv).1 b)))
+          (fun b ↦ ih b (((F.wValid_mk a f).mp hv).1 b)))
       z.1 z.2
 
 /-- The one-level computation rule for `recProp`: on `mk x` it applies `step`
@@ -404,7 +404,7 @@ theorem recProp_mk {I : Type uI} {F : SlicePFunctor.{uA, uB, uI, uI} I I}
     (step : (x : F.toSliceDomPFunctor.Obj F.windex) →
       (F.toPFunctor.B x.1.1 → Prop) → Prop)
     (x : F.toSliceDomPFunctor.Obj F.windex) :
-    W.recProp step (W.mk x) = step x (fun b => W.recProp step (x.1.2 b)) := by
+    W.recProp step (W.mk x) = step x (fun b ↦ W.recProp step (x.1.2 b)) := by
   obtain ⟨⟨a, v⟩, hc⟩ := x
   rfl
 

--- a/geb-lean/vendor/geb-mathlib/PROVENANCE.md
+++ b/geb-lean/vendor/geb-mathlib/PROVENANCE.md
@@ -1,6 +1,6 @@
 # Vendored geb-mathlib provenance
 
 - Source: https://github.com/rokopt/geb-mathlib.git
-- Source commit: 0a772c26a8f83278c28e6a388953f55f8beef7dd
-- Back-port patch: scripts/geb-mathlib-backport.patch (sha256 2574fc92ed0a5996910eaefde560dd1b0d88fd8fc10b99865c11abedd5a67f72)
+- Source commit: 0d5438156f18318af9b1618b14f228ccb698788b
+- Back-port patch: scripts/geb-mathlib-backport.patch (sha256 cb9067bac9668539fbba9860664888d4e018e5e495b8e11453e35d3242f12ad5)
 - The files under `Geb/` are an unmodified mirror of the source commit except where the back-port patch changes them; modified files carry a change notice in their header comment.


### PR DESCRIPTION
Upstream geb-mathlib moved to 0d54381, whose sole change past 0a772c2 is a style sweep replacing `fun x =>` with `fun x ↦`. Four patch hunks carried the old arrow form in their context lines and no longer applied. The adaptations themselves are unchanged; the regenerated patch differs from the previous one only in those context lines, hunk offsets, and index hashes. The vendored tree is refreshed to the new revision via scripts/refresh-geb-mathlib.sh, which reproduces it byte-identically from the committed patch (the no-op condition of docs/geb-mathlib-backport-notes.md).