### PR TITLE
Update vendored geb-mathlib

### DIFF
--- a/geb-lean/docs/geb-mathlib-backport-notes.md
+++ b/geb-lean/docs/geb-mathlib-backport-notes.md
@@ -9,6 +9,7 @@
   - [2. `linter.checkUnivs` configuration absent in v4.29](#2-lintercheckunivs-configuration-absent-in-v429)
   - [3. `ConcreteCategory` redesign (mathlib pull request 34741)](#3-concretecategory-redesign-mathlib-pull-request-34741)
   - [4. `WType.rec` motive left as an unreduced beta-redex](#4-wtyperec-motive-left-as-an-unreduced-beta-redex)
+  - [5. `simp` rewriting under dependent proof arguments narrowed in v4.33](#5-simp-rewriting-under-dependent-proof-arguments-narrowed-in-v433)
 - [Updating the patch for a new upstream](#updating-the-patch-for-a-new-upstream)
   - [The no-op condition](#the-no-op-condition)
 - [The hard wall](#the-hard-wall)
@@ -18,7 +19,7 @@
 
 These notes catalogue the categories of change in
 `scripts/geb-mathlib-backport.patch`, which adapts the vendored
-`geb-mathlib` `Geb` source (mathlib `v4.32.0-rc1`) to compile under this
+`geb-mathlib` `Geb` source (mathlib `v4.33.0-rc1`) to compile under this
 repository's `v4.29.0-rc6`. When a refresh fails, check whether the new
 failure matches a category below (extend the corresponding hunk) or is
 genuinely new (decide the adaptation, add a category here).
@@ -74,10 +75,10 @@ genuinely new (decide the adaptation, add a category here).
   the `Type`-valued naturality lemma whose statement is the goal
   (`α.app Y (Z.map f x) = Z'.map f (α.app X x)`).
 - Adaptation in `Presheaf/W.lean` (`value_wRestrTree`): the same
-  `ConcreteCategory.comp_apply` gap appears in a naturality step written
-  `rw [← ConcreteCategory.comp_apply, ← α.naturality f.op,
-  ConcreteCategory.comp_apply]`. Replace with
-  `exact (FunctorToTypes.naturality _ _ α f.op _).symm`; the `.symm` is
+  `ConcreteCategory.comp_apply` gap appears in a naturality step, a
+  term-mode proof chaining `ConcreteCategory.comp_apply` and
+  `ConcreteCategory.congr_hom`. Replace the chain with the term
+  `(FunctorToTypes.naturality _ _ α f.op _).symm`; the `.symm` is
   needed because this goal is the naturality equation with sides
   reversed.
 
@@ -95,6 +96,22 @@ genuinely new (decide the adaptation, add a category here).
   such step.
 - Adaptation: prepend `beta_reduce` as the first tactic of the minor
   premise, exposing `F.WValid (WType.mk a f)` for the existing rewrite.
+
+### 5. `simp` rewriting under dependent proof arguments narrowed in v4.33
+
+- Upstream cause: `Presheaf/W.lean`'s `isHereditarilyNatural_mk_forgetNode`
+  closes its converse direction with
+  `exact h.trans (wRestrTree_congr F g (value_down F n b) _ _)`. The
+  `wRestrTree_congr` bridge compensates for v4.33's `simp`, which no
+  longer rewrites the `value_down` occurrence sitting under
+  `wRestrTree`'s dependent head-index proof argument.
+- v4.29 symptom: `simp only [value_down F n, map_down F g] at h`
+  rewrites that occurrence as well, so the bridge's left-hand side no
+  longer occurs in `h`: application type mismatch on the `h.trans`
+  argument.
+- Adaptation: close with `exact h` (drop the `.trans` bridge). The
+  private `wRestrTree_congr` lemma compiles under v4.29 and is left
+  unmodified, unused.
 
 ## Updating the patch for a new upstream
 
@@ -152,7 +169,7 @@ When a vendored module depends on a mathlib definition or theorem that
 does not exist in `v4.29.0-rc6` (a genuinely new result, not a rename),
 no patch hunk can supply it and `sorry`/`admit` are banned. Such a module
 is dropped from the vendored copy via the refresh script's exclusion list
-until either `geb-lean` is forward-migrated to `v4.32.0-rc1` or the
+until either `geb-lean` is forward-migrated to `v4.33.0-rc1` or the
 consuming exploration is deferred.
 
 ## Tooling notes

--- a/geb-lean/scripts/geb-mathlib-backport.patch
+++ b/geb-lean/scripts/geb-mathlib-backport.patch
@@ -77,7 +77,7 @@ index 429483f..8754442 100644
      (J : Type uJ) [Category.{vJ} J] : Type (max (uA + 1) (uB + 1) uI uJ vI vJ)
      extends PresheafPFunctorData.{uI, uJ, uA, uB, vI, vJ} I J where
 diff --git a/vendor/geb-mathlib/Geb/Mathlib/Data/PFunctor/Presheaf/W.lean b/vendor/geb-mathlib/Geb/Mathlib/Data/PFunctor/Presheaf/W.lean
-index cab3559..1b78d18 100644
+index 8a4bc84..0539afe 100644
 --- a/vendor/geb-mathlib/Geb/Mathlib/Data/PFunctor/Presheaf/W.lean
 +++ b/vendor/geb-mathlib/Geb/Mathlib/Data/PFunctor/Presheaf/W.lean
 @@ -3,6 +3,7 @@ Copyright (c) 2026 The geb-mathlib contributors. All rights reserved.
@@ -88,17 +88,28 @@ index cab3559..1b78d18 100644
  module
  
  public import Geb.Mathlib.Data.PFunctor.Slice.W
-@@ -619,7 +620,7 @@ theorem value_wRestrTree {I : Type uI} [Category.{vI} I]
+@@ -424,7 +425,7 @@ theorem isHereditarilyNatural_mk_forgetNode {I : Type uI} [Category.{vI} I]
+     refine ⟨fun i i' g b ↦ ?_, fun b ↦ (n.1.2 b).2.down.2.2⟩
+     have h := congrArg (fun u ↦ u.down.1) (hnat g b)
+     simp only [value_down F n, map_down F g] at h
+-    exact h.trans (wRestrTree_congr F g (value_down F n b) _ _)
++    exact h
+ 
+ /-- The fixed-point constructor of the presheaf W-type: the `objPresheaf`-value
+ at the carrier presheaf `F.W` maps into `F.W`, fibrewise over `I`. It builds the
+@@ -630,9 +631,7 @@ theorem value_wRestrTree {I : Type uI} [Category.{vI} I]
              hn.2 hn.1⟩, rfl⟩ : (F.objPresheaf Y).obj ⟨F.q a⟩)) =
            α.app ⟨i'⟩ ((F.objPresheaf Y).map f.op
-             ⟨⟨pnodeSlice (fun b ↦ pelimData F Y α (fchild b)) hv hn.1, hn.2 hn.1⟩, rfl⟩) := by
--      rw [← ConcreteCategory.comp_apply, ← α.naturality f.op, ConcreteCategory.comp_apply]
-+      exact (FunctorToTypes.naturality _ _ α f.op _).symm
+             ⟨⟨pnodeSlice (fun b ↦ pelimData F Y α (fchild b)) hv hn.1, hn.2 hn.1⟩, rfl⟩) :=
+-      (ConcreteCategory.comp_apply _ _ _).symm.trans
+-        ((ConcreteCategory.congr_hom (α.naturality f.op).symm _).trans
+-          (ConcreteCategory.comp_apply _ _ _))
++      (FunctorToTypes.naturality _ _ α f.op _).symm
      change (α.app ⟨F.q (F.shapeRestr f ⟨a, hqi⟩).1⟩
            (⟨⟨F.objRestrElt f (pnodeSlice (fun b ↦ pelimData F Y α (fchild b)) hv hn.1) hqi,
              hn'.2 hn'.1⟩, rfl⟩ : (F.objPresheaf Y).obj ⟨F.q (F.shapeRestr f ⟨a, hqi⟩).1⟩)) ≍
 diff --git a/vendor/geb-mathlib/Geb/Mathlib/Data/PFunctor/Slice/Basic.lean b/vendor/geb-mathlib/Geb/Mathlib/Data/PFunctor/Slice/Basic.lean
-index 579e42f..568164a 100644
+index 2b85da3..0445d60 100644
 --- a/vendor/geb-mathlib/Geb/Mathlib/Data/PFunctor/Slice/Basic.lean
 +++ b/vendor/geb-mathlib/Geb/Mathlib/Data/PFunctor/Slice/Basic.lean
 @@ -3,6 +3,7 @@ Copyright (c) 2026 The geb-mathlib contributors. All rights reserved.
@@ -109,7 +120,7 @@ index 579e42f..568164a 100644
  module
  
  public import Mathlib.Data.PFunctor.Univariate.Basic
-@@ -89,17 +90,17 @@ public section
+@@ -94,17 +95,17 @@ public section
  
  universe uA uB uD uC uX uX' uY uZ
  
@@ -205,7 +216,7 @@ index ff11455..9d14602 100644
  
  end SlicePFunctor
 diff --git a/vendor/geb-mathlib/Geb/Mathlib/Data/PFunctor/Slice/W.lean b/vendor/geb-mathlib/Geb/Mathlib/Data/PFunctor/Slice/W.lean
-index afbc314..533b3ed 100644
+index 6458274..b126356 100644
 --- a/vendor/geb-mathlib/Geb/Mathlib/Data/PFunctor/Slice/W.lean
 +++ b/vendor/geb-mathlib/Geb/Mathlib/Data/PFunctor/Slice/W.lean
 @@ -3,6 +3,7 @@ Copyright (c) 2026 The geb-mathlib contributors. All rights reserved.
@@ -221,9 +232,9 @@ index afbc314..533b3ed 100644
    WType.rec (motive := fun w ↦ (elimData F Y p g hg w).valid ↔ F.WValid w)
      (fun a f ih ↦ by
 +      beta_reduce
-       rw [F.wValid_mk, elimData_valid_mk]
-       exact and_congr (forall_congr' ih) (by simp only [OverInput, elimData_index]; rfl))
-     w
+       rw [F.wValid_mk a f, elimData_valid_mk F Y p g hg a f]
+       exact and_congr (forall_congr' ih)
+         (iff_of_eq (congrArg (F.OverInput a)
 diff --git a/vendor/geb-mathlib/Geb.lean b/vendor/geb-mathlib/Geb.lean
 index 5d37c79..9b07ec4 100644
 --- a/vendor/geb-mathlib/Geb.lean

--- a/geb-lean/vendor/geb-mathlib/Geb/Mathlib/CategoryTheory/Grothendieck.lean
+++ b/geb-lean/vendor/geb-mathlib/Geb/Mathlib/CategoryTheory/Grothendieck.lean
@@ -42,7 +42,10 @@ is the covariant Grothendieck construction. This module adds:
 `GrothendieckOp` and `CoGrothendieck` are semireducible `def` type
 synonyms, not `abbrev`s and not new structures: instance synthesis and
 object-level dot notation stop at the new names, while all round-trip
-lemmas hold by `rfl`. Morphism-level dot notation resolves through
+lemmas hold by `rfl`. Both are `@[implicit_reducible]`: type-level
+unification compares types at implicit transparency, so the attribute
+lets keyed `rw`/`simp` matching cross the synonym while instance
+synthesis and dot notation still stop at it. Morphism-level dot notation resolves through
 `Quiver.Hom` to `Grothendieck.Hom`'s own projections (whose op-side
 types make direction misuse a type error); the wrapper accessors
 `homBase`/`homFiber` are therefore free functions, used qualified or
@@ -83,7 +86,7 @@ universe u v u₂ v₂
 
 namespace CategoryTheory
 
-open Functor
+open CategoryTheory.Functor
 
 variable {C : Type u} [Category.{v} C]
 
@@ -117,6 +120,7 @@ end Grothendieck
 oppositization of `F`: objects are pairs of a base object `c : C` and a
 fiber object of `F.obj c`, and morphisms reverse the fiber direction
 relative to `Grothendieck F`. -/
+@[implicit_reducible]
 def GrothendieckOp (F : C ⥤ Cat.{v₂, u₂}) : Type (max u u₂) :=
   Grothendieck (F ⋙ Cat.opFunctor)
 
@@ -350,6 +354,7 @@ the opposite category of `GrothendieckOp G`. Objects are pairs of
 `c : C` and an object of `G.obj (op c)`; a morphism `X ⟶ Y` consists of
 `β : X.base ⟶ Y.base` in `C` and a fiber morphism
 `X.fiber ⟶ (G.map β.op).toFunctor.obj Y.fiber`. -/
+@[implicit_reducible]
 def CoGrothendieck (G : Cᵒᵖ ⥤ Cat.{v₂, u₂}) : Type (max u u₂) :=
   (GrothendieckOp G)ᵒᵖ
 

--- a/geb-lean/vendor/geb-mathlib/Geb/Mathlib/Data/PFunctor/Presheaf/W.lean
+++ b/geb-lean/vendor/geb-mathlib/Geb/Mathlib/Data/PFunctor/Presheaf/W.lean
@@ -251,7 +251,8 @@ theorem wRestrTree_id {I : Type uI} [Category.{vI} I]
   cases tree with
   | mk a fchild =>
     simp only [wRestrTree]
-    rw [F.objRestrElt_id, SlicePFunctor.W.mk_dest]
+    rw [F.objRestrElt_id]
+    exact SlicePFunctor.W.mk_dest _
 
 /-- Restriction along a composite factors: `dest_mk` exposes the inner
 restriction and `objRestrElt_comp` splits the rebuilt root. -/
@@ -294,6 +295,16 @@ private theorem cast_down {I : Type uI} [Category.{vI} I]
     (u : (F.W).obj ⟨k⟩) :
     (cast (congrArg (fun k : I ↦ (F.W).obj ⟨k⟩) e) u).down.1 = u.down.1 := by
   cases e
+  rfl
+
+/-- `wRestrTree` respects equality of the restricted trees; the head-index
+witnesses are proof-irrelevant. -/
+private theorem wRestrTree_congr {I : Type uI} [Category.{vI} I]
+    (F : PresheafPFunctor.{uI, uI, uA, uB, vI, vI} I I) ⦃j j' : I⦄ (g : j' ⟶ j)
+    {z z' : F.toSlicePFunctor.W} (hz : z = z')
+    (hq : F.q (PFunctor.W.head z.1) = j) (hq' : F.q (PFunctor.W.head z'.1) = j) :
+    F.wRestrTree g z hq = F.wRestrTree g z' hq' := by
+  cases hz
   rfl
 
 /-- Two carrier fibre elements with equal underlying trees are equal. -/
@@ -413,7 +424,7 @@ theorem isHereditarilyNatural_mk_forgetNode {I : Type uI} [Category.{vI} I]
   · intro hnat
     refine ⟨fun i i' g b ↦ ?_, fun b ↦ (n.1.2 b).2.down.2.2⟩
     have h := congrArg (fun u ↦ u.down.1) (hnat g b)
-    simp only [value_down, map_down] at h
+    simp only [value_down F n, map_down F g] at h
     exact h
 
 /-- The fixed-point constructor of the presheaf W-type: the `objPresheaf`-value
@@ -619,8 +630,8 @@ theorem value_wRestrTree {I : Type uI} [Category.{vI} I]
         Y.map f.op (α.app ⟨F.q a⟩ (⟨⟨pnodeSlice (fun b ↦ pelimData F Y α (fchild b)) hv hn.1,
             hn.2 hn.1⟩, rfl⟩ : (F.objPresheaf Y).obj ⟨F.q a⟩)) =
           α.app ⟨i'⟩ ((F.objPresheaf Y).map f.op
-            ⟨⟨pnodeSlice (fun b ↦ pelimData F Y α (fchild b)) hv hn.1, hn.2 hn.1⟩, rfl⟩) := by
-      exact (FunctorToTypes.naturality _ _ α f.op _).symm
+            ⟨⟨pnodeSlice (fun b ↦ pelimData F Y α (fchild b)) hv hn.1, hn.2 hn.1⟩, rfl⟩) :=
+      (FunctorToTypes.naturality _ _ α f.op _).symm
     change (α.app ⟨F.q (F.shapeRestr f ⟨a, hqi⟩).1⟩
           (⟨⟨F.objRestrElt f (pnodeSlice (fun b ↦ pelimData F Y α (fchild b)) hv hn.1) hqi,
             hn'.2 hn'.1⟩, rfl⟩ : (F.objPresheaf Y).obj ⟨F.q (F.shapeRestr f ⟨a, hqi⟩).1⟩)) ≍

--- a/geb-lean/vendor/geb-mathlib/Geb/Mathlib/Data/PFunctor/Slice/Basic.lean
+++ b/geb-lean/vendor/geb-mathlib/Geb/Mathlib/Data/PFunctor/Slice/Basic.lean
@@ -72,7 +72,12 @@ reuses these — its carrier is `SliceDomPFunctor.Obj` and its `map` the
 namespaces' `map`,
 `SliceDomPFunctor.ofCurried` / `rCurried` / `DirectionOver` / `Direction`,
 and `SlicePFunctor.ShapeOver` / `Shape` are `@[expose]` so the
-wrapper and tests can unfold them across the module boundary.
+wrapper and tests can unfold them across the module boundary. The fibre
+formers `DirectionOver` / `Direction` / `ShapeOver` / `Shape` are
+additionally `@[implicit_reducible]`: they occur inside dependent types,
+and type-level unification compares types at implicit transparency, so
+without the attribute keyed matching fails on terms whose types differ
+only by unfolding them.
 
 ## References
 
@@ -137,13 +142,13 @@ direction-input map. -/
 
 /-- The direction-input-map condition on a direction of shape `a`: that its
 image under `rCurried a` is `i`. Point-free as `(· = i) ∘ rCurried a`. -/
-@[expose] def DirectionOver {dom : Type uD} (F : SliceDomPFunctor.{uA, uB} dom)
+@[expose, implicit_reducible] def DirectionOver {dom : Type uD} (F : SliceDomPFunctor.{uA, uB} dom)
     (a : F.A) (i : dom) : F.B a → Prop :=
   (· = i) ∘ F.rCurried a
 
 /-- The directions of shape `a` lying over the base point `i`: the fibre
 of `rCurried a` over `i`. -/
-@[expose] def Direction {dom : Type uD} (F : SliceDomPFunctor.{uA, uB} dom)
+@[expose, implicit_reducible] def Direction {dom : Type uD} (F : SliceDomPFunctor.{uA, uB} dom)
     (a : F.A) (i : dom) : Type uB :=
   Subtype (F.DirectionOver a i)
 
@@ -225,12 +230,12 @@ theorem map_comp {dom : Type uD} {cod : Type uC} (F : SlicePFunctor.{uA, uB, uD,
 
 /-- The shape-output-map condition on a shape: that its image under `q`
 is `j`. Point-free as `(· = j) ∘ q`. -/
-@[expose] def ShapeOver {dom : Type uD} {cod : Type uC}
+@[expose, implicit_reducible] def ShapeOver {dom : Type uD} {cod : Type uC}
     (F : SlicePFunctor.{uA, uB, uD, uC} dom cod) (j : cod) : F.A → Prop :=
   (· = j) ∘ F.q
 
 /-- The shapes lying over `j`: the fibre of `q` over `j`. -/
-@[expose] def Shape {dom : Type uD} {cod : Type uC}
+@[expose, implicit_reducible] def Shape {dom : Type uD} {cod : Type uC}
     (F : SlicePFunctor.{uA, uB, uD, uC} dom cod) (j : cod) : Type uA :=
   Subtype (F.ShapeOver j)
 

--- a/geb-lean/vendor/geb-mathlib/Geb/Mathlib/Data/PFunctor/Slice/W.lean
+++ b/geb-lean/vendor/geb-mathlib/Geb/Mathlib/Data/PFunctor/Slice/W.lean
@@ -332,8 +332,10 @@ theorem elimData_valid {I : Type uI} (F : SlicePFunctor.{uA, uB, uI, uI} I I)
   WType.rec (motive := fun w ↦ (elimData F Y p g hg w).valid ↔ F.WValid w)
     (fun a f ih ↦ by
       beta_reduce
-      rw [F.wValid_mk, elimData_valid_mk]
-      exact and_congr (forall_congr' ih) (by simp only [OverInput, elimData_index]; rfl))
+      rw [F.wValid_mk a f, elimData_valid_mk F Y p g hg a f]
+      exact and_congr (forall_congr' ih)
+        (iff_of_eq (congrArg (F.OverInput a)
+          (funext fun b ↦ elimData_index F Y p g hg (f b)))))
     w
 
 /-- The eliminator of the slice W-type: the morphism into any slice algebra

--- a/geb-lean/vendor/geb-mathlib/PROVENANCE.md
+++ b/geb-lean/vendor/geb-mathlib/PROVENANCE.md
@@ -1,6 +1,6 @@
 # Vendored geb-mathlib provenance
 
 - Source: https://github.com/rokopt/geb-mathlib.git
-- Source commit: 0d5438156f18318af9b1618b14f228ccb698788b
-- Back-port patch: scripts/geb-mathlib-backport.patch (sha256 cb9067bac9668539fbba9860664888d4e018e5e495b8e11453e35d3242f12ad5)
+- Source commit: 4cb1cdfad07dbbdbf228795683b38fd59c99b4bf
+- Back-port patch: scripts/geb-mathlib-backport.patch (sha256 5f020147d40eaac770446e8404fd53cfdca403a7cc5efa4bae80d97bdf91935f)
 - The files under `Geb/` are an unmodified mirror of the source commit except where the back-port patch changes them; modified files carry a change notice in their header comment.


### PR DESCRIPTION
Adapt to vendored geb-mathlib's adaptations to Lean's mathlib's v4.33.0-rc1.