### PR TITLE
fix(geb-mathlib): regenerate back-port patch onto 6615f65

### DIFF
--- a/geb-lean/scripts/geb-mathlib-backport.patch
+++ b/geb-lean/scripts/geb-mathlib-backport.patch
@@ -1,16 +1,16 @@
 diff --git a/vendor/geb-mathlib/Geb/Mathlib/Data/PFunctor/Presheaf/Basic.lean b/vendor/geb-mathlib/Geb/Mathlib/Data/PFunctor/Presheaf/Basic.lean
-index 429483f..8754442 100644
+index 004265e..fc173cb 100644
 --- a/vendor/geb-mathlib/Geb/Mathlib/Data/PFunctor/Presheaf/Basic.lean
 +++ b/vendor/geb-mathlib/Geb/Mathlib/Data/PFunctor/Presheaf/Basic.lean
-@@ -3,6 +3,7 @@ Copyright (c) 2026 The geb-mathlib contributors. All rights reserved.
+@@ -3,6 +3,7 @@ Copyright (c) 2026 Terence Rokop. All rights reserved.
  Released under Apache 2.0 license as described in the file LICENSE.
- Authors: The geb-mathlib contributors
+ Authors: Terence Rokop
  -/
 +-- Modified from geb-mathlib by scripts/geb-mathlib-backport.patch.
  module
  
  public import Geb.Mathlib.Data.PFunctor.Slice.Basic
-@@ -97,7 +98,7 @@ later diamond via `PresheafDomPFunctorData` and `SlicePFunctor`); pinned
+@@ -101,7 +102,7 @@ later diamond via `PresheafDomPFunctorData` and `SlicePFunctor`); pinned
  references to it elsewhere take the synthesized order
  `PresheafDomPFunctorData.{uI, uA, uB, vI}`.
  
@@ -19,7 +19,7 @@ index 429483f..8754442 100644
  the inherited `PFunctor` universes `uA`/`uB`: they are
  the two `Type` universes of the `PFunctor` parent and appear only together in
  the result `max`, so the linter flags them as a pair that could be unified. The
-@@ -139,10 +140,10 @@ open CategoryTheory
+@@ -143,10 +144,10 @@ open CategoryTheory
  
  universe uI uJ uA uB uZ u v vI vJ uX
  
@@ -31,7 +31,7 @@ index 429483f..8754442 100644
  structure PresheafDomPFunctorData (I : Type uI) [Category.{vI} I] :
      Type (max (uA + 1) (uB + 1) uI vI)
      extends SliceDomPFunctor.{uA, uB} I where
-@@ -247,8 +248,7 @@ private theorem value_map {I : Type uI} [Category.{vI} I]
+@@ -251,8 +252,7 @@ private theorem value_map {I : Type uI} [Category.{vI} I]
      intro i i' f b
      simp only [value_map]
      refine (congrArg (fun w ↦ α.app ⟨i'⟩ w) (x.2 f b)).trans ?_
@@ -41,7 +41,7 @@ index 429483f..8754442 100644
  
  /-- Functoriality in the input presheaf: the identity transformation acts as
  the identity. -/
-@@ -277,10 +277,10 @@ theorem map_comp {I : Type uI} [Category.{vI} I] (F : PresheafDomPFunctorData.{u
+@@ -281,10 +281,10 @@ theorem map_comp {I : Type uI} [Category.{vI} I] (F : PresheafDomPFunctorData.{u
  
  end PresheafDomPFunctorData
  
@@ -53,7 +53,7 @@ index 429483f..8754442 100644
  structure PresheafDomPFunctor (I : Type uI) [Category.{vI} I] :
      Type (max (uA + 1) (uB + 1) uI vI)
      extends PresheafDomPFunctorData.{uI, uA, uB, vI} I where
-@@ -289,10 +289,10 @@ structure PresheafDomPFunctor (I : Type uI) [Category.{vI} I] :
+@@ -293,10 +293,10 @@ structure PresheafDomPFunctor (I : Type uI) [Category.{vI} I] :
  
  attribute [ext] PresheafDomPFunctorData PresheafDomPFunctor
  
@@ -65,7 +65,7 @@ index 429483f..8754442 100644
  structure PresheafPFunctorData (I : Type uI) [Category.{vI} I]
      (J : Type uJ) [Category.{vJ} J] : Type (max (uA + 1) (uB + 1) uI uJ vI vJ)
      extends PresheafDomPFunctorData.{uI, uA, uB, vI} I, SlicePFunctor.{uA, uB, uI, uJ} I J where
-@@ -382,9 +382,9 @@ structure IsFunctorial {I : Type uI} [Category.{vI} I] {J : Type uJ} [Category.{
+@@ -386,9 +386,9 @@ structure IsFunctorial {I : Type uI} [Category.{vI} I] {J : Type uJ} [Category.{
  
  end PresheafPFunctorData
  
@@ -77,17 +77,17 @@ index 429483f..8754442 100644
      (J : Type uJ) [Category.{vJ} J] : Type (max (uA + 1) (uB + 1) uI uJ vI vJ)
      extends PresheafPFunctorData.{uI, uJ, uA, uB, vI, vJ} I J where
 diff --git a/vendor/geb-mathlib/Geb/Mathlib/Data/PFunctor/Presheaf/W.lean b/vendor/geb-mathlib/Geb/Mathlib/Data/PFunctor/Presheaf/W.lean
-index 8a4bc84..0539afe 100644
+index 415d9f8..aea4009 100644
 --- a/vendor/geb-mathlib/Geb/Mathlib/Data/PFunctor/Presheaf/W.lean
 +++ b/vendor/geb-mathlib/Geb/Mathlib/Data/PFunctor/Presheaf/W.lean
-@@ -3,6 +3,7 @@ Copyright (c) 2026 The geb-mathlib contributors. All rights reserved.
+@@ -3,6 +3,7 @@ Copyright (c) 2026 Terence Rokop. All rights reserved.
  Released under Apache 2.0 license as described in the file LICENSE.
- Authors: The geb-mathlib contributors
+ Authors: Terence Rokop
  -/
 +-- Modified from geb-mathlib by scripts/geb-mathlib-backport.patch.
  module
  
- public import Geb.Mathlib.Data.PFunctor.Slice.W
+ public import Geb.Mathlib.Data.PFunctor.Presheaf.Basic
 @@ -424,7 +425,7 @@ theorem isHereditarilyNatural_mk_forgetNode {I : Type uI} [Category.{vI} I]
      refine ⟨fun i i' g b ↦ ?_, fun b ↦ (n.1.2 b).2.down.2.2⟩
      have h := congrArg (fun u ↦ u.down.1) (hnat g b)
@@ -96,25 +96,25 @@ index 8a4bc84..0539afe 100644
 +    exact h
  
  /-- The fixed-point constructor of the presheaf W-type: the `objPresheaf`-value
- at the carrier presheaf `F.W` maps into `F.W`, fibrewise over `I`. It builds the
+ at the carrier presheaf `F.W` maps into `F.W`, fiberwise over `I`. It builds the
 @@ -630,9 +631,7 @@ theorem value_wRestrTree {I : Type uI} [Category.{vI} I]
              hn.2 hn.1⟩, rfl⟩ : (F.objPresheaf Y).obj ⟨F.q a⟩)) =
            α.app ⟨i'⟩ ((F.objPresheaf Y).map f.op
-             ⟨⟨pnodeSlice (fun b ↦ pelimData F Y α (fchild b)) hv hn.1, hn.2 hn.1⟩, rfl⟩) :=
+             ⟨⟨pNodeSlice (fun b ↦ pElimData F Y α (fchild b)) hv hn.1, hn.2 hn.1⟩, rfl⟩) :=
 -      (ConcreteCategory.comp_apply _ _ _).symm.trans
 -        ((ConcreteCategory.congr_hom (α.naturality f.op).symm _).trans
 -          (ConcreteCategory.comp_apply _ _ _))
 +      (FunctorToTypes.naturality _ _ α f.op _).symm
      change (α.app ⟨F.q (F.shapeRestr f ⟨a, hqi⟩).1⟩
-           (⟨⟨F.objRestrElt f (pnodeSlice (fun b ↦ pelimData F Y α (fchild b)) hv hn.1) hqi,
+           (⟨⟨F.objRestrElt f (pNodeSlice (fun b ↦ pElimData F Y α (fchild b)) hv hn.1) hqi,
              hn'.2 hn'.1⟩, rfl⟩ : (F.objPresheaf Y).obj ⟨F.q (F.shapeRestr f ⟨a, hqi⟩).1⟩)) ≍
 diff --git a/vendor/geb-mathlib/Geb/Mathlib/Data/PFunctor/Slice/Basic.lean b/vendor/geb-mathlib/Geb/Mathlib/Data/PFunctor/Slice/Basic.lean
-index 2b85da3..0445d60 100644
+index b1a1552..6f3e66e 100644
 --- a/vendor/geb-mathlib/Geb/Mathlib/Data/PFunctor/Slice/Basic.lean
 +++ b/vendor/geb-mathlib/Geb/Mathlib/Data/PFunctor/Slice/Basic.lean
-@@ -3,6 +3,7 @@ Copyright (c) 2026 The geb-mathlib contributors. All rights reserved.
+@@ -3,6 +3,7 @@ Copyright (c) 2026 Terence Rokop. All rights reserved.
  Released under Apache 2.0 license as described in the file LICENSE.
- Authors: The geb-mathlib contributors
+ Authors: Terence Rokop
  -/
 +-- Modified from geb-mathlib by scripts/geb-mathlib-backport.patch.
  module
@@ -141,12 +141,12 @@ index 2b85da3..0445d60 100644
      extends SliceDomPFunctor.{uA, uB, uD} dom where
    /-- The shape-output map: each shape is assigned a `cod`-index. -/
 diff --git a/vendor/geb-mathlib/Geb/Mathlib/Data/PFunctor/Slice/Functor.lean b/vendor/geb-mathlib/Geb/Mathlib/Data/PFunctor/Slice/Functor.lean
-index ff11455..9d14602 100644
+index 2862e7d..9b3104d 100644
 --- a/vendor/geb-mathlib/Geb/Mathlib/Data/PFunctor/Slice/Functor.lean
 +++ b/vendor/geb-mathlib/Geb/Mathlib/Data/PFunctor/Slice/Functor.lean
-@@ -3,6 +3,7 @@ Copyright (c) 2026 The geb-mathlib contributors. All rights reserved.
+@@ -3,6 +3,7 @@ Copyright (c) 2026 Terence Rokop. All rights reserved.
  Released under Apache 2.0 license as described in the file LICENSE.
- Authors: The geb-mathlib contributors
+ Authors: Terence Rokop
  -/
 +-- Modified from geb-mathlib by scripts/geb-mathlib-backport.patch.
  module
@@ -216,12 +216,12 @@ index ff11455..9d14602 100644
  
  end SlicePFunctor
 diff --git a/vendor/geb-mathlib/Geb/Mathlib/Data/PFunctor/Slice/W.lean b/vendor/geb-mathlib/Geb/Mathlib/Data/PFunctor/Slice/W.lean
-index 6458274..b126356 100644
+index 2f62943..568cbe6 100644
 --- a/vendor/geb-mathlib/Geb/Mathlib/Data/PFunctor/Slice/W.lean
 +++ b/vendor/geb-mathlib/Geb/Mathlib/Data/PFunctor/Slice/W.lean
-@@ -3,6 +3,7 @@ Copyright (c) 2026 The geb-mathlib contributors. All rights reserved.
+@@ -3,6 +3,7 @@ Copyright (c) 2026 Terence Rokop. All rights reserved.
  Released under Apache 2.0 license as described in the file LICENSE.
- Authors: The geb-mathlib contributors
+ Authors: Terence Rokop
  -/
 +-- Modified from geb-mathlib by scripts/geb-mathlib-backport.patch.
  module
@@ -236,20 +236,22 @@ index 6458274..b126356 100644
        exact and_congr (forall_congr' ih)
          (iff_of_eq (congrArg (F.OverInput a)
 diff --git a/vendor/geb-mathlib/Geb.lean b/vendor/geb-mathlib/Geb.lean
-index 5d37c79..9b07ec4 100644
+index ce78258..2e3e12d 100644
 --- a/vendor/geb-mathlib/Geb.lean
 +++ b/vendor/geb-mathlib/Geb.lean
-@@ -3,12 +3,12 @@ Copyright (c) 2026 The geb-mathlib contributors. All rights reserved.
+@@ -3,14 +3,13 @@ Copyright (c) 2026 Terence Rokop. All rights reserved.
  Released under Apache 2.0 license as described in the file LICENSE.
- Authors: The geb-mathlib contributors
+ Authors: Terence Rokop
  -/
 +-- Modified from geb-mathlib by scripts/geb-mathlib-backport.patch.
  module -- shake: keep-all, shake: keep-downstream
  
- public import Geb.Mathlib
  public import Geb.Cslib
  public import Geb.Internal
--import GebMeta
+ public import Geb.Mathlib
  
+-import GebMeta
+-
  /-!
  # Geb root module
+ 

--- a/geb-lean/vendor/geb-mathlib/Geb.lean
+++ b/geb-lean/vendor/geb-mathlib/Geb.lean
@@ -1,14 +1,14 @@
 /-
-Copyright (c) 2026 The geb-mathlib contributors. All rights reserved.
+Copyright (c) 2026 Terence Rokop. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: The geb-mathlib contributors
+Authors: Terence Rokop
 -/
 -- Modified from geb-mathlib by scripts/geb-mathlib-backport.patch.
 module -- shake: keep-all, shake: keep-downstream
 
-public import Geb.Mathlib
 public import Geb.Cslib
 public import Geb.Internal
+public import Geb.Mathlib
 
 /-!
 # Geb root module

--- a/geb-lean/vendor/geb-mathlib/Geb/Cslib.lean
+++ b/geb-lean/vendor/geb-mathlib/Geb/Cslib.lean
@@ -1,7 +1,7 @@
 /-
-Copyright (c) 2026 The geb-mathlib contributors. All rights reserved.
+Copyright (c) 2026 Terence Rokop. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: The geb-mathlib contributors
+Authors: Terence Rokop
 -/
 module
 

--- a/geb-lean/vendor/geb-mathlib/Geb/Internal.lean
+++ b/geb-lean/vendor/geb-mathlib/Geb/Internal.lean
@@ -1,7 +1,7 @@
 /-
-Copyright (c) 2026 The geb-mathlib contributors. All rights reserved.
+Copyright (c) 2026 Terence Rokop. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: The geb-mathlib contributors
+Authors: Terence Rokop
 -/
 module
 

--- a/geb-lean/vendor/geb-mathlib/Geb/Mathlib.lean
+++ b/geb-lean/vendor/geb-mathlib/Geb/Mathlib.lean
@@ -1,12 +1,12 @@
 /-
-Copyright (c) 2026 The geb-mathlib contributors. All rights reserved.
+Copyright (c) 2026 Terence Rokop. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: The geb-mathlib contributors
+Authors: Terence Rokop
 -/
 module
 
-public import Geb.Mathlib.Data
 public import Geb.Mathlib.CategoryTheory
+public import Geb.Mathlib.Data
 public import Geb.Mathlib.Logic
 
 /-!

--- a/geb-lean/vendor/geb-mathlib/Geb/Mathlib/CategoryTheory.lean
+++ b/geb-lean/vendor/geb-mathlib/Geb/Mathlib/CategoryTheory.lean
@@ -1,7 +1,7 @@
 /-
-Copyright (c) 2026 The geb-mathlib contributors. All rights reserved.
+Copyright (c) 2026 Terence Rokop. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: The geb-mathlib contributors
+Authors: Terence Rokop
 -/
 module
 

--- a/geb-lean/vendor/geb-mathlib/Geb/Mathlib/CategoryTheory/FreeCoprodCompDisc.lean
+++ b/geb-lean/vendor/geb-mathlib/Geb/Mathlib/CategoryTheory/FreeCoprodCompDisc.lean
@@ -1,7 +1,7 @@
 /-
-Copyright (c) 2026 The geb-mathlib contributors. All rights reserved.
+Copyright (c) 2026 Terence Rokop. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: The geb-mathlib contributors
+Authors: Terence Rokop
 -/
 module
 
@@ -26,7 +26,7 @@ coproducts, and the coproducts' functorial action, constructively.
   transport `FreeCoprodCompDisc.homOfEq`.
 * `FreeCoprodCompDisc.Endo`, `FreeCoprodCompDisc.EndoMor` — the
   object-map and morphism-map components of endofunctors.
-* `FreeCoprodCompDisc.copr`, `FreeCoprodCompDisc.coprMor` — the
+* `FreeCoprodCompDisc.coprod`, `FreeCoprodCompDisc.coprodMor` — the
   indexed coproducts and their functorial action.
 
 ## Implementation notes
@@ -90,18 +90,18 @@ def EndoMor (F : Endo D) : Type (max (u + 1) v) :=
 treated as a discrete category. The result lives in the completion at
 index universe `max u uI`, which is the original completion — making
 the result an in-category coproduct — exactly when `uI ≤ u`. -/
-def copr.{uI} (I : Type uI) (fi : I → FreeCoprodCompDisc.{u, v} D) :
+def coprod.{uI} (I : Type uI) (fi : I → FreeCoprodCompDisc.{u, v} D) :
     FreeCoprodCompDisc.{max u uI} D :=
   ⟨(Σ i : I, (fi i).1), Sigma.uncurry (fun i ↦ (fi i).2)⟩
 
-/-- The functorial action of `FreeCoprodCompDisc.copr` on morphisms: a
-reindexing function together with a componentwise family of morphisms
-induces a morphism of indexed coproducts. -/
-def coprMor.{uI} (I J : Type uI) (r : I → J)
+/-- The functorial action of `FreeCoprodCompDisc.coprod` on morphisms:
+a reindexing function together with a componentwise family of
+morphisms induces a morphism of indexed coproducts. -/
+def coprodMor.{uI} (I J : Type uI) (r : I → J)
     (fi : I → FreeCoprodCompDisc.{u, v} D)
     (gj : J → FreeCoprodCompDisc.{u, v} D)
     (hom : (i : I) → Hom D (fi i) (gj (r i))) :
-    Hom D (copr D I fi) (copr D J gj) :=
+    Hom D (coprod D I fi) (coprod D J gj) :=
   ⟨Sigma.map r (fun i ↦ (hom i).1),
     funext (fun p ↦ congrFun (hom p.1).2 p.2)⟩
 

--- a/geb-lean/vendor/geb-mathlib/Geb/Mathlib/CategoryTheory/Grothendieck.lean
+++ b/geb-lean/vendor/geb-mathlib/Geb/Mathlib/CategoryTheory/Grothendieck.lean
@@ -1,13 +1,13 @@
 /-
-Copyright (c) 2026 The geb-mathlib contributors. All rights reserved.
+Copyright (c) 2026 Terence Rokop. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: The geb-mathlib contributors
+Authors: Terence Rokop
 -/
 module
 
-public import Mathlib.CategoryTheory.Grothendieck
 public import Mathlib.CategoryTheory.Category.Cat.Op
 public import Mathlib.CategoryTheory.Comma.Over.Basic
+public import Mathlib.CategoryTheory.Grothendieck
 public import Mathlib.CategoryTheory.Whiskering
 public import Mathlib.Tactic.Attr.Core
 
@@ -90,7 +90,7 @@ open CategoryTheory.Functor
 
 variable {C : Type u} [Category.{v} C]
 
-/-! ## Covariant construction: `Cat`-valued packaging -/
+/-! ### Covariant construction: `Cat`-valued packaging -/
 
 namespace Grothendieck
 
@@ -114,7 +114,7 @@ theorem functorToCat_map {E : Cat.{v, u}} {F F' : ↑E ⥤ Cat.{v, u}}
 
 end Grothendieck
 
-/-! ## The Grothendieck construction of an oppositized functor -/
+/-! ### The Grothendieck construction of an oppositized functor -/
 
 /-- The covariant Grothendieck construction applied to the
 oppositization of `F`: objects are pairs of a base object `c : C` and a
@@ -347,7 +347,7 @@ theorem functorToCat_obj {E : Cat.{v, u}} (F : ↑E ⥤ Cat.{v, u}) :
 
 end GrothendieckOp
 
-/-! ## The contravariant Grothendieck construction -/
+/-! ### The contravariant Grothendieck construction -/
 
 /-- The contravariant Grothendieck construction of `G : Cᵒᵖ ⥤ Cat`:
 the opposite category of `GrothendieckOp G`. Objects are pairs of

--- a/geb-lean/vendor/geb-mathlib/Geb/Mathlib/Data.lean
+++ b/geb-lean/vendor/geb-mathlib/Geb/Mathlib/Data.lean
@@ -1,7 +1,7 @@
 /-
-Copyright (c) 2026 The geb-mathlib contributors. All rights reserved.
+Copyright (c) 2026 Terence Rokop. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: The geb-mathlib contributors
+Authors: Terence Rokop
 -/
 module
 

--- a/geb-lean/vendor/geb-mathlib/Geb/Mathlib/Data/PFunctor.lean
+++ b/geb-lean/vendor/geb-mathlib/Geb/Mathlib/Data/PFunctor.lean
@@ -1,13 +1,13 @@
 /-
-Copyright (c) 2026 The geb-mathlib contributors. All rights reserved.
+Copyright (c) 2026 Terence Rokop. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: The geb-mathlib contributors
+Authors: Terence Rokop
 -/
 module
 
-public import Geb.Mathlib.Data.PFunctor.Slice
-public import Geb.Mathlib.Data.PFunctor.Presheaf
 public import Geb.Mathlib.Data.PFunctor.IndRec
+public import Geb.Mathlib.Data.PFunctor.Presheaf
+public import Geb.Mathlib.Data.PFunctor.Slice
 
 /-!
 # PFunctor — index

--- a/geb-lean/vendor/geb-mathlib/Geb/Mathlib/Data/PFunctor/IndRec.lean
+++ b/geb-lean/vendor/geb-mathlib/Geb/Mathlib/Data/PFunctor/IndRec.lean
@@ -1,7 +1,7 @@
 /-
-Copyright (c) 2026 The geb-mathlib contributors. All rights reserved.
+Copyright (c) 2026 Terence Rokop. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: The geb-mathlib contributors
+Authors: Terence Rokop
 -/
 module
 

--- a/geb-lean/vendor/geb-mathlib/Geb/Mathlib/Data/PFunctor/IndRec/Basic.lean
+++ b/geb-lean/vendor/geb-mathlib/Geb/Mathlib/Data/PFunctor/IndRec/Basic.lean
@@ -1,7 +1,7 @@
 /-
-Copyright (c) 2026 The geb-mathlib contributors. All rights reserved.
+Copyright (c) 2026 Terence Rokop. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: The geb-mathlib contributors
+Authors: Terence Rokop
 -/
 module
 
@@ -29,7 +29,7 @@ of [DybjerSetzer2003].
 ## Main definitions
 
 * `IR.pFunctor` — the polynomial functor whose W-type defines codes:
-  shapes `IR.Shape`, directions `IR.Dir`.
+  shapes `IR.Shape`, directions `IR.Direction`.
 * `IR.Dest`, `IR.Dest.elim`, `IR.Dest.elimInv`, `IR.destEquiv` — the
   pattern-matched destructor for morphisms out of `IR.Obj`, its
   conversions to and from such morphisms, and the equivalence they
@@ -43,7 +43,7 @@ of [DybjerSetzer2003].
   shape.
 * `IR.elim`, `IR.rec` — the eliminator and the dependent recursor,
   the latter with step arguments of type `IR.RecStep` (the `Type`
-  specialization, alongside `IR.IndStep` for `Prop`, of the
+  specialization, alongside `IR.InductionStep` for `Prop`, of the
   `Sort`-valued `IR.Step`).
 * `IR.interpObj`, `IR.interpMor` — the object map and morphism map of
   the interpretation of an `IR` code on `FreeCoprodCompDisc`.
@@ -55,6 +55,8 @@ of [DybjerSetzer2003].
 ## Main statements
 
 * `IR.ext`, `IR.snd_eq_of_eq` — extensionality for codes.
+* `IR.induction` — the induction principle, the recursor restricted to
+  `Prop`-valued motives.
 
 ## Implementation notes
 
@@ -105,30 +107,31 @@ def Shape : Type (max (uA + 1) uD) :=
 
 /-- The direction type of the polynomial functor whose W-type defines
 codes for positive inductive-recursive types. -/
-def Dir : Shape.{uA, uD} D → Type (max uA uD) :=
+def Direction : Shape.{uA, uD} D → Type (max uA uD) :=
   Sum.elim (fun _ ↦ PEmpty)
     (Sum.elim (fun A ↦ ULift.{uD} A) (fun A ↦ A → D))
 
-/-- Simplification for the constant (`iota`) case of `IR.Dir`. -/
+/-- Simplification for the constant (`iota`) case of `IR.Direction`. -/
 @[simp]
-theorem dir_iota (d : D) : Dir.{uA, uD} D (Sum.inl d) = PEmpty := rfl
+theorem direction_iota (d : D) : Direction.{uA, uD} D (Sum.inl d) = PEmpty := rfl
 
-/-- Simplification for the dependent sum (`sigma`) case of `IR.Dir`. -/
+/-- Simplification for the dependent sum (`sigma`) case of
+`IR.Direction`. -/
 @[simp]
-theorem dir_sigma (A : Type uA) : Dir D (Sum.inr (Sum.inl A)) = ULift A := rfl
+theorem direction_sigma (A : Type uA) : Direction D (Sum.inr (Sum.inl A)) = ULift A := rfl
 
 /-- Simplification for the dependent product (`delta`) case of
-`IR.Dir`. -/
+`IR.Direction`. -/
 @[simp]
-theorem dir_delta (A : Type uA) : Dir D (Sum.inr (Sum.inr A)) = (A → D) := rfl
+theorem direction_delta (A : Type uA) : Direction D (Sum.inr (Sum.inr A)) = (A → D) := rfl
 
 /-- Rewrite the direction type along a shape-type equality. -/
-def dirOfEq {s s' : Shape.{uA, uD} D} : s = s' → Dir D s → Dir D s'
+def directionOfEq {s s' : Shape.{uA, uD} D} : s = s' → Direction D s → Direction D s'
   | rfl => id
 
-/-- Elimination rule for `IR.Dir`. -/
-def dirElim.{v} (V : Type v) (σ : (A : Type uA) → A → V)
-    (δ : (A : Type uA) → (A → D) → V) (s : Shape D) (ds : Dir D s) : V :=
+/-- Elimination rule for `IR.Direction`. -/
+def directionElim.{v} (V : Type v) (σ : (A : Type uA) → A → V)
+    (δ : (A : Type uA) → (A → D) → V) (s : Shape D) (ds : Direction D s) : V :=
   match s with
   | Sum.inl _ => PEmpty.elim ds
   | Sum.inr (Sum.inl (A : Type uA)) => σ A (ULift.down ds)
@@ -137,7 +140,7 @@ def dirElim.{v} (V : Type v) (σ : (A : Type uA) → A → V)
 /-- The polynomial functor whose W-type defines codes for positive
 inductive-recursive types. -/
 def pFunctor : PFunctor.{max (uA + 1) uD, max uA uD} :=
-  ⟨Shape D, Dir D⟩
+  ⟨Shape D, Direction D⟩
 
 /-- The value at `V` of the interpretation of `IR.pFunctor` as an
 endofunctor on `Type`. -/
@@ -150,7 +153,7 @@ def ObjFst : Type (max (uA + 1) uD) :=
 
 /-- The second component of `IR.Obj`. -/
 def ObjSnd.{v} (V : Type v) : ObjFst D → Type (max uA uD v) :=
-  fun s ↦ Dir.{uA, uD} D s → V
+  fun s ↦ Direction.{uA, uD} D s → V
 
 /-- Rewrite the second component of `IR.Obj` along a shape-type
 equality. -/
@@ -180,7 +183,7 @@ def objDelta.{v} (V : Type v) (A : Type uA) (f : (A → D) → V) :
 `IR.objIota` element: direction assignments out of the empty direction
 type are all equal. -/
 theorem objIota_eq_mk.{v} (V : Type v) (d : D)
-    (ds : Dir.{uA, uD} D (Sum.inl d) → V) :
+    (ds : Direction.{uA, uD} D (Sum.inl d) → V) :
     objIota D V d = (⟨Sum.inl d, ds⟩ : Obj.{uA, uD, v} D V) :=
   congrArg (Sigma.mk (Sum.inl d)) (funext (fun x ↦ PEmpty.elim x))
 
@@ -320,7 +323,7 @@ def IR : Type (max (uA + 1) uD) :=
 namespace IR
 
 /-- The constructor for `IR`. -/
-def mk (s : Shape D) (d : Dir D s → IR D) : IR D :=
+def mk (s : Shape D) (d : Direction D s → IR D) : IR D :=
   WType.mk.{max (uA + 1) uD, max uA uD} s d
 
 /-- The constant (`iota`) code: no subcodes; its interpretation is the
@@ -342,19 +345,19 @@ def delta (A : Type uA) (c : (A → D) → IR.{uA, uD} D) : IR D :=
   mk D (Sum.inr (Sum.inr A)) c
 
 /-- Congruence for `IR.mk` in the direction assignment. -/
-theorem mk_congr (s : Shape D) {ds ds' : Dir D s → IR D} :
+theorem mk_congr (s : Shape D) {ds ds' : Direction D s → IR D} :
     ds = ds' → mk.{uA, uD} D s ds = mk.{uA, uD} D s ds'
   | rfl => rfl
 
 /-- The motive of the proof of `IR.ext`. -/
-def ExtMotive (s : Shape.{uA, uD} D) (d : Dir D s → IR D) (s' : Shape D)
+def ExtMotive (s : Shape.{uA, uD} D) (d : Direction D s → IR D) (s' : Shape D)
     (eq1 : s = s') : Prop :=
-  ∀ d' : Dir D s' → IR D, d = d' ∘ dirOfEq D eq1 → mk D s d = mk D s' d'
+  ∀ d' : Direction D s' → IR D, d = d' ∘ directionOfEq D eq1 → mk D s d = mk D s' d'
 
 /-- Extensionality for `IR` (equality is determined by equality of
 shapes and pointwise equality of directions). -/
 theorem ext {ir ir' : IR.{uA, uD} D} (eq1 : ir.1 = ir'.1)
-    (eq2 : ir.2 = ir'.2 ∘ dirOfEq D eq1) : ir = ir' :=
+    (eq2 : ir.2 = ir'.2 ∘ directionOfEq D eq1) : ir = ir' :=
   match ir, ir' with
   | ⟨s, d⟩, ⟨_, d'⟩ =>
       Eq.rec (motive := ExtMotive D s d) (fun _ ↦ mk_congr D s) eq1 d' eq2
@@ -363,7 +366,7 @@ theorem ext {ir ir' : IR.{uA, uD} D} (eq1 : ir.1 = ir'.1)
 pointwise equality of directions (transported along the shape equality
 induced by the first projection). -/
 theorem snd_eq_of_eq {ir ir' : IR.{uA, uD} D} :
-    (eq : ir = ir') → ir.2 = ir'.2 ∘ dirOfEq D (congrArg (fun t ↦ t.1) eq)
+    (eq : ir = ir') → ir.2 = ir'.2 ∘ directionOfEq D (congrArg (fun t ↦ t.1) eq)
   | rfl => rfl
 
 /-- The eliminator (the algebra morphism from the initial algebra) for
@@ -379,11 +382,11 @@ def elimAlg.{v} (V : Type v) (alg : Alg.{uA, uD, v} D V) : IR D → V :=
 `Sort`-valued motive: from a shape, a subcode assignment, and results
 for the subcodes, produce the result for the constructed code. The
 result sort (an `imax` expression) is left to inference; the
-specializations `IR.RecStep` and `IR.IndStep` carry the explicit
+specializations `IR.RecStep` and `IR.InductionStep` carry the explicit
 ascriptions. -/
 def Step.{v} (motive : IR.{uA, uD} D → Sort v) :=
-  (a : Shape D) → (f : Dir D a → IR D) →
-  ((d : Dir D a) → motive (f d)) → motive (mk D a f)
+  (a : Shape D) → (f : Direction D a → IR D) →
+  ((d : Direction D a) → motive (f d)) → motive (mk D a f)
 
 /-- The step argument type at a `Type`-valued motive (for `IR.rec`,
 `IR.sigmaRec`, and their companions). -/
@@ -391,18 +394,18 @@ def RecStep.{v} (motive : IR.{uA, uD} D → Type v) :
     Type (max (uA + 1) uD v) :=
   Step D motive
 
-/-- The step argument type at a `Prop`-valued motive (for `IR.ind`). -/
-def IndStep (motive : IR.{uA, uD} D → Prop) : Prop :=
+/-- The step argument type at a `Prop`-valued motive (for `IR.induction`). -/
+def InductionStep (motive : IR.{uA, uD} D → Prop) : Prop :=
   Step D motive
 
 /-- The induction principle — the recursor restricted to `Prop`-valued
 motives. (The compiler does not generate code for `WType.rec`
 applications, so `WType.rec` is used only here, where propositions
 need no code.) -/
-theorem ind (motive : IR D → Prop) :
-    IndStep.{uA, uD} D motive → ∀ t : IR D, motive t :=
+theorem induction (motive : IR D → Prop) :
+    InductionStep.{uA, uD} D motive → ∀ t : IR D, motive t :=
   WType.rec.{0, max (uA + 1) uD, max uA uD}
-    (α := Shape D) (β := Dir D) (motive := motive)
+    (α := Shape D) (β := Direction D) (motive := motive)
 
 /-- The `IR.pFunctor` algebra over a sigma type generated by a
 recursor step. -/
@@ -433,14 +436,14 @@ def sigmaRec.{v} (motive : IR D → Type v)
 the first projection. -/
 theorem sigmaRec_fst_step.{v} (motive : IR D → Type v)
     (mk' : RecStep.{uA, uD, v} D motive) :
-    IndStep.{uA, uD} D (fun t ↦ (sigmaRec D motive mk' t).1 = t) :=
+    InductionStep.{uA, uD} D (fun t ↦ (sigmaRec D motive mk' t).1 = t) :=
   fun _ _ ih ↦ ext D rfl (funext ih)
 
 /-- `IR.sigmaRec` is a section of the first projection. -/
 theorem sigmaRec_fst.{v} (motive : IR D → Type v)
     (mk' : RecStep.{uA, uD, v} D motive) :
     ∀ t : IR D, (sigmaRec D motive mk' t).1 = t :=
-  ind D (motive := fun t ↦ (sigmaRec D motive mk' t).1 = t)
+  induction D (motive := fun t ↦ (sigmaRec D motive mk' t).1 = t)
     (sigmaRec_fst_step D motive mk')
 
 /-- The shape component of `IR.sigmaRec` agrees with the shape
@@ -456,7 +459,7 @@ component of the argument, transported along `IR.sigmaRec_fst_fst`. -/
 theorem sigmaRec_fst_snd.{v} (motive : IR D → Type v)
     (mk' : RecStep.{uA, uD, v} D motive) (t : IR D) :
     (sigmaRec D motive mk' t).1.2 =
-      t.2 ∘ dirOfEq D (sigmaRec_fst_fst D motive mk' t) :=
+      t.2 ∘ directionOfEq D (sigmaRec_fst_fst D motive mk' t) :=
   snd_eq_of_eq D (sigmaRec_fst D motive mk' t)
 
 /-- The recursor — the dependent eliminator for `IR`. -/
@@ -480,7 +483,7 @@ of the interpretations `α` of the subcodes. -/
 def interpObjSigma (A : Type uA)
     (α : A → FreeCoprodCompDisc.Endo.{uA, uD} D) :
     FreeCoprodCompDisc.Endo.{uA, uD} D :=
-  fun X ↦ FreeCoprodCompDisc.copr.{uA, uD, uA} D A (fun a ↦ α a X)
+  fun X ↦ FreeCoprodCompDisc.coprod.{uA, uD, uA} D A (fun a ↦ α a X)
 
 /-- The dependent product (`delta`) case of the interpretation of an
 `IR` code on `FreeCoprodCompDisc`: at an object `X`, the indexed
@@ -490,7 +493,7 @@ def interpObjDelta (A : Type uA)
     (α : (A → D) → FreeCoprodCompDisc.Endo.{uA, uD} D) :
     FreeCoprodCompDisc.Endo.{uA, uD} D :=
   fun X ↦
-    FreeCoprodCompDisc.copr.{uA, uD, uA} D (A → X.1) (fun g ↦ α (X.2 ∘ g) X)
+    FreeCoprodCompDisc.coprod.{uA, uD, uA} D (A → X.1) (fun g ↦ α (X.2 ∘ g) X)
 
 /-- The algebra which computes one step of the interpretation of an
 `IR` code on `FreeCoprodCompDisc`. -/
@@ -521,7 +524,7 @@ def interpMorSigma (A : Type uA)
     (μ : (a : A) → FreeCoprodCompDisc.EndoMor D (α a)) :
     FreeCoprodCompDisc.EndoMor D (interpObjSigma D A α) :=
   fun X Y h ↦
-    FreeCoprodCompDisc.coprMor D A A id
+    FreeCoprodCompDisc.coprodMor D A A id
       (fun a ↦ α a X)
       (fun a ↦ α a Y)
       (fun a ↦ μ a X Y h)
@@ -535,7 +538,7 @@ def interpMorDelta (A : Type uA)
     (μ : (f : A → D) → FreeCoprodCompDisc.EndoMor D (α f)) :
     FreeCoprodCompDisc.EndoMor D (interpObjDelta D A α) :=
   fun X Y h ↦
-    FreeCoprodCompDisc.coprMor D (A → X.1) (A → Y.1) (fun g ↦ h.1 ∘ g)
+    FreeCoprodCompDisc.coprodMor D (A → X.1) (A → Y.1) (fun g ↦ h.1 ∘ g)
       (fun g ↦ α (X.2 ∘ g) X)
       (fun g ↦ α (Y.2 ∘ g) Y)
       (fun g ↦

--- a/geb-lean/vendor/geb-mathlib/Geb/Mathlib/Data/PFunctor/Presheaf.lean
+++ b/geb-lean/vendor/geb-mathlib/Geb/Mathlib/Data/PFunctor/Presheaf.lean
@@ -1,7 +1,7 @@
 /-
-Copyright (c) 2026 The geb-mathlib contributors. All rights reserved.
+Copyright (c) 2026 Terence Rokop. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: The geb-mathlib contributors
+Authors: Terence Rokop
 -/
 module
 

--- a/geb-lean/vendor/geb-mathlib/Geb/Mathlib/Data/PFunctor/Presheaf/Basic.lean
+++ b/geb-lean/vendor/geb-mathlib/Geb/Mathlib/Data/PFunctor/Presheaf/Basic.lean
@@ -1,7 +1,7 @@
 /-
-Copyright (c) 2026 The geb-mathlib contributors. All rights reserved.
+Copyright (c) 2026 Terence Rokop. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: The geb-mathlib contributors
+Authors: Terence Rokop
 -/
 -- Modified from geb-mathlib by scripts/geb-mathlib-backport.patch.
 module
@@ -12,21 +12,24 @@ public import Mathlib.CategoryTheory.Opposites
 public import Mathlib.CategoryTheory.Types.Basic
 
 /-!
-# Presheaf-domain polynomial functors (constructive core)
+# Presheaf polynomial functors (constructive core)
 
 A presheaf-domain polynomial functor extends a `SliceDomPFunctor` on the
 objects of a category `I` with a contravariant `I`-action on arities: for
 each shape `a`, the assignment `i ↦ Direction a i` extends to a presheaf on
-`I` via a restriction map `directionRestr a f`. This file is the p.r.a. (parametric
-right adjoint) construction restricted to the domain side; the full
-categorical packaging appears in sibling modules. Every declaration here is
+`I` via a restriction map `directionRestr a f`. A presheaf polynomial functor
+adds the shape-output side: a `J`-action `shapeRestr` on shapes with an arity
+reindexing `reindex`, assembling the output as a presheaf on `J`. This file
+is the constructive core of the p.r.a. (parametric right adjoint)
+construction, both the domain-restricted functor and the full
+`(Iᵒᵖ ⥤ Type) → (Jᵒᵖ ⥤ Type)` action. Every declaration here is
 `Classical.choice`-free; the categorical packaging that pulls in
 `Classical.choice` from mathlib is in the sibling `Presheaf.Functor` module.
 
-The design uses the option-(A) fibre encoding: directions over `i` are
-`SliceDomPFunctor.Direction a i = Subtype (DirectionOver a i)`, the fibre of
+Directions over `i` are
+`SliceDomPFunctor.Direction a i = Subtype (DirectionOver a i)`, the fiber of
 the direction-input map `rCurried a` over `i`. The `directionRestr` field
-reindexes these fibres contravariantly.
+reindexes these fibers contravariantly.
 
 ## Main definitions
 
@@ -56,7 +59,8 @@ reindexes these fibres contravariantly.
 * `PresheafPFunctorData.IsFunctorial` — the full functor laws bundled.
 * `PresheafPFunctor` — the full bundle: operations with a functoriality proof.
 * `PresheafPFunctor.objRestrElt` / `objRestr` — the restriction action of the
-  output presheaf on a `J`-morphism, on the dom value and on `F.obj Z`.
+  output presheaf on a `J`-morphism, on a slice element over an arbitrary
+  projection and on `F.obj Z`.
 * `PresheafPFunctor.objPresheaf` — the output presheaf `T(Z) : Jᵒᵖ ⥤ Type`, a
   `Functor` value with `map_id` / `map_comp` discharged from `isFunctorial`.
 * `PresheafPFunctor.mapPresheaf` — the presheaf morphism
@@ -93,7 +97,7 @@ The morphism universes of `I` and `J` are named `vI` and `vJ` (via
 `[Category.{vI} I]` / `[Category.{vJ} J]`), and every parent and presheaf-functor
 argument pins its universes, so no declaration's signature carries an auto-bound
 `u_N` variable. `PresheafDomPFunctorData` uses
-`extends SliceDomPFunctor.{uA, uB} I` with pinned universes (load-bearing for a
+`extends SliceDomPFunctor.{uA, uB} I` with pinned universes (required for a
 later diamond via `PresheafDomPFunctorData` and `SlicePFunctor`); pinned
 references to it elsewhere take the synthesized order
 `PresheafDomPFunctorData.{uI, uA, uB, vI}`.
@@ -328,7 +332,7 @@ namespace PresheafPFunctorData
 /-- Each `reindex g a` commutes with `directionRestr` (a presheaf morphism
 `E_T(shapeRestr g a) ⟶ E_T(a)`): for `f : i' ⟶ i`,
 `directionRestr a.1 f ∘ reindex g a = reindex g a ∘ directionRestr (shapeRestr g a).1 f`.
-Ordinary fibre maps only; no `shapeRestr` transport. -/
+Ordinary fiber maps only; no `shapeRestr` transport. -/
 @[expose] def ReindexNaturality {I : Type uI} [Category.{vI} I] {J : Type uJ} [Category.{vJ} J]
     (F : PresheafPFunctorData.{uI, uJ, uA, uB, vI, vJ} I J) : Prop :=
   ∀ ⦃j j' : J⦄ (g : j' ⟶ j) (a : F.Shape j) ⦃i i' : I⦄ (f : i' ⟶ i),
@@ -391,8 +395,7 @@ structure PresheafPFunctor (I : Type uI) [Category.{vI} I]
   /-- Proof the operations are functorial. -/
   isFunctorial : toPresheafPFunctorData.IsFunctorial
 
-attribute [ext] PresheafPFunctorData
-  PresheafPFunctor
+attribute [ext] PresheafPFunctorData PresheafPFunctor
 
 namespace PresheafPFunctor
 
@@ -520,7 +523,7 @@ theorem objRestrElt_comp {I : Type uI} [Category.{vI} I] {J : Type uJ} [Category
     (F.cast_val_heq (congrFun (F.isFunctorial.shapeRestr_comp g h) ⟨a, hq⟩) ⟨b1, rfl⟩) hb
 
 /-- The output presheaf `T(Z) : Jᵒᵖ ⥤ Type`, built directly as a `Functor`
-value. Its fibre over `j` is the subtype of the dom value `F.obj Z` whose
+value. Its fiber over `j` is the subtype of the dom value `F.obj Z` whose
 `q`-output index is `j`; its restriction maps are the shape-and-direction
 reindex action `objRestr`, whose `map_id` / `map_comp` are discharged
 from `F.isFunctorial`. -/
@@ -538,7 +541,7 @@ from `F.isFunctorial`. -/
     exact F.objRestrElt_comp g.unop h.unop w.1.1 w.2 (F.shapeRestr g.unop ⟨w.1.shape, w.2⟩).2
 
 /-- Naturality of the dom morphism map with respect to `objPresheaf`'s
-`J`-restriction: for `α : NatTrans Z Z'`, the dom `map α` carries the fibre of
+`J`-restriction: for `α : NatTrans Z Z'`, the dom `map α` carries the fiber of
 `objPresheaf Z` over `j` into that of `objPresheaf Z'` (it preserves the
 `q`-output index, the shape being fixed by `SliceDomPFunctor.map_fst`) and
 commutes with the shape-and-direction reindex restriction `objRestr g`. The
@@ -555,7 +558,7 @@ theorem map_objRestr {I : Type uI} [Category.{vI} I] {J : Type uJ} [Category.{vJ
 
 /-- The natural transformation `objPresheaf Z ⟶ objPresheaf Z'` induced by a
 morphism `α : Z ⟶ Z'` of input presheaves: each component is the dom `map α` on
-the underlying element, restricted to the `q`-indexed fibre (the dom map
+the underlying element, restricted to the `q`-indexed fiber (the dom map
 preserves the output index, the shape being fixed by
 `SliceDomPFunctor.map_fst`); naturality is `map_objRestr`. The categorical
 wrapper `functor.map` reuses it. -/

--- a/geb-lean/vendor/geb-mathlib/Geb/Mathlib/Data/PFunctor/Presheaf/Functor.lean
+++ b/geb-lean/vendor/geb-mathlib/Geb/Mathlib/Data/PFunctor/Presheaf/Functor.lean
@@ -1,7 +1,7 @@
 /-
-Copyright (c) 2026 The geb-mathlib contributors. All rights reserved.
+Copyright (c) 2026 Terence Rokop. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: The geb-mathlib contributors
+Authors: Terence Rokop
 -/
 module
 
@@ -9,17 +9,17 @@ public import Geb.Mathlib.Data.PFunctor.Presheaf.Basic
 public import Mathlib.CategoryTheory.Elements
 
 /-!
-# Presheaf-domain polynomial functors: categorical wrapper
+# Presheaf polynomial functors: categorical wrapper
 
-Packages the constructive core (`Presheaf.Basic`) as a
-`CategoryTheory.Functor` on the presheaf category `Iᵒᵖ ⥤ Type`. The
+Packages the constructive core (`Presheaf.Basic`) as `CategoryTheory.Functor`
+values: the domain-side functor `(Iᵒᵖ ⥤ Type) ⥤ Type` and the presheaf
+polynomial functor `(Iᵒᵖ ⥤ Type) ⥤ (Jᵒᵖ ⥤ Type)`. The
 functor-category packaging — constructing `CategoryTheory.Functor` objects
 over presheaf categories and discharging their laws — is
 `Classical.choice`-dependent, so this packaging is kept in a separate
-module from the choice-free core; the module
-`Data.PFunctor.Presheaf.Functor` is on
-`GebMeta.classicalAllowedModules`. The notation `↾` (`TypeCat.ofHom`) is
-choice-free: `objPresheaf` uses `↾` and is `{propext, Quot.sound}`. This
+module from the choice-free core. The notation `↾` (`TypeCat.ofHom`) is
+itself choice-free: `objPresheaf` uses `↾` and depends only on `propext`
+and `Quot.sound`. This
 module also relates the core to mathlib's category of elements:
 `elemMap_eq_categoryOfElements_map` proves the choice-free core `elemMap` is
 the object map of mathlib's `Classical.choice`-dependent
@@ -36,7 +36,7 @@ the object map of mathlib's `Classical.choice`-dependent
 
 * `PresheafPFunctor.functor_obj` / `functor_map` — the categorical functor's
   object map is the core `objPresheaf`, and its morphism map is the
-  dom `map` restricted to the `q`-indexed fibre.
+  dom `map` restricted to the `q`-indexed fiber.
 * `PresheafDomPFunctorData.elemMap_eq_categoryOfElements_map` — the core's
   choice-free `elemMap` is the object map of mathlib's
   `Classical.choice`-dependent `CategoryOfElements.map`, across `toElements`.
@@ -53,7 +53,7 @@ shortcut: the codomain is a plain type category, not an `Over` category.
 `functor` assembles directly: its object map is `objPresheaf`, and its morphism
 map is the core `mapPresheaf` — the natural transformation a
 functor-category hom `α` induces, whose component is the dom `map α` restricted
-to the `q`-indexed fibre (the dom map preserves the output index, so it
+to the `q`-indexed fiber (the dom map preserves the output index, so it
 restricts), with naturality `map_objRestr`. The outer functor laws come from
 the dom `map_id` / `map_comp`. There is no `Functor.toOver`
 analogue for presheaf codomains. The morphism universes of `I` and `J` are
@@ -139,7 +139,7 @@ theorem functor_obj {I : Type uI} [Category.{vI} I] {J : Type uJ} [Category.{vJ}
     F.functor.obj Z = F.objPresheaf Z :=
   rfl
 
-/-- `functor.map`'s component over `j`, applied to a `q`-indexed fibre element,
+/-- `functor.map`'s component over `j`, applied to a `q`-indexed fiber element,
 applies the dom `map` to the underlying element: its underlying dom value is
 the dom `map α` of the input's. -/
 theorem functor_map {I : Type uI} [Category.{vI} I] {J : Type uJ} [Category.{vJ} J]

--- a/geb-lean/vendor/geb-mathlib/Geb/Mathlib/Data/PFunctor/Presheaf/W.lean
+++ b/geb-lean/vendor/geb-mathlib/Geb/Mathlib/Data/PFunctor/Presheaf/W.lean
@@ -1,13 +1,13 @@
 /-
-Copyright (c) 2026 The geb-mathlib contributors. All rights reserved.
+Copyright (c) 2026 Terence Rokop. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: The geb-mathlib contributors
+Authors: Terence Rokop
 -/
 -- Modified from geb-mathlib by scripts/geb-mathlib-backport.patch.
 module
 
-public import Geb.Mathlib.Data.PFunctor.Slice.W
 public import Geb.Mathlib.Data.PFunctor.Presheaf.Basic
+public import Geb.Mathlib.Data.PFunctor.Slice.W
 
 /-!
 # W-types of presheaf polynomial functors: hereditary naturality (constructive core)
@@ -26,30 +26,30 @@ restricts the root shape and reindexes the direction-assignment via the
 generalized `PresheafPFunctor.objRestrElt`, conjugated by the slice destructor
 and constructor. `IsHereditarilyNatural` folds the local naturality equation
 over the whole tree through the slice W-type's `Prop`-valued paramorphism
-`SlicePFunctor.W.recProp`; `isHereditarilyNatural_mk` is its one-level
+`SlicePFunctor.W.RecProp`; `isHereditarilyNatural_mk` is its one-level
 computation rule.
 
 ## Main definitions
 
 * `PresheafPFunctor.wRestrTree` — the root-only restriction of a slice W-tree
-  along a morphism, via the generalized `objRestrElt` at `p := windex`.
+  along a morphism, via the generalized `objRestrElt` at `p := wIndex`.
 * `PresheafPFunctor.IsHereditarilyNatural` — the tree-level naturality predicate
-  on slice W-trees, defined by `SlicePFunctor.W.recProp`.
-* `PresheafPFunctor.wRestr` — restriction on the `ULift`ed carrier fibre,
+  on slice W-trees, defined by `SlicePFunctor.W.RecProp`.
+* `PresheafPFunctor.wRestr` — restriction on the `ULift`ed carrier fiber,
   reindexing the underlying tree along a morphism while preserving the index and
   hereditary naturality.
 * `PresheafPFunctor.W` — the carrier presheaf `Iᵒᵖ ⥤ Type (max uI uA uB)`, whose
-  fibre over `j` is the `ULift` of the hereditarily-natural slice W-trees indexed
+  fiber over `j` is the `ULift` of the hereditarily-natural slice W-trees indexed
   at `j` and whose restriction maps are `wRestr`.
 * `PresheafPFunctor.W.forgetNode` / `PresheafPFunctor.W.rememberNode` — the
   mutually inverse translations between a presheaf node over the carrier
-  presheaf `F.W` and the underlying slice node over `windex` together with the
+  presheaf `F.W` and the underlying slice node over `wIndex` together with the
   hereditary naturality of its children.
 * `PresheafPFunctor.W.mk` / `PresheafPFunctor.W.dest` — the fixed-point
-  constructor and destructor: mutually inverse fibrewise maps between the
+  constructor and destructor: mutually inverse fiberwise maps between the
   `objPresheaf`-value at `F.W` and `F.W`, exhibiting `F.W` as a fixed point of
   the `objPresheaf`-action at `F.W`.
-* `PresheafPFunctor.W.PElimData` / `pelimStep` / `pelimData` — the eliminator's
+* `PresheafPFunctor.W.PElimData` / `pElimStep` / `pElimData` — the eliminator's
   fold carrier, algebra, and fold (a `WType.elim` fold whose value is guarded by
   hereditary naturality, since the presheaf algebra acts only on natural nodes):
   the presheaf analogue of the slice `ElimData` machinery.
@@ -63,7 +63,7 @@ computation rule.
 * `PresheafPFunctor.isHereditarilyNatural_mk` — the one-level unfolding of
   `IsHereditarilyNatural` on a constructor `SlicePFunctor.W.mk x`: local
   naturality at the root, together with hereditary naturality of every child.
-* `PresheafPFunctor.windex_wRestrTree` — the index of a root-restricted tree is
+* `PresheafPFunctor.wIndex_wRestrTree` — the index of a root-restricted tree is
   the restriction morphism's source.
 * `PresheafPFunctor.isHereditarilyNatural_wRestrTree` — hereditary naturality is
   preserved by the root-only restriction, a one-level argument.
@@ -87,30 +87,30 @@ This is the presheaf endofunctor case, `I = J`, so the slice endofunctor
 `F.toSlicePFunctor : SlicePFunctor I I` has a W-type. `wRestrTree` and
 `IsHereditarilyNatural` act on the un-lifted trees `F.toSlicePFunctor.W` of type
 `Type (max uA uB)`; the carrier presheaf `W` `ULift`s the indexed subtype into
-`Type (max uI uA uB)` so its fibres land in a single universe with the index
+`Type (max uI uA uB)` so its fibers land in a single universe with the index
 category `I`.
 
 The recursion in `IsHereditarilyNatural` is confined to the slice W-type's
-`Prop`-valued paramorphism `SlicePFunctor.W.recProp`: no explicit self-recursion
+`Prop`-valued paramorphism `SlicePFunctor.W.RecProp`: no explicit self-recursion
 and no `induction` tactic appear. The child-index witness required by
 `wRestrTree` is discharged from the compatibility of the node's
 direction-assignment (`SliceDomPFunctor.compatible_iff`) together with the
-direction's fibre constraint, exactly as `PresheafDomPFunctorData.value` obtains
+direction's fiber constraint, exactly as `PresheafDomPFunctorData.value` obtains
 its index equality.
 
 The eliminator `elim` folds the underlying slice tree into a target value with a
-bespoke `WType.elim` fold (`pelimData`, carrier `PElimData`, algebra
-`pelimStep`), the presheaf analogue of the slice `elim`'s `ElimData` fold. The
+bespoke `WType.elim` fold (`pElimData`, carrier `PElimData`, algebra
+`pElimStep`), the presheaf analogue of the slice `elim`'s `ElimData` fold. The
 presheaf algebra `α` acts only on natural nodes, so — unlike the slice `elim`,
 whose algebra is total — the fold's value is a function of the subtree's
 hereditary naturality, and the fold carries a naturality proxy (via the guard
-`P ∧ ∀ hp : P, Q hp`, builtin `And` with `Q` proof-irrelevant in `hp`) letting
+`P ∧ ∀ hp : P, Q hp`, the standard `And` with `Q` proof-irrelevant in `hp`) letting
 `α` apply at each node. The value fold is
 a non-dependent `WType.elim` (code-generatable); the recursion in the
-accompanying proofs (`pelimData_valid`, `elimVal_wRestr`) stays inside
-`WType.rec` / `SlicePFunctor.W.ind`. Only the existence half of the
+accompanying proofs (`pElimData_valid`, `elimVal_wRestr`) stays inside
+`WType.rec` / `SlicePFunctor.W.induction`. Only the existence half of the
 initial-algebra universal property is established — the carrier, its fixed-point
-structure, and `elim` with its computation rule `elim_mk` and over-`I` law
+structure, and `elim` with its computation rule `elim_mk` and naturality law
 `comp_elim`; uniqueness of `elim` is not formalized.
 
 ## References
@@ -137,7 +137,7 @@ namespace PresheafPFunctor
 /-- The root-only restriction of a slice W-tree `z` along a morphism `g : j' ⟶ j`
 (where `j` is the index of `z`): restrict the root shape and reindex its
 direction-assignment via the generalized `objRestrElt` at the projection
-`p := F.toSlicePFunctor.windex`, conjugating by the slice destructor and
+`p := F.toSlicePFunctor.wIndex`, conjugating by the slice destructor and
 constructor. The head-index witness required by `objRestrElt` is the hypothesis
 `hq`, the root's `q`-output index being read from `PFunctor.W.head`. -/
 @[expose] def wRestrTree {I : Type uI} [Category.{vI} I]
@@ -151,14 +151,14 @@ constructor. The head-index witness required by `objRestrElt` is the hypothesis
 subtree along a morphism `g` agrees with selecting the child at the reindexed
 direction, hereditarily. The local conjunct is the tree analogue of
 `PresheafDomPFunctorData.IsNatural`; the fold over the tree is carried by the
-slice W-type's `Prop`-valued paramorphism `SlicePFunctor.W.recProp`. -/
+slice W-type's `Prop`-valued paramorphism `SlicePFunctor.W.RecProp`. -/
 @[expose] def IsHereditarilyNatural {I : Type uI} [Category.{vI} I]
     (F : PresheafPFunctor.{uI, uI, uA, uB, vI, vI} I I) : F.toSlicePFunctor.W → Prop :=
-  SlicePFunctor.W.recProp (fun x ih ↦
+  SlicePFunctor.W.RecProp (fun x ih ↦
     (∀ ⦃i i' : I⦄ (g : i' ⟶ i) (b : F.toSliceDomPFunctor.Direction x.1.1 i),
         x.1.2 (F.directionRestr x.1.1 g b).1
           = F.wRestrTree g (x.1.2 b.1)
-              (((F.toSliceDomPFunctor.compatible_iff F.toSlicePFunctor.windex x.1.1 x.1.2).mp
+              (((F.toSliceDomPFunctor.compatible_iff F.toSlicePFunctor.wIndex x.1.1 x.1.2).mp
                 x.2 b.1).trans b.2)) ∧ ∀ b, ih b)
 
 /-- One-level unfolding of `IsHereditarilyNatural` on a constructor
@@ -166,12 +166,12 @@ slice W-type's `Prop`-valued paramorphism `SlicePFunctor.W.recProp`. -/
 naturality of every child subtree. From `SlicePFunctor.W.recProp_mk`. -/
 theorem isHereditarilyNatural_mk {I : Type uI} [Category.{vI} I]
     (F : PresheafPFunctor.{uI, uI, uA, uB, vI, vI} I I)
-    (x : F.toSliceDomPFunctor.Obj F.toSlicePFunctor.windex) :
+    (x : F.toSliceDomPFunctor.Obj F.toSlicePFunctor.wIndex) :
     F.IsHereditarilyNatural (SlicePFunctor.W.mk x) ↔
       (∀ ⦃i i' : I⦄ (g : i' ⟶ i) (b : F.toSliceDomPFunctor.Direction x.1.1 i),
           x.1.2 (F.directionRestr x.1.1 g b).1
             = F.wRestrTree g (x.1.2 b.1)
-                (((F.toSliceDomPFunctor.compatible_iff F.toSlicePFunctor.windex x.1.1 x.1.2).mp
+                (((F.toSliceDomPFunctor.compatible_iff F.toSlicePFunctor.wIndex x.1.1 x.1.2).mp
                   x.2 b.1).trans b.2)) ∧
         ∀ b, F.IsHereditarilyNatural (x.1.2 b) := by
   unfold IsHereditarilyNatural
@@ -180,10 +180,10 @@ theorem isHereditarilyNatural_mk {I : Type uI} [Category.{vI} I]
 /-- The index of a root-restricted tree is `j'`: `wRestrTree g z` rebuilds the
 root with the restricted shape `(shapeRestr g _).1`, whose `q`-output index is
 `j'`. -/
-theorem windex_wRestrTree {I : Type uI} [Category.{vI} I]
+theorem wIndex_wRestrTree {I : Type uI} [Category.{vI} I]
     (F : PresheafPFunctor.{uI, uI, uA, uB, vI, vI} I I) ⦃j j' : I⦄ (g : j' ⟶ j)
     (z : F.toSlicePFunctor.W) (hq : F.q (PFunctor.W.head z.1) = j) :
-    F.toSlicePFunctor.windex (F.wRestrTree g z hq) = j' := by
+    F.toSlicePFunctor.wIndex (F.wRestrTree g z hq) = j' := by
   obtain ⟨tree, hvalid⟩ := z
   cases tree with
   | mk a f => exact (F.shapeRestr g ⟨a, hq⟩).2
@@ -194,7 +194,7 @@ original node assigns to the direction's `reindex`. The analogue of
 direction, matching `objRestrElt`'s internal `⟨·, rfl⟩` reconstruction. -/
 private theorem snd_objRestrElt {I : Type uI} [Category.{vI} I]
     (F : PresheafPFunctor.{uI, uI, uA, uB, vI, vI} I I) ⦃j j' : I⦄ (g : j' ⟶ j)
-    (x : F.toSliceDomPFunctor.Obj F.toSlicePFunctor.windex) (hq : F.q x.1.1 = j) ⦃i : I⦄
+    (x : F.toSliceDomPFunctor.Obj F.toSlicePFunctor.wIndex) (hq : F.q x.1.1 = j) ⦃i : I⦄
     (d : F.toSliceDomPFunctor.Direction (F.objRestrElt g x hq).1.1 i) :
     (F.objRestrElt g x hq).1.2 d.1 = x.1.2 (F.reindex g ⟨x.1.1, hq⟩ d).1 := by
   obtain ⟨dv, rfl⟩ := d
@@ -225,7 +225,7 @@ theorem isHereditarilyNatural_wRestrTree {I : Type uI} [Category.{vI} I]
     · intro b
       exact hz_children (F.reindex g ⟨a, hq⟩ ⟨b, rfl⟩).1
 
-/-- Restriction on the ULifted carrier fibre: apply `wRestrTree` to the
+/-- Restriction on the `ULift`ed carrier fiber: apply `wRestrTree` to the
 underlying tree of `w` along `g`, re-establishing the index (`j'`, read from the
 restricted root shape via `shapeRestr`) and hereditary naturality (preserved by
 `wRestrTree`, a one-level consequence of `isHereditarilyNatural_mk` and
@@ -233,12 +233,12 @@ restricted root shape via `shapeRestr`) and hereditary naturality (preserved by
 @[expose] def wRestr {I : Type uI} [Category.{vI} I]
     (F : PresheafPFunctor.{uI, uI, uA, uB, vI, vI} I I) ⦃j j' : I⦄ (g : j' ⟶ j) :
     ULift.{uI} { w : F.toSlicePFunctor.W //
-        F.toSlicePFunctor.windex w = j ∧ F.IsHereditarilyNatural w } →
+        F.toSlicePFunctor.wIndex w = j ∧ F.IsHereditarilyNatural w } →
       ULift.{uI} { w : F.toSlicePFunctor.W //
-        F.toSlicePFunctor.windex w = j' ∧ F.IsHereditarilyNatural w } :=
+        F.toSlicePFunctor.wIndex w = j' ∧ F.IsHereditarilyNatural w } :=
   fun w ↦ ULift.up
     ⟨F.wRestrTree g w.down.1 w.down.2.1,
-      F.windex_wRestrTree g w.down.1 w.down.2.1,
+      F.wIndex_wRestrTree g w.down.1 w.down.2.1,
       F.isHereditarilyNatural_wRestrTree g w.down.1 w.down.2.1 w.down.2.2⟩
 
 /-- Restriction along an identity fixes the tree: `objRestrElt_id` collapses the
@@ -269,14 +269,14 @@ theorem wRestrTree_comp {I : Type uI} [Category.{vI} I]
       (F.shapeRestr g ⟨a, hq⟩).2]
 
 /-- The carrier presheaf `W : Iᵒᵖ ⥤ Type` of the presheaf polynomial endofunctor
-`F`: its fibre over `j` is the `ULift` of the hereditarily-natural slice W-trees
+`F`: its fiber over `j` is the `ULift` of the hereditarily-natural slice W-trees
 indexed at `j`, and its restriction maps are `wRestr`. The functor laws transport
 from `objRestrElt_id` / `objRestrElt_comp` through `wRestrTree`, `ULift`, and
 `Subtype`. -/
 @[expose] def W {I : Type uI} [Category.{vI} I]
     (F : PresheafPFunctor.{uI, uI, uA, uB, vI, vI} I I) : Iᵒᵖ ⥤ Type (max uI uA uB) where
   obj j := ULift.{uI} { w : F.toSlicePFunctor.W //
-    F.toSlicePFunctor.windex w = j.unop ∧ F.IsHereditarilyNatural w }
+    F.toSlicePFunctor.wIndex w = j.unop ∧ F.IsHereditarilyNatural w }
   map g := ↾ (F.wRestr g.unop)
   map_id j := by
     ext w
@@ -284,11 +284,11 @@ from `objRestrElt_id` / `objRestrElt_comp` through `wRestrTree`, `ULift`, and
   map_comp g h := by
     ext w
     exact F.wRestrTree_comp g.unop h.unop w.down.1 w.down.2.1
-      (F.windex_wRestrTree g.unop w.down.1 w.down.2.1)
+      (F.wIndex_wRestrTree g.unop w.down.1 w.down.2.1)
 
 namespace W
 
-/-- Casting a carrier fibre element along an index equality leaves its
+/-- Casting a carrier fiber element along an index equality leaves its
 underlying slice W-tree unchanged. -/
 private theorem cast_down {I : Type uI} [Category.{vI} I]
     (F : PresheafPFunctor.{uI, uI, uA, uB, vI, vI} I I) {k k' : I} (e : k = k')
@@ -307,7 +307,7 @@ private theorem wRestrTree_congr {I : Type uI} [Category.{vI} I]
   cases hz
   rfl
 
-/-- Two carrier fibre elements with equal underlying trees are equal. -/
+/-- Two carrier fiber elements with equal underlying trees are equal. -/
 private theorem obj_ext {I : Type uI} [Category.{vI} I]
     (F : PresheafPFunctor.{uI, uI, uA, uB, vI, vI} I I) {k : I} {u u' : (F.W).obj ⟨k⟩}
     (h : u.down.1 = u'.down.1) : u = u' := by
@@ -315,7 +315,7 @@ private theorem obj_ext {I : Type uI} [Category.{vI} I]
   obtain ⟨u'⟩ := u'
   exact congrArg ULift.up (Subtype.ext h)
 
-/-- The underlying tree of a restricted fibre element is the root-restriction of
+/-- The underlying tree of a restricted fiber element is the root-restriction of
 the underlying tree. -/
 private theorem map_down {I : Type uI} [Category.{vI} I]
     (F : PresheafPFunctor.{uI, uI, uA, uB, vI, vI} I I) ⦃i i' : I⦄ (f : i' ⟶ i)
@@ -324,7 +324,7 @@ private theorem map_down {I : Type uI} [Category.{vI} I]
   rfl
 
 /-- The underlying tree of the value a presheaf node over `F.W` assigns to a
-direction is the underlying tree of the carried child fibre element. -/
+direction is the underlying tree of the carried child fiber element. -/
 private theorem value_down {I : Type uI} [Category.{vI} I]
     (F : PresheafPFunctor.{uI, uI, uA, uB, vI, vI} I I)
     (n : F.toSliceDomPFunctor.Obj (PresheafDomPFunctorData.elemProj (F.W))) ⦃i : I⦄
@@ -335,49 +335,49 @@ private theorem value_down {I : Type uI} [Category.{vI} I]
       n.2 b.1).trans b.2)
     (n.1.2 b.1).2
 
-/-- Rebuild a carrier fibre element from its underlying tree, its `windex`, and
-its hereditary naturality: a total-space element over `windex w.down.1` equal to
+/-- Rebuild a carrier fiber element from its underlying tree, its `wIndex`, and
+its hereditary naturality: a total-space element over `wIndex w.down.1` equal to
 the original total-space element over `i`. -/
 private theorem sigma_eta {I : Type uI} [Category.{vI} I]
     (F : PresheafPFunctor.{uI, uI, uA, uB, vI, vI} I I) {i : I} (w : (F.W).obj ⟨i⟩) :
-    (⟨F.toSlicePFunctor.windex w.down.1, ULift.up ⟨w.down.1, rfl, w.down.2.2⟩⟩ :
+    (⟨F.toSlicePFunctor.wIndex w.down.1, ULift.up ⟨w.down.1, rfl, w.down.2.2⟩⟩ :
       Σ i : I, (F.W).obj ⟨i⟩) = ⟨i, w⟩ := by
   obtain ⟨⟨t, hi, hh⟩⟩ := w
   cases hi
   rfl
 
 /-- Forget a presheaf node over the carrier presheaf `F.W` to the underlying
-slice node over `windex`: retain the shape, and send each direction to the
-underlying slice W-tree of its carried fibre element. -/
+slice node over `wIndex`: retain the shape, and send each direction to the
+underlying slice W-tree of its carried fiber element. -/
 @[expose] def forgetNode {I : Type uI} [Category.{vI} I]
     (F : PresheafPFunctor.{uI, uI, uA, uB, vI, vI} I I)
     (n : F.toSliceDomPFunctor.Obj (PresheafDomPFunctorData.elemProj (F.W))) :
-    F.toSliceDomPFunctor.Obj F.toSlicePFunctor.windex :=
+    F.toSliceDomPFunctor.Obj F.toSlicePFunctor.wIndex :=
   ⟨⟨n.1.1, fun b ↦ (n.1.2 b).2.down.1⟩,
-    (F.toSliceDomPFunctor.compatible_iff F.toSlicePFunctor.windex _ _).mpr fun b ↦
+    (F.toSliceDomPFunctor.compatible_iff F.toSlicePFunctor.wIndex _ _).mpr fun b ↦
       ((n.1.2 b).2.down.2.1).trans
         ((F.toSliceDomPFunctor.compatible_iff (PresheafDomPFunctorData.elemProj (F.W)) _ _).mp
           n.2 b)⟩
 
-/-- Remember a slice node over `windex` whose children are hereditarily natural
+/-- Remember a slice node over `wIndex` whose children are hereditarily natural
 as a presheaf node over the carrier presheaf `F.W`: retain the shape, and send
-each direction to the carried fibre element built from the child tree, its index
-`windex`, and its hereditary naturality. -/
+each direction to the carried fiber element built from the child tree, its index
+`wIndex`, and its hereditary naturality. -/
 @[expose] def rememberNode {I : Type uI} [Category.{vI} I]
     (F : PresheafPFunctor.{uI, uI, uA, uB, vI, vI} I I)
-    (y : F.toSliceDomPFunctor.Obj F.toSlicePFunctor.windex)
+    (y : F.toSliceDomPFunctor.Obj F.toSlicePFunctor.wIndex)
     (hchildren : ∀ b, F.IsHereditarilyNatural (y.1.2 b)) :
     F.toSliceDomPFunctor.Obj (PresheafDomPFunctorData.elemProj (F.W)) :=
-  ⟨⟨y.1.1, fun b ↦ ⟨F.toSlicePFunctor.windex (y.1.2 b),
+  ⟨⟨y.1.1, fun b ↦ ⟨F.toSlicePFunctor.wIndex (y.1.2 b),
       ULift.up ⟨y.1.2 b, rfl, hchildren b⟩⟩⟩,
     (F.toSliceDomPFunctor.compatible_iff (PresheafDomPFunctorData.elemProj (F.W)) _ _).mpr fun b ↦
-      (F.toSliceDomPFunctor.compatible_iff F.toSlicePFunctor.windex _ _).mp y.2 b⟩
+      (F.toSliceDomPFunctor.compatible_iff F.toSlicePFunctor.wIndex _ _).mp y.2 b⟩
 
 /-- `rememberNode` depends on the slice node only, not the hereditary-naturality
 data (which occupies a `Prop` position). -/
 private theorem rememberNode_eq {I : Type uI} [Category.{vI} I]
     (F : PresheafPFunctor.{uI, uI, uA, uB, vI, vI} I I)
-    {y y' : F.toSliceDomPFunctor.Obj F.toSlicePFunctor.windex}
+    {y y' : F.toSliceDomPFunctor.Obj F.toSlicePFunctor.wIndex}
     (hy : ∀ b, F.IsHereditarilyNatural (y.1.2 b))
     (hy' : ∀ b, F.IsHereditarilyNatural (y'.1.2 b)) (e : y = y') :
     rememberNode F y hy = rememberNode F y' hy' := by
@@ -387,7 +387,7 @@ private theorem rememberNode_eq {I : Type uI} [Category.{vI} I]
 /-- `forgetNode` inverts `rememberNode`. -/
 private theorem forgetNode_rememberNode {I : Type uI} [Category.{vI} I]
     (F : PresheafPFunctor.{uI, uI, uA, uB, vI, vI} I I)
-    (y : F.toSliceDomPFunctor.Obj F.toSlicePFunctor.windex)
+    (y : F.toSliceDomPFunctor.Obj F.toSlicePFunctor.wIndex)
     (hchildren : ∀ b, F.IsHereditarilyNatural (y.1.2 b)) :
     forgetNode F (rememberNode F y hchildren) = y := by
   apply Subtype.ext
@@ -428,7 +428,7 @@ theorem isHereditarilyNatural_mk_forgetNode {I : Type uI} [Category.{vI} I]
     exact h
 
 /-- The fixed-point constructor of the presheaf W-type: the `objPresheaf`-value
-at the carrier presheaf `F.W` maps into `F.W`, fibrewise over `I`. It builds the
+at the carrier presheaf `F.W` maps into `F.W`, fiberwise over `I`. It builds the
 slice W-tree from the node (via `forgetNode` and the slice constructor
 `SlicePFunctor.W.mk`), reads its index from the node's `q`-output index, and
 supplies hereditary naturality via `isHereditarilyNatural_mk_forgetNode`. -/
@@ -453,9 +453,9 @@ a shape with a family of hereditarily-natural subtrees, reassembled (via
   exact ⟨⟨rememberNode F (SlicePFunctor.W.dest z.down.1) hchildren,
       (isHereditarilyNatural_mk_forgetNode F _).mp (by rw [forgetNode_rememberNode F]; exact hz)⟩,
     calc F.q (SlicePFunctor.W.dest z.down.1).1.1
-        = F.toSlicePFunctor.windex (SlicePFunctor.W.mk (SlicePFunctor.W.dest z.down.1)) :=
-          (SlicePFunctor.W.windex_mk (SlicePFunctor.W.dest z.down.1)).symm
-      _ = F.toSlicePFunctor.windex z.down.1 := by rw [SlicePFunctor.W.mk_dest]
+        = F.toSlicePFunctor.wIndex (SlicePFunctor.W.mk (SlicePFunctor.W.dest z.down.1)) :=
+          (SlicePFunctor.W.wIndex_mk (SlicePFunctor.W.dest z.down.1)).symm
+      _ = F.toSlicePFunctor.wIndex z.down.1 := by rw [SlicePFunctor.W.mk_dest]
       _ = j := z.down.2.1⟩
 
 /-- `dest` is a left inverse of `mk`. -/
@@ -517,7 +517,7 @@ structure PElimData {I : Type uI} [Category.{vI} I]
 carriers' values: the direction assignment sends `b` to the child value
 `(c b).value`, compatible with `elemProj Y` by the children's `over` and the
 node's `OverInput`. -/
-@[expose] def pnodeSlice {I : Type uI} [Category.{vI} I]
+@[expose] def pNodeSlice {I : Type uI} [Category.{vI} I]
     {F : PresheafPFunctor.{uI, uI, uA, uB, vI, vI} I I}
     {Y : Iᵒᵖ ⥤ Type (max uI uA uB)} {a : F.toPFunctor.A}
     (c : F.toPFunctor.B a → PElimData F Y)
@@ -528,11 +528,11 @@ node's `OverInput`. -/
     (F.toSliceDomPFunctor.compatible_iff (PresheafDomPFunctorData.elemProj Y) a _).mpr
       fun b ↦ ((c b).over (hv.1 b) (hc b)).trans (congrFun hv.2 b)⟩
 
-/-- The value-fold algebra step: index and admissibility as for `windexStep`; a
+/-- The value-fold algebra step: index and admissibility as for `wIndexStep`; a
 hereditary-naturality proxy `H` combining the children's proxies with the
-naturality of the assembled node (`pnodeSlice`); and a value that applies the
+naturality of the assembled node (`pNodeSlice`); and a value that applies the
 presheaf algebra `α` to that node, packaged over the shape's `q`-output index. -/
-@[expose] def pelimStep {I : Type uI} [Category.{vI} I]
+@[expose] def pElimStep {I : Type uI} [Category.{vI} I]
     (F : PresheafPFunctor.{uI, uI, uA, uB, vI, vI} I I)
     (Y : Iᵒᵖ ⥤ Type (max uI uA uB)) (α : NatTrans (F.objPresheaf Y) Y) :
     F.toPFunctor.Obj (PElimData F Y) → PElimData F Y :=
@@ -540,52 +540,52 @@ presheaf algebra `α` to that node, packaged over the shape's `q`-output index. 
     { index := F.q x.1
       valid := F.toSlicePFunctor.NodeValid x.1 (fun b ↦ (x.2 b).toWIndex)
       H := fun hv ↦ (∀ b, (x.2 b).H (hv.1 b)) ∧
-        (∀ hc : (∀ b, (x.2 b).H (hv.1 b)), F.IsNatural (pnodeSlice x.2 hv hc))
+        (∀ hc : (∀ b, (x.2 b).H (hv.1 b)), F.IsNatural (pNodeSlice x.2 hv hc))
       value := fun hv hn ↦
-        ⟨F.q x.1, α.app ⟨F.q x.1⟩ ⟨⟨pnodeSlice x.2 hv hn.1, hn.2 hn.1⟩, rfl⟩⟩
+        ⟨F.q x.1, α.app ⟨F.q x.1⟩ ⟨⟨pNodeSlice x.2 hv hn.1, hn.2 hn.1⟩, rfl⟩⟩
       over := fun _ _ ↦ rfl }
 
 /-- The value fold: the `F.toPFunctor`-algebra morphism into
-`(PElimData F Y, pelimStep)` given by `WType.elim`, a single non-dependent fold
+`(PElimData F Y, pElimStep)` given by `WType.elim`, a single non-dependent fold
 with no explicit recursion. -/
-@[expose] def pelimData {I : Type uI} [Category.{vI} I]
+@[expose] def pElimData {I : Type uI} [Category.{vI} I]
     (F : PresheafPFunctor.{uI, uI, uA, uB, vI, vI} I I)
     (Y : Iᵒᵖ ⥤ Type (max uI uA uB)) (α : NatTrans (F.objPresheaf Y) Y) :
     F.toPFunctor.W → PElimData F Y :=
-  WType.elim (PElimData F Y) (pelimStep F Y α)
+  WType.elim (PElimData F Y) (pElimStep F Y α)
 
-/-- The index-and-admissibility projection of `pelimData` agrees with the slice
-fold `windexValid`: the value fold refines the slice fold, so admissibility and
+/-- The index-and-admissibility projection of `pElimData` agrees with the slice
+fold `wIndexValid`: the value fold refines the slice fold, so admissibility and
 the root index transport from the slice results. Proved by the dependent
 recursor `WType.rec`. -/
-theorem pelimData_toWIndex {I : Type uI} [Category.{vI} I]
+theorem pElimData_toWIndex {I : Type uI} [Category.{vI} I]
     (F : PresheafPFunctor.{uI, uI, uA, uB, vI, vI} I I)
     (Y : Iᵒᵖ ⥤ Type (max uI uA uB)) (α : NatTrans (F.objPresheaf Y) Y) (w : F.toPFunctor.W) :
-    (pelimData F Y α w).toWIndex = F.windexValid w :=
-  WType.rec (motive := fun w ↦ (pelimData F Y α w).toWIndex = F.windexValid w)
+    (pElimData F Y α w).toWIndex = F.wIndexValid w :=
+  WType.rec (motive := fun w ↦ (pElimData F Y α w).toWIndex = F.wIndexValid w)
     (fun a f ih ↦ by
-      change F.windexStep ⟨a, fun b ↦ (pelimData F Y α (f b)).toWIndex⟩ =
-        F.windexStep ⟨a, fun b ↦ F.windexValid (f b)⟩
+      change F.wIndexStep ⟨a, fun b ↦ (pElimData F Y α (f b)).toWIndex⟩ =
+        F.wIndexStep ⟨a, fun b ↦ F.wIndexValid (f b)⟩
       rw [funext ih])
     w
 
-/-- The admissibility component of `pelimData` is `WValid`. -/
-theorem pelimData_valid {I : Type uI} [Category.{vI} I]
+/-- The admissibility component of `pElimData` is `WValid`. -/
+theorem pElimData_valid {I : Type uI} [Category.{vI} I]
     (F : PresheafPFunctor.{uI, uI, uA, uB, vI, vI} I I)
     (Y : Iᵒᵖ ⥤ Type (max uI uA uB)) (α : NatTrans (F.objPresheaf Y) Y) (w : F.toPFunctor.W) :
-    (pelimData F Y α w).valid = F.WValid w :=
-  congrArg SlicePFunctor.WIndex.valid (pelimData_toWIndex F Y α w)
+    (pElimData F Y α w).valid = F.WValid w :=
+  congrArg SlicePFunctor.WIndex.valid (pElimData_toWIndex F Y α w)
 
-/-- The index component of `pelimData` is the root index. -/
-theorem pelimData_index {I : Type uI} [Category.{vI} I]
+/-- The index component of `pElimData` is the root index. -/
+theorem pElimData_index {I : Type uI} [Category.{vI} I]
     (F : PresheafPFunctor.{uI, uI, uA, uB, vI, vI} I I)
     (Y : Iᵒᵖ ⥤ Type (max uI uA uB)) (α : NatTrans (F.objPresheaf Y) Y) (w : F.toPFunctor.W) :
-    (pelimData F Y α w).index = F.windexRoot w :=
-  (congrArg SlicePFunctor.WIndex.index (pelimData_toWIndex F Y α w)).trans
-    (F.windexValid_index_eq_windexRoot w)
+    (pElimData F Y α w).index = F.wIndexRoot w :=
+  (congrArg SlicePFunctor.WIndex.index (pElimData_toWIndex F Y α w)).trans
+    (F.wIndexValid_index_eq_wIndexRoot w)
 
 /-- A natural transformation's components respect heterogeneous equality of
-fibre elements over equal indices. -/
+fiber elements over equal indices. -/
 private theorem app_heq.{w} {I : Type uI} [Category.{vI} I]
     {Z Z' : Iᵒᵖ ⥤ Type w} (β : NatTrans Z Z') {k k' : I} (hk : k = k')
     {x : Z.obj ⟨k⟩} {x' : Z.obj ⟨k'⟩} (hx : x ≍ x') :
@@ -594,7 +594,7 @@ private theorem app_heq.{w} {I : Type uI} [Category.{vI} I]
   cases hx
   rfl
 
-/-- Two fibre elements of `objPresheaf Y` over equal indices whose underlying
+/-- Two fiber elements of `objPresheaf Y` over equal indices whose underlying
 dom values are equal are heterogeneously equal. -/
 private theorem objPresheaf_obj_heq {I : Type uI} [Category.{vI} I]
     (F : PresheafPFunctor.{uI, uI, uA, uB, vI, vI} I I) (Y : Iᵒᵖ ⥤ Type (max uI uA uB))
@@ -612,14 +612,14 @@ theorem value_wRestrTree {I : Type uI} [Category.{vI} I]
     (Y : Iᵒᵖ ⥤ Type (max uI uA uB)) (α : NatTrans (F.objPresheaf Y) Y)
     (t : F.toSlicePFunctor.W) ⦃i i' : I⦄ (f : i' ⟶ i)
     (hqi : F.q (PFunctor.W.head t.1) = i)
-    (hv : (pelimData F Y α t.1).valid) (hn : (pelimData F Y α t.1).H hv)
-    (hv' : (pelimData F Y α (F.wRestrTree f t hqi).1).valid)
-    (hn' : (pelimData F Y α (F.wRestrTree f t hqi).1).H hv') :
-    (pelimData F Y α (F.wRestrTree f t hqi).1).value hv' hn' =
+    (hv : (pElimData F Y α t.1).valid) (hn : (pElimData F Y α t.1).H hv)
+    (hv' : (pElimData F Y α (F.wRestrTree f t hqi).1).valid)
+    (hn' : (pElimData F Y α (F.wRestrTree f t hqi).1).H hv') :
+    (pElimData F Y α (F.wRestrTree f t hqi).1).value hv' hn' =
       ⟨i', Y.map f.op (cast (congrArg (fun k : I ↦ Y.obj ⟨k⟩)
-          (((pelimData F Y α t.1).over hv hn).trans
-            ((pelimData_index F Y α t.1).trans hqi)))
-        ((pelimData F Y α t.1).value hv hn).2)⟩ := by
+          (((pElimData F Y α t.1).over hv hn).trans
+            ((pElimData_index F Y α t.1).trans hqi)))
+        ((pElimData F Y α t.1).value hv hn).2)⟩ := by
   obtain ⟨tree, hval⟩ := t
   cases tree with
   | mk a fchild =>
@@ -627,16 +627,16 @@ theorem value_wRestrTree {I : Type uI} [Category.{vI} I]
     have hqa : F.q a = i := hqi
     subst hqa
     have hnat :
-        Y.map f.op (α.app ⟨F.q a⟩ (⟨⟨pnodeSlice (fun b ↦ pelimData F Y α (fchild b)) hv hn.1,
+        Y.map f.op (α.app ⟨F.q a⟩ (⟨⟨pNodeSlice (fun b ↦ pElimData F Y α (fchild b)) hv hn.1,
             hn.2 hn.1⟩, rfl⟩ : (F.objPresheaf Y).obj ⟨F.q a⟩)) =
           α.app ⟨i'⟩ ((F.objPresheaf Y).map f.op
-            ⟨⟨pnodeSlice (fun b ↦ pelimData F Y α (fchild b)) hv hn.1, hn.2 hn.1⟩, rfl⟩) :=
+            ⟨⟨pNodeSlice (fun b ↦ pElimData F Y α (fchild b)) hv hn.1, hn.2 hn.1⟩, rfl⟩) :=
       (FunctorToTypes.naturality _ _ α f.op _).symm
     change (α.app ⟨F.q (F.shapeRestr f ⟨a, hqi⟩).1⟩
-          (⟨⟨F.objRestrElt f (pnodeSlice (fun b ↦ pelimData F Y α (fchild b)) hv hn.1) hqi,
+          (⟨⟨F.objRestrElt f (pNodeSlice (fun b ↦ pElimData F Y α (fchild b)) hv hn.1) hqi,
             hn'.2 hn'.1⟩, rfl⟩ : (F.objPresheaf Y).obj ⟨F.q (F.shapeRestr f ⟨a, hqi⟩).1⟩)) ≍
         Y.map f.op (α.app ⟨F.q a⟩
-          (⟨⟨pnodeSlice (fun b ↦ pelimData F Y α (fchild b)) hv hn.1, hn.2 hn.1⟩, rfl⟩ :
+          (⟨⟨pNodeSlice (fun b ↦ pElimData F Y α (fchild b)) hv hn.1, hn.2 hn.1⟩, rfl⟩ :
             (F.objPresheaf Y).obj ⟨F.q a⟩))
     rw [hnat]
     exact app_heq α (F.shapeRestr f ⟨a, hqi⟩).2
@@ -646,38 +646,38 @@ theorem value_wRestrTree {I : Type uI} [Category.{vI} I]
 hereditarily-natural subtrees is natural: local naturality of the enclosing tree
 (each child restricting to the child at the reindexed direction) transports
 through the fold's value-restriction coherence `value_wRestrTree`. -/
-private theorem isNatural_pnodeSlice {I : Type uI} [Category.{vI} I]
+private theorem isNatural_pNodeSlice {I : Type uI} [Category.{vI} I]
     (F : PresheafPFunctor.{uI, uI, uA, uB, vI, vI} I I)
     (Y : Iᵒᵖ ⥤ Type (max uI uA uB)) (α : NatTrans (F.objPresheaf Y) Y)
     {a : F.toPFunctor.A} (fc : F.toPFunctor.B a → F.toSlicePFunctor.W)
-    (hv : F.toSlicePFunctor.NodeValid a (fun b ↦ (pelimData F Y α (fc b).1).toWIndex))
-    (hc : ∀ b, (pelimData F Y α (fc b).1).H (hv.1 b))
+    (hv : F.toSlicePFunctor.NodeValid a (fun b ↦ (pElimData F Y α (fc b).1).toWIndex))
+    (hc : ∀ b, (pElimData F Y α (fc b).1).H (hv.1 b))
     (hloc : ∀ ⦃i i' : I⦄ (g : i' ⟶ i) (b : F.toSliceDomPFunctor.Direction a i)
         (hq : F.q (PFunctor.W.head (fc b.1).1) = i),
         fc (F.directionRestr a g b).1 = F.wRestrTree g (fc b.1) hq) :
-    F.IsNatural (pnodeSlice (fun b ↦ pelimData F Y α (fc b).1) hv hc) := by
+    F.IsNatural (pNodeSlice (fun b ↦ pElimData F Y α (fc b).1) hv hc) := by
   intro i i' g b
-  change F.value (pnodeSlice (fun b ↦ pelimData F Y α (fc b).1) hv hc) (F.directionRestr a g b) =
-    Y.map g.op (F.value (pnodeSlice (fun b ↦ pelimData F Y α (fc b).1) hv hc) b)
+  change F.value (pNodeSlice (fun b ↦ pElimData F Y α (fc b).1) hv hc) (F.directionRestr a g b) =
+    Y.map g.op (F.value (pNodeSlice (fun b ↦ pElimData F Y α (fc b).1) hv hc) b)
   have hqit : F.q (PFunctor.W.head (fc b.1).1) = i :=
-    (pelimData_index F Y α (fc b.1).1).symm.trans ((congrFun hv.2 b.1).trans b.2)
-  have hgen : ∀ (T : F.toSlicePFunctor.W) (hvT : (pelimData F Y α T.1).valid)
-      (hnT : (pelimData F Y α T.1).H hvT), T = F.wRestrTree g (fc b.1) hqit →
-      (pelimData F Y α T.1).value hvT hnT =
+    (pElimData_index F Y α (fc b.1).1).symm.trans ((congrFun hv.2 b.1).trans b.2)
+  have hgen : ∀ (T : F.toSlicePFunctor.W) (hvT : (pElimData F Y α T.1).valid)
+      (hnT : (pElimData F Y α T.1).H hvT), T = F.wRestrTree g (fc b.1) hqit →
+      (pElimData F Y α T.1).value hvT hnT =
         ⟨i', Y.map g.op (cast (congrArg (fun k : I ↦ Y.obj ⟨k⟩)
-            (((pelimData F Y α (fc b.1).1).over (hv.1 b.1) (hc b.1)).trans
-              ((pelimData_index F Y α (fc b.1).1).trans hqit)))
-          ((pelimData F Y α (fc b.1).1).value (hv.1 b.1) (hc b.1)).2)⟩ := by
+            (((pElimData F Y α (fc b.1).1).over (hv.1 b.1) (hc b.1)).trans
+              ((pElimData_index F Y α (fc b.1).1).trans hqit)))
+          ((pElimData F Y α (fc b.1).1).value (hv.1 b.1) (hc b.1)).2)⟩ := by
     intro T hvT hnT hT
     subst hT
     exact value_wRestrTree F Y α (fc b.1) g hqit (hv.1 b.1) (hc b.1) hvT hnT
   have hchild :
-      (pnodeSlice (fun b ↦ pelimData F Y α (fc b).1) hv hc).1.2
+      (pNodeSlice (fun b ↦ pElimData F Y α (fc b).1) hv hc).1.2
           (F.directionRestr a g b).1 =
         ⟨i', Y.map g.op (cast (congrArg (fun k : I ↦ Y.obj ⟨k⟩)
-            (((pelimData F Y α (fc b.1).1).over (hv.1 b.1) (hc b.1)).trans
-              ((pelimData_index F Y α (fc b.1).1).trans hqit)))
-          ((pelimData F Y α (fc b.1).1).value (hv.1 b.1) (hc b.1)).2)⟩ :=
+            (((pElimData F Y α (fc b.1).1).over (hv.1 b.1) (hc b.1)).trans
+              ((pElimData_index F Y α (fc b.1).1).trans hqit)))
+          ((pElimData F Y α (fc b.1).1).value (hv.1 b.1) (hc b.1)).2)⟩ :=
     hgen (fc (F.directionRestr a g b).1) (hv.1 (F.directionRestr a g b).1)
       (hc (F.directionRestr a g b).1) (hloc g b hqit)
   simp only [PresheafDomPFunctorData.value]
@@ -686,75 +686,77 @@ private theorem isNatural_pnodeSlice {I : Type uI} [Category.{vI} I]
   rw [hchild]
   rfl
 
-/-- The node the value fold assembles at a validated hereditarily-natural tree,
-as an element of the output presheaf's fibre over the root index: the shape and
-the children's fold values, natural by the tree's hereditary naturality. -/
-theorem pelimData_H_of_isHN {I : Type uI} [Category.{vI} I]
+/-- The value fold's hereditary-naturality proxy `H` holds at every validated
+hereditarily-natural tree: the children's proxies hold by the tree recursion
+(`SlicePFunctor.W.induction`), and the node the fold assembles (`pNodeSlice`)
+is natural by `isNatural_pNodeSlice`, from the tree's local naturality. -/
+theorem pElimData_H_of_isHereditarilyNatural {I : Type uI} [Category.{vI} I]
     (F : PresheafPFunctor.{uI, uI, uA, uB, vI, vI} I I)
     (Y : Iᵒᵖ ⥤ Type (max uI uA uB)) (α : NatTrans (F.objPresheaf Y) Y)
-    (w : F.toSlicePFunctor.W) (hv : (pelimData F Y α w.1).valid)
-    (hn : F.IsHereditarilyNatural w) : (pelimData F Y α w.1).H hv :=
-  SlicePFunctor.W.ind
-    (motive := fun z ↦ ∀ (hv : (pelimData F Y α z.1).valid),
-      F.IsHereditarilyNatural z → (pelimData F Y α z.1).H hv)
+    (w : F.toSlicePFunctor.W) (hv : (pElimData F Y α w.1).valid)
+    (hn : F.IsHereditarilyNatural w) : (pElimData F Y α w.1).H hv :=
+  SlicePFunctor.W.induction
+    (motive := fun z ↦ ∀ (hv : (pElimData F Y α z.1).valid),
+      F.IsHereditarilyNatural z → (pElimData F Y α z.1).H hv)
     (fun x ih hv hHN ↦ by
       refine ⟨fun b ↦ ih b (hv.1 b) (((F.isHereditarilyNatural_mk x).mp hHN).2 b), fun _ ↦ ?_⟩
-      exact isNatural_pnodeSlice F Y α x.1.2 hv
+      exact isNatural_pNodeSlice F Y α x.1.2 hv
         (fun b ↦ ih b (hv.1 b) (((F.isHereditarilyNatural_mk x).mp hHN).2 b))
         (fun _ _ g b _ ↦ ((F.isHereditarilyNatural_mk x).mp hHN).1 g b))
     w hv hn
 
-/-- The fibre value the fold contributes to a validated hereditarily-natural
+/-- The fiber value the fold contributes to a validated hereditarily-natural
 tree indexed at `j`: the total-space value's `Y`-component, transported to the
-fibre over `j` through the fold's `over` law and root-index agreement. -/
+fiber over `j` through the fold's `over` law and root-index agreement. -/
 @[expose] def elimVal {I : Type uI} [Category.{vI} I]
     (F : PresheafPFunctor.{uI, uI, uA, uB, vI, vI} I I)
     (Y : Iᵒᵖ ⥤ Type (max uI uA uB)) (α : NatTrans (F.objPresheaf Y) Y) {j : I}
     (z : (F.W).obj ⟨j⟩) : Y.obj ⟨j⟩ :=
   cast (congrArg (fun i : I ↦ Y.obj ⟨i⟩)
-      ((((pelimData F Y α z.down.1.1).over
-          ((pelimData_valid F Y α z.down.1.1) ▸ z.down.1.2)
-          (pelimData_H_of_isHN F Y α z.down.1
-            ((pelimData_valid F Y α z.down.1.1) ▸ z.down.1.2) z.down.2.2)).trans
-        (pelimData_index F Y α z.down.1.1)).trans z.down.2.1))
-    ((pelimData F Y α z.down.1.1).value
-      ((pelimData_valid F Y α z.down.1.1) ▸ z.down.1.2)
-      (pelimData_H_of_isHN F Y α z.down.1
-        ((pelimData_valid F Y α z.down.1.1) ▸ z.down.1.2) z.down.2.2)).2
+      ((((pElimData F Y α z.down.1.1).over
+          ((pElimData_valid F Y α z.down.1.1) ▸ z.down.1.2)
+          (pElimData_H_of_isHereditarilyNatural F Y α z.down.1
+            ((pElimData_valid F Y α z.down.1.1) ▸ z.down.1.2) z.down.2.2)).trans
+        (pElimData_index F Y α z.down.1.1)).trans z.down.2.1))
+    ((pElimData F Y α z.down.1.1).value
+      ((pElimData_valid F Y α z.down.1.1) ▸ z.down.1.2)
+      (pElimData_H_of_isHereditarilyNatural F Y α z.down.1
+        ((pElimData_valid F Y α z.down.1.1) ▸ z.down.1.2) z.down.2.2)).2
 
 /-- The total-space fold value at a carrier element is `elimVal` paired with the
-index: the `Y`-component is `elimVal` and the base point is the fibre index.
+index: the `Y`-component is `elimVal` and the base point is the fiber index.
 Proof-irrelevance identifies the fold's internal hereditary-naturality proof with
 any supplied one. -/
 theorem value_eq_elimVal {I : Type uI} [Category.{vI} I]
     (F : PresheafPFunctor.{uI, uI, uA, uB, vI, vI} I I)
     (Y : Iᵒᵖ ⥤ Type (max uI uA uB)) (α : NatTrans (F.objPresheaf Y) Y) {j : I}
-    (z : (F.W).obj ⟨j⟩) (hv : (pelimData F Y α z.down.1.1).valid)
-    (hn : (pelimData F Y α z.down.1.1).H hv) :
-    (pelimData F Y α z.down.1.1).value hv hn = ⟨j, elimVal F Y α z⟩ := by
-  refine Sigma.ext (((((pelimData F Y α z.down.1.1).over hv hn).trans
-    (pelimData_index F Y α z.down.1.1)).trans z.down.2.1)) ?_
+    (z : (F.W).obj ⟨j⟩) (hv : (pElimData F Y α z.down.1.1).valid)
+    (hn : (pElimData F Y α z.down.1.1).H hv) :
+    (pElimData F Y α z.down.1.1).value hv hn = ⟨j, elimVal F Y α z⟩ := by
+  refine Sigma.ext (((((pElimData F Y α z.down.1.1).over hv hn).trans
+    (pElimData_index F Y α z.down.1.1)).trans z.down.2.1)) ?_
   exact (cast_heq _ _).symm
 
 /-- `elimVal` commutes with the restriction maps: the value of a restricted
 carrier element is the `Y`-restriction of the value. It glues the fold-level
 restriction coherence `value_wRestrTree` (the one-level argument, combining the
 fold's one-level computation with `α`'s naturality) with `value_eq_elimVal`,
-which identifies the two total-space fold values' fibre components with the two
-`elimVal`s; the tree recursion is confined to `pelimData_H_of_isHN`. -/
+which identifies the two total-space fold values' fiber components with the two
+`elimVal`s; the tree recursion is confined to `pElimData_H_of_isHereditarilyNatural`. -/
 theorem elimVal_wRestr {I : Type uI} [Category.{vI} I]
     (F : PresheafPFunctor.{uI, uI, uA, uB, vI, vI} I I)
     (Y : Iᵒᵖ ⥤ Type (max uI uA uB)) (α : NatTrans (F.objPresheaf Y) Y) ⦃i i' : I⦄
     (g : i' ⟶ i) (z : (F.W).obj ⟨i⟩) :
     elimVal F Y α ((F.W).map g.op z) = Y.map g.op (elimVal F Y α z) := by
-  have hvz : (pelimData F Y α z.down.1.1).valid :=
-    (pelimData_valid F Y α z.down.1.1) ▸ z.down.1.2
-  have hnz : (pelimData F Y α z.down.1.1).H hvz :=
-    pelimData_H_of_isHN F Y α z.down.1 hvz z.down.2.2
-  have hvzr : (pelimData F Y α ((F.W).map g.op z).down.1.1).valid :=
-    (pelimData_valid F Y α ((F.W).map g.op z).down.1.1) ▸ ((F.W).map g.op z).down.1.2
-  have hnzr : (pelimData F Y α ((F.W).map g.op z).down.1.1).H hvzr :=
-    pelimData_H_of_isHN F Y α ((F.W).map g.op z).down.1 hvzr ((F.W).map g.op z).down.2.2
+  have hvz : (pElimData F Y α z.down.1.1).valid :=
+    (pElimData_valid F Y α z.down.1.1) ▸ z.down.1.2
+  have hnz : (pElimData F Y α z.down.1.1).H hvz :=
+    pElimData_H_of_isHereditarilyNatural F Y α z.down.1 hvz z.down.2.2
+  have hvzr : (pElimData F Y α ((F.W).map g.op z).down.1.1).valid :=
+    (pElimData_valid F Y α ((F.W).map g.op z).down.1.1) ▸ ((F.W).map g.op z).down.1.2
+  have hnzr : (pElimData F Y α ((F.W).map g.op z).down.1.1).H hvzr :=
+    pElimData_H_of_isHereditarilyNatural F Y α ((F.W).map g.op z).down.1 hvzr
+      ((F.W).map g.op z).down.2.2
   have eR := value_eq_elimVal F Y α ((F.W).map g.op z) hvzr hnzr
   have eW := value_wRestrTree F Y α z.down.1 g z.down.2.1 hvz hnz hvzr hnzr
   have key : (⟨i', elimVal F Y α ((F.W).map g.op z)⟩ : Σ k : I, Y.obj ⟨k⟩)
@@ -773,7 +775,7 @@ presheaf algebra `(Y, α)`. Its component over `j` is the bespoke value fold
     ext z
     exact elimVal_wRestr F Y α g.unop z
 
-/-- `elim` is a genuine presheaf morphism: it commutes with the restriction
+/-- `elim` is a presheaf morphism: it commutes with the restriction
 maps of `F.W` and `Y`. The `NatTrans` naturality of `elim`, mirroring the slice
 `comp_elim`. -/
 theorem comp_elim {I : Type uI} [Category.{vI} I]
@@ -791,12 +793,12 @@ theorem elim_mk {I : Type uI} [Category.{vI} I]
     (x : (F.objPresheaf F.W).obj ⟨j⟩) :
     (elim F Y α).app ⟨j⟩ (mk x) =
       α.app ⟨j⟩ ((F.mapPresheaf (elim F Y α)).app ⟨j⟩ x) := by
-  have hv : (pelimData F Y α (mk x).down.1.1).valid :=
-    (pelimData_valid F Y α (mk x).down.1.1) ▸ (mk x).down.1.2
-  have hn : (pelimData F Y α (mk x).down.1.1).H hv :=
-    pelimData_H_of_isHN F Y α (mk x).down.1 hv (mk x).down.2.2
+  have hv : (pElimData F Y α (mk x).down.1.1).valid :=
+    (pElimData_valid F Y α (mk x).down.1.1) ▸ (mk x).down.1.2
+  have hn : (pElimData F Y α (mk x).down.1.1).H hv :=
+    pElimData_H_of_isHereditarilyNatural F Y α (mk x).down.1 hv (mk x).down.2.2
   have hq : F.q x.1.1.1.1 = j := x.2
-  have hchild : ∀ b, (pelimData F Y α (x.1.1.1.2 b).2.down.1.1).value (hv.1 b) (hn.1 b)
+  have hchild : ∀ b, (pElimData F Y α (x.1.1.1.2 b).2.down.1.1).value (hv.1 b) (hn.1 b)
       = (⟨(x.1.1.1.2 b).1, elimVal F Y α (x.1.1.1.2 b).2⟩ : Σ i : I, Y.obj ⟨i⟩) :=
     fun b ↦ value_eq_elimVal F Y α (x.1.1.1.2 b).2 (hv.1 b) (hn.1 b)
   have hval := value_eq_elimVal F Y α (mk x) hv hn

--- a/geb-lean/vendor/geb-mathlib/Geb/Mathlib/Data/PFunctor/Slice.lean
+++ b/geb-lean/vendor/geb-mathlib/Geb/Mathlib/Data/PFunctor/Slice.lean
@@ -1,7 +1,7 @@
 /-
-Copyright (c) 2026 The geb-mathlib contributors. All rights reserved.
+Copyright (c) 2026 Terence Rokop. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: The geb-mathlib contributors
+Authors: Terence Rokop
 -/
 module
 

--- a/geb-lean/vendor/geb-mathlib/Geb/Mathlib/Data/PFunctor/Slice/Basic.lean
+++ b/geb-lean/vendor/geb-mathlib/Geb/Mathlib/Data/PFunctor/Slice/Basic.lean
@@ -1,7 +1,7 @@
 /-
-Copyright (c) 2026 The geb-mathlib contributors. All rights reserved.
+Copyright (c) 2026 Terence Rokop. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: The geb-mathlib contributors
+Authors: Terence Rokop
 -/
 -- Modified from geb-mathlib by scripts/geb-mathlib-backport.patch.
 module
@@ -39,7 +39,7 @@ categorical packaging is in the sibling `Slice.Functor` module.
 * `SliceDomPFunctor.ofCurried` / `rCurried` — the curried constructor and
   the direction-input map in dependently-curried form.
 * `SliceDomPFunctor.DirectionOver` / `Direction` — the direction-input-map
-  condition on a direction of shape `a`, and the fibre of `rCurried a`
+  condition on a direction of shape `a`, and the fiber of `rCurried a`
   over `i`.
 * `SliceDomPFunctor.Obj` / `map` — the domain-restricted functor's
   object and morphism maps; `map_id` / `map_comp` its functoriality.
@@ -48,7 +48,7 @@ categorical packaging is in the sibling `Slice.Functor` module.
   underlying function; `map_w` that it lies over `cod`, `map_id` /
   `map_comp` its functoriality.
 * `SlicePFunctor.ShapeOver` / `Shape` — the shape-output-map condition and
-  the fibre of `q` over `j`.
+  the fiber of `q` over `j`.
 
 ## Main statements
 
@@ -72,7 +72,7 @@ reuses these — its carrier is `SliceDomPFunctor.Obj` and its `map` the
 namespaces' `map`,
 `SliceDomPFunctor.ofCurried` / `rCurried` / `DirectionOver` / `Direction`,
 and `SlicePFunctor.ShapeOver` / `Shape` are `@[expose]` so the
-wrapper and tests can unfold them across the module boundary. The fibre
+wrapper and tests can unfold them across the module boundary. The fiber
 formers `DirectionOver` / `Direction` / `ShapeOver` / `Shape` are
 additionally `@[implicit_reducible]`: they occur inside dependent types,
 and type-level unification compares types at implicit transparency, so
@@ -146,7 +146,7 @@ image under `rCurried a` is `i`. Point-free as `(· = i) ∘ rCurried a`. -/
     (a : F.A) (i : dom) : F.B a → Prop :=
   (· = i) ∘ F.rCurried a
 
-/-- The directions of shape `a` lying over the base point `i`: the fibre
+/-- The directions of shape `a` lying over the base point `i`: the fiber
 of `rCurried a` over `i`. -/
 @[expose, implicit_reducible] def Direction {dom : Type uD} (F : SliceDomPFunctor.{uA, uB} dom)
     (a : F.A) (i : dom) : Type uB :=
@@ -234,7 +234,7 @@ is `j`. Point-free as `(· = j) ∘ q`. -/
     (F : SlicePFunctor.{uA, uB, uD, uC} dom cod) (j : cod) : F.A → Prop :=
   (· = j) ∘ F.q
 
-/-- The shapes lying over `j`: the fibre of `q` over `j`. -/
+/-- The shapes lying over `j`: the fiber of `q` over `j`. -/
 @[expose, implicit_reducible] def Shape {dom : Type uD} {cod : Type uC}
     (F : SlicePFunctor.{uA, uB, uD, uC} dom cod) (j : cod) : Type uA :=
   Subtype (F.ShapeOver j)

--- a/geb-lean/vendor/geb-mathlib/Geb/Mathlib/Data/PFunctor/Slice/Functor.lean
+++ b/geb-lean/vendor/geb-mathlib/Geb/Mathlib/Data/PFunctor/Slice/Functor.lean
@@ -1,7 +1,7 @@
 /-
-Copyright (c) 2026 The geb-mathlib contributors. All rights reserved.
+Copyright (c) 2026 Terence Rokop. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: The geb-mathlib contributors
+Authors: Terence Rokop
 -/
 -- Modified from geb-mathlib by scripts/geb-mathlib-backport.patch.
 module

--- a/geb-lean/vendor/geb-mathlib/Geb/Mathlib/Data/PFunctor/Slice/W.lean
+++ b/geb-lean/vendor/geb-mathlib/Geb/Mathlib/Data/PFunctor/Slice/W.lean
@@ -1,7 +1,7 @@
 /-
-Copyright (c) 2026 The geb-mathlib contributors. All rights reserved.
+Copyright (c) 2026 Terence Rokop. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: The geb-mathlib contributors
+Authors: Terence Rokop
 -/
 -- Modified from geb-mathlib by scripts/geb-mathlib-backport.patch.
 module
@@ -22,7 +22,7 @@ The index (codomain-assignment) and the admissibility predicate
 tree is the output index of its root, so it is not recursive at all; the
 predicate is recursive, but is obtained from mathlib's non-dependent W-type
 eliminator `WType.elim`, folding the index and the predicate together into
-the structure `WIndex` via the algebra `windexStep`. Carrying the index
+the structure `WIndex` via the algebra `wIndexStep`. Carrying the index
 inside the fold is what lets the algebra state the direction-input-map
 condition `OverInput` — the children's index family, as a function of
 direction, equals `rCurried a`, the shape of `SliceDomPFunctor.Compatible`:
@@ -30,7 +30,7 @@ the plain `Prop`-valued fold discards the children, so the condition would
 be inexpressible without either this
 pairing or the dependent recursor.
 
-The carrier `W` is the admissible trees, with structure map `windex`. Its
+The carrier `W` is the admissible trees, with structure map `wIndex`. Its
 constructor `mk` and destructor `dest` are mutually inverse (`W` is a fixed
 point of the slice endofunctor), and `elim` is the morphism into any slice
 algebra over `I`. Only the existence half of the initial-algebra universal
@@ -48,7 +48,7 @@ admissibility component to `WValid`. A direct `WType.rec` definition of a
 `Type`-valued datum (such as `elim`'s value) would be `noncomputable` — the
 code generator does not compile recursor applications — which the project's
 constructive discipline forbids; a `Prop`-valued recursor definition such as
-`recProp` is exempt, its content being erased. All of this stays
+`RecProp` is exempt, its content being erased. All of this stays
 `Classical.choice`-free.
 
 The single index type is forced: the constraint compares a child's
@@ -57,9 +57,9 @@ codomain-index against the parent's domain-index, so it typechecks only when
 
 ## Main definitions
 
-* `SlicePFunctor.windexRoot` — the index of a slice W-tree: the output index
+* `SlicePFunctor.wIndexRoot` — the index of a slice W-tree: the output index
   of its root shape. Not recursive.
-* `SlicePFunctor.WIndex` / `SlicePFunctor.windexStep` / `SlicePFunctor.windexValid`
+* `SlicePFunctor.WIndex` / `SlicePFunctor.wIndexStep` / `SlicePFunctor.wIndexValid`
   — the index-and-admissibility carrier, the algebra computing it, and the fold.
   `SlicePFunctor.ForAll` / `SlicePFunctor.AllValid` / `SlicePFunctor.OverInput` /
   `SlicePFunctor.NodeValid` are the direction-quantifier, the
@@ -67,43 +67,43 @@ codomain-index against the parent's domain-index, so it typechecks only when
   direction-input-map condition, and the node-admissibility predicate
   combining the latter two.
 * `SlicePFunctor.WValid` — the domain-restriction predicate: the admissibility
-  component of `windexValid`.
+  component of `wIndexValid`.
 * `SlicePFunctor.W` — the carrier of the slice W-type: the admissible trees.
-* `SlicePFunctor.windex` — the slice W-type's structure map into `I`.
+* `SlicePFunctor.wIndex` — the slice W-type's structure map into `I`.
 * `SlicePFunctor.W.mk` / `SlicePFunctor.W.dest` — the constructor and
   destructor of the slice W-type.
 * `SlicePFunctor.W.ElimData` / `SlicePFunctor.W.elimStep` /
   `SlicePFunctor.W.elimData` — the `elim` carrier, algebra, and fold.
 * `SlicePFunctor.W.elim` — the morphism from the slice W-type into any slice
   algebra over `I`.
-* `SlicePFunctor.W.recProp` — the paramorphism from the slice W-type into
+* `SlicePFunctor.W.RecProp` — the paramorphism from the slice W-type into
   `Prop`: a predicate whose step sees each node and its child subtrees together
   with the children's predicate values.
 
 ## Main statements
 
-* `SlicePFunctor.windexValid_index_eq_windexRoot` — the index component of the
+* `SlicePFunctor.wIndexValid_index_eq_wIndexRoot` — the index component of the
   fold agrees with the non-recursive root index; one non-recursive case split.
 * `SlicePFunctor.wValid_mk` — admissibility unfolded one level.
 * `SlicePFunctor.W.dest_mk` / `SlicePFunctor.W.mk_dest` — `mk` and `dest` are
   mutually inverse.
-* `SlicePFunctor.W.windex_mk` / `SlicePFunctor.W.comp_elim` — `mk` and `elim`
+* `SlicePFunctor.W.wIndex_mk` / `SlicePFunctor.W.comp_elim` — `mk` and `elim`
   lie over `I`.
 * `SlicePFunctor.W.elim_mk` — the computation rule for `elim`: it is a morphism
   of slice algebras.
 * `SlicePFunctor.W.elimData_valid` — the fold's admissibility component agrees
   with `WValid`; a use of the dependent recursor `WType.rec`.
-* `SlicePFunctor.W.ind` — structural induction for the slice W-type, the wrapped
+* `SlicePFunctor.W.induction` — structural induction for the slice W-type, the wrapped
   form of `WType.rec` on the admissibility subtype.
-* `SlicePFunctor.W.recProp_mk` — the one-level computation rule for `recProp`.
+* `SlicePFunctor.W.recProp_mk` — the one-level computation rule for `RecProp`.
 
 ## Implementation notes
 
-`windexValid` folds into the structure `WIndex` (`index`, `valid`) via
-`windexStep`; a node's `valid` is `NodeValid` — `AllValid` (every child
+`wIndexValid` folds into the structure `WIndex` (`index`, `valid`) via
+`wIndexStep`; a node's `valid` is `NodeValid` — `AllValid` (every child
 admissible) and `OverInput` (the children's index family equal to `rCurried a`,
 the `Compatible` shape). Its index component is the depth-1 root output
-index, so `windexValid_index_eq_windexRoot` needs only `cases`. `elim`'s
+index, so `wIndexValid_index_eq_wIndexRoot` needs only `cases`. `elim`'s
 value is computed by `elimData`, a single non-dependent `WType.elim` with
 algebra `elimStep` into
 the structure `ElimData` (extending `WIndex` with a `value` function and an
@@ -112,11 +112,11 @@ recursor is used only in the proof `elimData_valid` (a `WType.rec` application
 showing the fold's admissibility component agrees with `WValid`). A direct
 `WType.rec` *definition* of a `Type`-valued datum (such as `elim`'s value) would
 be rejected by the code generator as `noncomputable`; a `WType.rec` application
-in a proof, or a `Prop`-valued `WType.rec` definition such as `recProp`, is
-unproblematic. `windexRoot`, `ForAll`, `AllValid`, `OverInput`,
-`NodeValid`, `windexStep`,
-`windexValid`, `WValid`, `W`, `windex`, `W.mk`, `W.dest`, `W.elimStep`,
-`W.elimData`, `W.elim`, and `W.recProp` are `@[expose]` so a wrapper module and
+in a proof, or a `Prop`-valued `WType.rec` definition such as `RecProp`, is
+unproblematic. `wIndexRoot`, `ForAll`, `AllValid`, `OverInput`,
+`NodeValid`, `wIndexStep`,
+`wIndexValid`, `WValid`, `W`, `wIndex`, `W.mk`, `W.dest`, `W.elimStep`,
+`W.elimData`, `W.elim`, and `W.RecProp` are `@[expose]` so a wrapper module and
 the tests can unfold them across the module boundary.
 
 ## References
@@ -138,12 +138,12 @@ namespace SlicePFunctor
 
 /-- The index of a slice W-tree: the `q`-assigned output index of its root
 shape. Not recursive — it reads only the root node, via `PFunctor.W.head`. -/
-@[expose] def windexRoot {I : Type uI} (F : SlicePFunctor.{uA, uB, uI, uI} I I) :
+@[expose] def wIndexRoot {I : Type uI} (F : SlicePFunctor.{uA, uB, uI, uI} I I) :
     F.toPFunctor.W → I :=
   F.q ∘ PFunctor.W.head
 
 /-- The index and admissibility of a slice W-tree, the two components folded
-together by `windexValid`. -/
+together by `wIndexValid`. -/
 @[ext]
 structure WIndex (I : Type uI) where
   /-- The tree's index: the output index of its root shape. -/
@@ -180,29 +180,29 @@ direction-input map (`OverInput`). -/
 /-- The algebra computing a node's index and admissibility from its children's:
 the index is the `q`-assigned output index of the shape, and the node is
 `NodeValid`. -/
-@[expose] def windexStep {I : Type uI} (F : SlicePFunctor.{uA, uB, uI, uI} I I) :
+@[expose] def wIndexStep {I : Type uI} (F : SlicePFunctor.{uA, uB, uI, uI} I I) :
     F.toPFunctor.Obj (WIndex I) → WIndex I :=
   fun ⟨a, c⟩ ↦ { index := F.q a, valid := F.NodeValid a c }
 
 /-- The index paired with admissibility: the `F.toPFunctor`-algebra morphism
-into `(WIndex I, windexStep)` given by `WType.elim`. -/
-@[expose] def windexValid {I : Type uI} (F : SlicePFunctor.{uA, uB, uI, uI} I I) :
+into `(WIndex I, wIndexStep)` given by `WType.elim`. -/
+@[expose] def wIndexValid {I : Type uI} (F : SlicePFunctor.{uA, uB, uI, uI} I I) :
     F.toPFunctor.W → WIndex I :=
-  WType.elim (WIndex I) F.windexStep
+  WType.elim (WIndex I) F.wIndexStep
 
 /-- The domain-restriction predicate on slice W-trees: a tree is admitted when
 every node's children sit over the direction-input indices prescribed by
-`r`. The admissibility component of `windexValid`. -/
+`r`. The admissibility component of `wIndexValid`. -/
 @[expose] def WValid {I : Type uI} (F : SlicePFunctor.{uA, uB, uI, uI} I I) :
     F.toPFunctor.W → Prop :=
-  WIndex.valid ∘ F.windexValid
+  WIndex.valid ∘ F.wIndexValid
 
-/-- The index component of `windexValid` agrees with the non-recursive root
+/-- The index component of `wIndexValid` agrees with the non-recursive root
 index. A depth-1 fact: proved by a single non-recursive case split. -/
 @[simp]
-theorem windexValid_index_eq_windexRoot {I : Type uI}
+theorem wIndexValid_index_eq_wIndexRoot {I : Type uI}
     (F : SlicePFunctor.{uA, uB, uI, uI} I I) (w : F.toPFunctor.W) :
-    (F.windexValid w).index = F.windexRoot w := by
+    (F.wIndexValid w).index = F.wIndexRoot w := by
   cases w with
   | mk a f => rfl
 
@@ -212,10 +212,10 @@ direction-input map. -/
 theorem wValid_mk {I : Type uI} (F : SlicePFunctor.{uA, uB, uI, uI} I I)
     (a : F.toPFunctor.A) (f : F.toPFunctor.B a → F.toPFunctor.W) :
     F.WValid (WType.mk a f) ↔
-      F.ForAll a (F.WValid ∘ f) ∧ F.OverInput a (F.windexRoot ∘ f) := by
-  have h : WIndex.index ∘ F.windexValid ∘ f = F.windexRoot ∘ f :=
-    funext fun b ↦ F.windexValid_index_eq_windexRoot (f b)
-  change (F.ForAll a (F.WValid ∘ f) ∧ F.OverInput a (WIndex.index ∘ F.windexValid ∘ f)) ↔ _
+      F.ForAll a (F.WValid ∘ f) ∧ F.OverInput a (F.wIndexRoot ∘ f) := by
+  have h : WIndex.index ∘ F.wIndexValid ∘ f = F.wIndexRoot ∘ f :=
+    funext fun b ↦ F.wIndexValid_index_eq_wIndexRoot (f b)
+  change (F.ForAll a (F.WValid ∘ f) ∧ F.OverInput a (WIndex.index ∘ F.wIndexValid ∘ f)) ↔ _
   rw [h]
 
 /-- The carrier of the slice W-type: the admissible `PFunctor` W-trees. -/
@@ -224,34 +224,34 @@ theorem wValid_mk {I : Type uI} (F : SlicePFunctor.{uA, uB, uI, uI} I I)
 
 /-- The slice W-type's structure map as an object of `Type/I`: the index of the
 underlying tree. -/
-@[expose] def windex {I : Type uI} (F : SlicePFunctor.{uA, uB, uI, uI} I I) : F.W → I :=
-  F.windexRoot ∘ Subtype.val
+@[expose] def wIndex {I : Type uI} (F : SlicePFunctor.{uA, uB, uI, uI} I I) : F.W → I :=
+  F.wIndexRoot ∘ Subtype.val
 
 namespace W
 
 /-- The constructor of the slice W-type: the slice endofunctor's value at
-`(W, windex)` maps into `W`. The algebra structure map. -/
+`(W, wIndex)` maps into `W`. The algebra structure map. -/
 @[expose] def mk {I : Type uI} {F : SlicePFunctor.{uA, uB, uI, uI} I I}
-    (x : F.toSliceDomPFunctor.Obj F.windex) : F.W :=
+    (x : F.toSliceDomPFunctor.Obj F.wIndex) : F.W :=
   ⟨WType.mk x.1.1 (Subtype.val ∘ x.1.2),
     (F.wValid_mk _ _).mpr ⟨fun b ↦ (x.1.2 b).property,
-      funext ((F.toSliceDomPFunctor.compatible_iff F.windex x.1.1 x.1.2).mp x.2)⟩⟩
+      funext ((F.toSliceDomPFunctor.compatible_iff F.wIndex x.1.1 x.1.2).mp x.2)⟩⟩
 
 /-- The destructor of the slice W-type: every admissible tree decomposes as a
 shape together with a compatible family of admissible subtrees. Inverse to
 `mk`. -/
 @[expose] def dest {I : Type uI} {F : SlicePFunctor.{uA, uB, uI, uI} I I}
-    (z : F.W) : F.toSliceDomPFunctor.Obj F.windex :=
+    (z : F.W) : F.toSliceDomPFunctor.Obj F.wIndex :=
   match z with
   | ⟨WType.mk a f, hw⟩ =>
       ⟨⟨a, fun b ↦ ⟨f b, ((F.wValid_mk a f).mp hw).1 b⟩⟩,
-        (F.toSliceDomPFunctor.compatible_iff F.windex a _).mpr
+        (F.toSliceDomPFunctor.compatible_iff F.wIndex a _).mpr
           fun b ↦ congrFun ((F.wValid_mk a f).mp hw).2 b⟩
 
 /-- `dest` is a left inverse of `mk`. -/
 @[simp]
 theorem dest_mk {I : Type uI} {F : SlicePFunctor.{uA, uB, uI, uI} I I}
-    (x : F.toSliceDomPFunctor.Obj F.windex) : dest (mk x) = x := by
+    (x : F.toSliceDomPFunctor.Obj F.wIndex) : dest (mk x) = x := by
   obtain ⟨⟨a, v⟩, hv⟩ := x
   apply Subtype.ext
   exact Sigma.ext rfl (heq_of_eq (funext fun b ↦ Subtype.ext rfl))
@@ -267,8 +267,8 @@ theorem mk_dest {I : Type uI} {F : SlicePFunctor.{uA, uB, uI, uI} I I}
 
 /-- `mk` lies over `I`: its index is the output index assigned by `F.obj`. -/
 @[simp]
-theorem windex_mk {I : Type uI} {F : SlicePFunctor.{uA, uB, uI, uI} I I}
-    (x : F.toSliceDomPFunctor.Obj F.windex) : F.windex (mk x) = F.obj F.windex x :=
+theorem wIndex_mk {I : Type uI} {F : SlicePFunctor.{uA, uB, uI, uI} I I}
+    (x : F.toSliceDomPFunctor.Obj F.wIndex) : F.wIndex (mk x) = F.obj F.wIndex x :=
   rfl
 
 /-- The `elim` fold carrier: extends `WIndex` to a slice morphism
@@ -282,7 +282,7 @@ structure ElimData {I : Type uI} (Y : Type uY) (p : Y → I) extends WIndex I wh
   over : p ∘ value = Function.const valid index
 
 /-- The slice-algebra step of the `elim` fold: index and admissibility
-(`NodeValid`) as for `windexStep`, and a value function that, given a node's
+(`NodeValid`) as for `wIndexStep`, and a value function that, given a node's
 admissibility, applies the target algebra `g` to the compatible family of its
 children's values, with `over` recording that the result lies over the index. -/
 @[expose] def elimStep {I : Type uI} (F : SlicePFunctor.{uA, uB, uI, uI} I I)
@@ -308,7 +308,7 @@ with no explicit recursion. -/
 @[simp]
 theorem elimData_index {I : Type uI} (F : SlicePFunctor.{uA, uB, uI, uI} I I)
     (Y : Type uY) (p : Y → I) (g : F.toSliceDomPFunctor.Obj p → Y) (hg : p ∘ g = F.obj p)
-    (w : F.toPFunctor.W) : (elimData F Y p g hg w).index = F.windexRoot w := by
+    (w : F.toPFunctor.W) : (elimData F Y p g hg w).index = F.wIndexRoot w := by
   cases w with
   | mk a f => rfl
 
@@ -350,10 +350,10 @@ argument to the fold's `value` function. -/
       ((elimData_valid F Y p g hg z.val).mpr z.property)
 
 /-- `elim` lies over `I`: composing with the target structure map recovers
-`windex`. -/
+`wIndex`. -/
 theorem comp_elim {I : Type uI} (F : SlicePFunctor.{uA, uB, uI, uI} I I)
     (Y : Type uY) (p : Y → I) (g : F.toSliceDomPFunctor.Obj p → Y) (hg : p ∘ g = F.obj p) :
-    p ∘ elim F Y p g hg = F.windex :=
+    p ∘ elim F Y p g hg = F.wIndex :=
   funext fun z ↦
     (congrFun (elimData F Y p g hg z.val).over
       ((elimData_valid F Y p g hg z.val).mpr z.property)).trans
@@ -363,7 +363,7 @@ theorem comp_elim {I : Type uI} (F : SlicePFunctor.{uA, uB, uI, uI} I I)
 is a morphism of slice algebras. -/
 theorem elim_mk {I : Type uI} (F : SlicePFunctor.{uA, uB, uI, uI} I I)
     (Y : Type uY) (p : Y → I) (g : F.toSliceDomPFunctor.Obj p → Y) (hg : p ∘ g = F.obj p)
-    (x : F.toSliceDomPFunctor.Obj F.windex) :
+    (x : F.toSliceDomPFunctor.Obj F.wIndex) :
     elim F Y p g hg (mk x) =
       g (F.toSliceDomPFunctor.map (elim F Y p g hg) (comp_elim F Y p g hg) x) :=
   rfl
@@ -372,9 +372,9 @@ theorem elim_mk {I : Type uI} (F : SlicePFunctor.{uA, uB, uI, uI} I I)
 admissible tree once it holds of `mk x` whenever it holds of each child
 `x.1.2 b`. The wrapped form of the dependent recursor `WType.rec` on the
 admissibility subtype. -/
-theorem ind {I : Type uI} {F : SlicePFunctor.{uA, uB, uI, uI} I I}
+theorem induction {I : Type uI} {F : SlicePFunctor.{uA, uB, uI, uI} I I}
     {motive : F.W → Prop}
-    (mk : ∀ (x : F.toSliceDomPFunctor.Obj F.windex),
+    (mk : ∀ (x : F.toSliceDomPFunctor.Obj F.wIndex),
         (∀ b, motive (x.1.2 b)) → motive (W.mk x)) :
     ∀ z, motive z :=
   fun z ↦
@@ -388,8 +388,8 @@ theorem ind {I : Type uI} {F : SlicePFunctor.{uA, uB, uI, uI} I I}
 hence its child subtrees `x.1.2 b`, together with the children's predicate
 values. The value is computed by `WType.rec` with a `Prop` motive, so no
 `noncomputable` flag arises. `@[expose]` so the presheaf layer can unfold it. -/
-@[expose] def recProp {I : Type uI} {F : SlicePFunctor.{uA, uB, uI, uI} I I}
-    (step : (x : F.toSliceDomPFunctor.Obj F.windex) →
+@[expose] def RecProp {I : Type uI} {F : SlicePFunctor.{uA, uB, uI, uI} I I}
+    (step : (x : F.toSliceDomPFunctor.Obj F.wIndex) →
       (F.toPFunctor.B x.1.1 → Prop) → Prop) :
     F.W → Prop :=
   fun z ↦
@@ -399,14 +399,14 @@ values. The value is computed by `WType.rec` with a `Prop` motive, so no
           (fun b ↦ ih b (((F.wValid_mk a f).mp hv).1 b)))
       z.1 z.2
 
-/-- The one-level computation rule for `recProp`: on `mk x` it applies `step`
+/-- The one-level computation rule for `RecProp`: on `mk x` it applies `step`
 to the node `x` and the family of child values. Definitional; stated for
 downstream unfolding. -/
 theorem recProp_mk {I : Type uI} {F : SlicePFunctor.{uA, uB, uI, uI} I I}
-    (step : (x : F.toSliceDomPFunctor.Obj F.windex) →
+    (step : (x : F.toSliceDomPFunctor.Obj F.wIndex) →
       (F.toPFunctor.B x.1.1 → Prop) → Prop)
-    (x : F.toSliceDomPFunctor.Obj F.windex) :
-    W.recProp step (W.mk x) = step x (fun b ↦ W.recProp step (x.1.2 b)) := by
+    (x : F.toSliceDomPFunctor.Obj F.wIndex) :
+    W.RecProp step (W.mk x) = step x (fun b ↦ W.RecProp step (x.1.2 b)) := by
   obtain ⟨⟨a, v⟩, hc⟩ := x
   rfl
 

--- a/geb-lean/vendor/geb-mathlib/Geb/Mathlib/Logic.lean
+++ b/geb-lean/vendor/geb-mathlib/Geb/Mathlib/Logic.lean
@@ -1,7 +1,7 @@
 /-
-Copyright (c) 2026 The geb-mathlib contributors. All rights reserved.
+Copyright (c) 2026 Terence Rokop. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: The geb-mathlib contributors
+Authors: Terence Rokop
 -/
 module
 

--- a/geb-lean/vendor/geb-mathlib/Geb/Mathlib/Logic/Equiv.lean
+++ b/geb-lean/vendor/geb-mathlib/Geb/Mathlib/Logic/Equiv.lean
@@ -1,7 +1,7 @@
 /-
-Copyright (c) 2026 The geb-mathlib contributors. All rights reserved.
+Copyright (c) 2026 Terence Rokop. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: The geb-mathlib contributors
+Authors: Terence Rokop
 -/
 module
 

--- a/geb-lean/vendor/geb-mathlib/Geb/Mathlib/Logic/Equiv/Basic.lean
+++ b/geb-lean/vendor/geb-mathlib/Geb/Mathlib/Logic/Equiv/Basic.lean
@@ -1,7 +1,7 @@
 /-
-Copyright (c) 2026 The geb-mathlib contributors. All rights reserved.
+Copyright (c) 2026 Terence Rokop. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: The geb-mathlib contributors
+Authors: Terence Rokop
 -/
 module
 
@@ -17,6 +17,11 @@ Extensions of `Mathlib.Logic.Equiv.Basic`.
 * `sigmaFstSectionElim` — eliminate a function into a sigma type along
   a proof that it is a section of the first projection, producing a
   dependent function.
+
+## Main statements
+
+* `sigmaFstSectionElim_eq` — `sigmaFstSectionElim` computes the
+  inverse direction of `Equiv.piEquivSubtypeSigma`.
 
 ## Tags
 

--- a/geb-lean/vendor/geb-mathlib/PROVENANCE.md
+++ b/geb-lean/vendor/geb-mathlib/PROVENANCE.md
@@ -1,6 +1,6 @@
 # Vendored geb-mathlib provenance
 
 - Source: https://github.com/rokopt/geb-mathlib.git
-- Source commit: 4cb1cdfad07dbbdbf228795683b38fd59c99b4bf
-- Back-port patch: scripts/geb-mathlib-backport.patch (sha256 5f020147d40eaac770446e8404fd53cfdca403a7cc5efa4bae80d97bdf91935f)
+- Source commit: 6615f65b6a6222866967b8f38ff1e5131f7cf4c5
+- Back-port patch: scripts/geb-mathlib-backport.patch (sha256 a7188f13bd746b005681f94a05790b363ab9bfa27b0092b944005bd197154848)
 - The files under `Geb/` are an unmodified mirror of the source commit except where the back-port patch changes them; modified files carry a change notice in their header comment.


### PR DESCRIPTION
upstream merges a style-standardization pass (mathlib naming conventions, coding style, docstring form) that displaces the context of every hunk without changing any adapted site: all five adaptation categories re-anchor unchanged. the Geb.lean hunk is re-applied by hand for the reordered import block and the GebMeta import moved to its own paragraph. verify the no-op condition: re-running the refresh against 6615f65 leaves the vendored tree byte-identical.