### PR TITLE
`PFunctor`-derived slice free monads

### DIFF
--- a/geb-lean/GebLean.lean
+++ b/geb-lean/GebLean.lean
@@ -144,6 +144,7 @@ import GebLean.RelInterpComposition
 import GebLean.RelSpanDiagram
 import GebLean.RestrictedCoendAsColimit
 import GebLean.Semicategory
+import GebLean.SliceW
 import GebLean.Utilities
 import GebLean.Utilities.ArrowCospanAdjunction
 import GebLean.Utilities.ArrowSpanAdjunction

--- a/geb-lean/GebLean/PolyBridge.lean
+++ b/geb-lean/GebLean/PolyBridge.lean
@@ -1,5 +1,6 @@
 import GebLean.PolyBridge.Slice
 import GebLean.PolyBridge.WEquiv
+import GebLean.PolyBridge.FreeMEquiv
 
 /-!
 # Polynomial-functor bridge
@@ -11,5 +12,7 @@ and the vendored `geb-mathlib` `SlicePFunctor` stack
 free-algebra layer (`GebLean/Ramified/AlgSig.lean`) is being reimplemented.
 `Slice` supplies the generic shape-level translation `toSlice`; `WEquiv`
 carries it to the initial algebras, the fiberwise equivalence
-`PolyFix P x ≃ { w : (toSlice P).W // wIndex w = x }`.
+`PolyFix P x ≃ { w : (toSlice P).W // wIndex w = x }`; `FreeMEquiv`
+identifies the translate augmentations and carries the comparison to the
+free monads, `PolyFreeM V P x ≃ SlicePFunctor.FreeM V.hom (toSlice P) x`.
 -/

--- a/geb-lean/GebLean/PolyBridge/FreeMEquiv.lean
+++ b/geb-lean/GebLean/PolyBridge/FreeMEquiv.lean
@@ -33,6 +33,17 @@ with the W-type transport `Iso.wEquivFiber` of this isomorphism.
 * `polyFreeMSliceEquiv` — the fiberwise equivalence
   `PolyFreeM V P x ≃ SlicePFunctor.FreeM V.hom (toSlice P) x`.
 
+## Main statements
+
+* `polyFreeMSliceEquiv_transport` — the equivalence commutes with reindexing a
+  tree along an equality of indices.
+* `polyFreeMSliceEquiv_pure` — the equivalence carries the legacy leaf
+  `polyFreeMPure` to the slice free monad's `pure`.
+* `polyFreeMSliceEquiv_node` — the equivalence carries a legacy node to the
+  slice free monad's `node`.
+* `polyFreeMSliceEquiv_bind` — the equivalence intertwines the legacy free-monad
+  bind with the slice free monad's `bind`.
+
 ## References
 
 N. Gambino and J. Kock, "Polynomial functors and polynomial monads",
@@ -88,5 +99,73 @@ with the W-type transport `Iso.wEquivFiber` of `translateSliceIso`. -/
 def polyFreeMSliceEquiv {X : Type u} (V : Over X) (P : PolyEndo X) (x : X) :
     PolyFreeM V P x ≃ SlicePFunctor.FreeM V.hom (toSlice P) x :=
   (polyFixSliceEquiv (polyTranslate V P) x).trans ((translateSliceIso V P).wEquivFiber x)
+
+/-- Transport naturality: `polyFreeMSliceEquiv` commutes with reindexing a tree
+along an equality of indices. Mirrors Phase A's `toSliceW_transport`. -/
+theorem polyFreeMSliceEquiv_transport {X : Type u} (V : Over X) (P : PolyEndo X)
+    {x x' : X} (h : x = x') (t : PolyFreeM V P x) :
+    polyFreeMSliceEquiv V P x' (h ▸ t) = h ▸ polyFreeMSliceEquiv V P x t := by
+  subst h
+  rfl
+
+/-- Pure naturality: `polyFreeMSliceEquiv` carries the legacy leaf
+`polyFreeMPure V P a` to the slice free monad's `pure a`. -/
+theorem polyFreeMSliceEquiv_pure {X : Type u} (V : Over X) (P : PolyEndo X) (x : X)
+    (a : { v : V.left // V.hom v = x }) :
+    polyFreeMSliceEquiv V P x (polyFreeMPure V P a) = SlicePFunctor.FreeM.pure a :=
+  Subtype.ext
+    (congrArg SlicePFunctor.W.mk
+      (Subtype.ext (Sigma.ext rfl (heq_of_eq (funext fun e => e.elim)))))
+
+/-- Node naturality: `polyFreeMSliceEquiv` carries a legacy node
+`PolyFix.mk x (Sum.inr p) ch` to the slice free monad's `node ⟨x, p⟩` with the
+children mapped through the equivalence. -/
+theorem polyFreeMSliceEquiv_node {X : Type u} (V : Over X) (P : PolyEndo X) (x : X)
+    (p : polyBetweenIndex X X P x)
+    (ch : ∀ e : (polyBetweenFamily X X (polyTranslate V P) x (Sum.inr p)).left,
+      PolyFreeM V P ((polyBetweenFamily X X (polyTranslate V P) x (Sum.inr p)).hom e)) :
+    polyFreeMSliceEquiv V P x (PolyFix.mk x (Sum.inr p) ch) =
+      SlicePFunctor.FreeM.node (F := toSlice P) (v := V.hom) ⟨x, p⟩
+        (fun e => polyFreeMSliceEquiv V P _ (ch e)) :=
+  rfl
+
+/-- Bind naturality: `polyFreeMSliceEquiv` intertwines the legacy free-monad
+bind `polyFreeMBind` with the slice free monad's `bind`. Proved by `PolyFix.ind`
+on the legacy tree, the only place where legacy elimination is admitted. -/
+theorem polyFreeMSliceEquiv_bind {X : Type u} (V B : Over X) (P : PolyEndo X) (x : X)
+    (t : PolyFreeM V P x)
+    (f : ∀ y, { a : V.left // V.hom a = y } → PolyFreeM B P y) :
+    polyFreeMSliceEquiv B P x (polyFreeMBind V B P t f) =
+      (polyFreeMSliceEquiv V P x t).bind
+        (fun y a => polyFreeMSliceEquiv B P y (f y a)) :=
+  PolyFix.ind (P := polyTranslate V P)
+    (motive := fun {y} t =>
+      polyFreeMSliceEquiv B P y (polyFreeMBind V B P t f) =
+        (polyFreeMSliceEquiv V P y t).bind
+          (fun z a => polyFreeMSliceEquiv B P z (f z a)))
+    (fun {y} i children ih => by
+      match i with
+      | Sum.inl a =>
+          have hpure :
+              polyFreeMSliceEquiv V P y
+                  (@PolyFix.mk X (polyTranslate V P) y (Sum.inl a) children) =
+                SlicePFunctor.FreeM.pure a :=
+            Subtype.ext (congrArg SlicePFunctor.W.mk
+              (Subtype.ext (Sigma.ext rfl (heq_of_eq (funext fun e => e.elim)))))
+          change polyFreeMSliceEquiv B P y (f y a) =
+              (polyFreeMSliceEquiv V P y
+                  (@PolyFix.mk X (polyTranslate V P) y (Sum.inl a) children)).bind
+                (fun z a => polyFreeMSliceEquiv B P z (f z a))
+          rw [hpure]
+          exact (SlicePFunctor.FreeM.pure_bind a
+            (fun z a => polyFreeMSliceEquiv B P z (f z a))).symm
+      | Sum.inr p =>
+          simp only [polyFreeMBind]
+          rw [polyFreeMSliceEquiv_node, polyFreeMSliceEquiv_node]
+          refine Eq.trans ?_ (SlicePFunctor.FreeM.bind_node (F := toSlice P) (v := V.hom)
+            ⟨y, p⟩ _ (fun z a => polyFreeMSliceEquiv B P z (f z a))).symm
+          exact congrArg (SlicePFunctor.FreeM.node (F := toSlice P) (v := B.hom) ⟨y, p⟩)
+            (funext fun e => ih e))
+    t
 
 end GebLean.PolyBridge

--- a/geb-lean/GebLean/PolyBridge/FreeMEquiv.lean
+++ b/geb-lean/GebLean/PolyBridge/FreeMEquiv.lean
@@ -1,0 +1,92 @@
+import GebLean.PolyBridge.WEquiv
+import GebLean.SliceW.Iso
+import GebLean.SliceW.FreeM
+import Mathlib.Logic.Equiv.Sum
+
+/-!
+# The translate augmentation isomorphism and the free-monad equivalence
+
+Relates this development's free monad `PolyFreeM V P` (`GebLean/PolyAlg.lean`),
+built as the initial algebra of the translate polynomial `V + P(-)`, to the
+slice free monad `SlicePFunctor.FreeM V.hom (toSlice P)` (`GebLean/SliceW/`),
+built as the fiber of the W-type of the slice augmentation
+`SlicePFunctor.translate V.hom (toSlice P)`. Both present the free monad on
+the polynomial endofunctor `P` with leaves `V`, in the sense of Gambino–Kock;
+the two augmentations are the same slice endofunctor `V + P(-)` under the
+translation `toSlice` (`GebLean/PolyBridge/Slice.lean`), and `translateSliceIso`
+is that identification as a container isomorphism.
+
+The isomorphism's shape equivalence distributes the sigma of the augmented
+index over its coproduct
+(`Σ x, ({ a // V.hom a = x } ⊕ polyBetweenIndex X X P x)`) into
+`V.left ⊕ Σ x, polyBetweenIndex X X P x` and contracts the leaf summand along
+`Equiv.sigmaFiberEquiv V.hom`. Positions and the two structure maps agree at
+node shapes definitionally; at leaf shapes positions are empty and the
+shape-output map agrees by the leaf's stored fiber witness. The free-monad
+equivalence then composes the initial-algebra comparison `polyFixSliceEquiv`
+with the W-type transport `Iso.wEquivFiber` of this isomorphism.
+
+## Main definitions
+
+* `translateSliceIso` — the container isomorphism
+  `toSlice (polyTranslate V P) ≅ SlicePFunctor.translate V.hom (toSlice P)`.
+* `polyFreeMSliceEquiv` — the fiberwise equivalence
+  `PolyFreeM V P x ≃ SlicePFunctor.FreeM V.hom (toSlice P) x`.
+
+## References
+
+N. Gambino and J. Kock, "Polynomial functors and polynomial monads",
+Mathematical Proceedings of the Cambridge Philosophical Society 154 (2013)
+153-192, DOI `10.1017/S0305004112000394`.
+
+M. Abbott, T. Altenkirch, N. Ghani, "Containers: Constructing strictly
+positive types", Theoretical Computer Science 342 (2005) 3-27, DOI
+`10.1016/j.tcs.2005.06.002`.
+
+## Tags
+
+free monad, W-type, initial algebra, container, slice category, PFunctor,
+polynomial functor
+-/
+
+namespace GebLean.PolyBridge
+
+open CategoryTheory
+
+universe u
+
+/-- The container isomorphism identifying the translation of the legacy
+translate polynomial `polyTranslate V P` with the slice augmentation
+`SlicePFunctor.translate V.hom (toSlice P)`. The shape equivalence distributes
+the sigma of the augmented index over its coproduct via `Equiv.sigmaSumDistrib`
+and contracts the leaf summand `Σ x, { a // V.hom a = x }` to `V.left` via
+`Equiv.sigmaFiberEquiv V.hom`. Positions coincide at every shape (empty at
+leaves, `P`'s positions at nodes); the shape-output map agrees by the leaf's
+fiber witness at leaf shapes and definitionally at nodes; the direction-input
+map agrees vacuously at leaves and definitionally at nodes. -/
+def translateSliceIso {X : Type u} (V : Over X) (P : PolyEndo X) :
+    SlicePFunctor.Iso (toSlice (polyTranslate V P))
+      (SlicePFunctor.translate V.hom (toSlice P)) where
+  shapeEquiv :=
+    (Equiv.sigmaSumDistrib (fun x => { a : V.left // V.hom a = x })
+        (fun x => polyBetweenIndex X X P x)).trans
+      (Equiv.sumCongr (Equiv.sigmaFiberEquiv V.hom) (Equiv.refl _))
+  posEquiv := fun a => match a with
+    | ⟨_, Sum.inl _⟩ => Equiv.refl _
+    | ⟨_, Sum.inr _⟩ => Equiv.refl _
+  q_comm := fun a => match a with
+    | ⟨_, Sum.inl ⟨_, hv⟩⟩ => hv
+    | ⟨_, Sum.inr _⟩ => rfl
+  r_comm := fun a b => match a, b with
+    | ⟨_, Sum.inl _⟩, b => b.elim
+    | ⟨_, Sum.inr _⟩, _ => rfl
+
+/-- The fiberwise equivalence between the legacy free monad `PolyFreeM V P x`
+and the slice free monad `SlicePFunctor.FreeM V.hom (toSlice P) x`. It composes
+the initial-algebra comparison `polyFixSliceEquiv` for the translate polynomial
+with the W-type transport `Iso.wEquivFiber` of `translateSliceIso`. -/
+def polyFreeMSliceEquiv {X : Type u} (V : Over X) (P : PolyEndo X) (x : X) :
+    PolyFreeM V P x ≃ SlicePFunctor.FreeM V.hom (toSlice P) x :=
+  (polyFixSliceEquiv (polyTranslate V P) x).trans ((translateSliceIso V P).wEquivFiber x)
+
+end GebLean.PolyBridge

--- a/geb-lean/GebLean/Ramified/Polynomial.lean
+++ b/geb-lean/GebLean/Ramified/Polynomial.lean
@@ -1,5 +1,6 @@
 import GebLean.Ramified.Polynomial.FreeAlg
 import GebLean.Ramified.Polynomial.RType
+import GebLean.Ramified.Polynomial.Term
 
 /-!
 # Ramified recurrence on the vendored polynomial-functor stack

--- a/geb-lean/GebLean/Ramified/Polynomial/Term.lean
+++ b/geb-lean/GebLean/Ramified/Polynomial/Term.lean
@@ -1,3 +1,4 @@
+import GebLean.PolyBridge.FreeMEquiv
 import GebLean.PolyBridge.Slice
 import GebLean.Ramified.Term
 import GebLean.SliceW.FreeM
@@ -15,7 +16,9 @@ right-unit and associativity laws, mirroring the legacy proofs with
 `SlicePFunctor.FreeM.bind_pure`, `SlicePFunctor.FreeM.bind_assoc`,
 `SlicePFunctor.FreeM.pure_transport`, and `SlicePFunctor.FreeM.bind_transport`
 in place of the legacy `polyFreeM_bind_pure`, `polyFreeM_bind_assoc`,
-`polyFreeMPure_transport`, and `polyFreeMBind_transport`.
+`polyFreeMPure_transport`, and `polyFreeMBind_transport`. The bridge equivalence
+`tmSliceEquiv` relates this realization to the legacy `Tm` layer, carrying
+`var`, `op`, and `subst` across it.
 
 ## Main definitions
 
@@ -27,6 +30,8 @@ in place of the legacy `polyFreeM_bind_pure`, `polyFreeM_bind_assoc`,
 * `Tm'.subst` — simultaneous substitution (the slice free monad's `bind`).
 * `Tm'.reind` — reindexing of a term along an equality of its sort.
 * `Tm'.weaken` — substitution along a sort-preserving variable renaming.
+* `tmSliceEquiv` — the bridge equivalence `Tm' sig Γ s ≃ Tm sig Γ s`,
+  inverting `polyFreeMSliceEquiv` at the context's variable family.
 
 ## Main statements
 
@@ -35,6 +40,12 @@ in place of the legacy `polyFreeM_bind_pure`, `polyFreeM_bind_assoc`,
 * `Tm'.var_subst` — substituting a variable by a tuple selects that tuple
   entry.
 * `Tm'.subst_reind` — substitution commutes with reindexing.
+* `tmSliceEquiv_var` — the bridge equivalence carries a primed variable term to
+  the legacy `Tm.var`.
+* `tmSliceEquiv_op` — the bridge equivalence carries a primed operation term to
+  the legacy `Tm.op` with arguments mapped through the equivalence.
+* `tmSliceEquiv_subst` — the bridge equivalence intertwines primed substitution
+  with legacy `Tm.subst`.
 
 ## References
 
@@ -151,5 +162,57 @@ def Tm'.weaken {sig : SortedSig S} {Γ Δ : Ctx S} {s : S}
     (f : Fin Γ.length → Fin Δ.length) (h : ∀ i, Δ.get (f i) = Γ.get i)
     (t : Tm' sig Γ s) : Tm' sig Δ s :=
   t.subst (fun i => Tm'.reind (h i) (Tm'.var (f i)))
+
+/-- The bridge equivalence between the primed term layer `Tm' sig Γ s` and the
+legacy term layer `Tm sig Γ s` (`GebLean/Ramified/Term.lean`): the free-monad
+equivalence `polyFreeMSliceEquiv` (`GebLean/PolyBridge/FreeMEquiv.lean`) at the
+context's variable family `varOver Γ` and the signature endofunctor
+`sig.polyEndo`, inverted so that the primed carrier reads as the source. The
+target reads by `(varOver Γ).hom = Γ.get` definitionally. -/
+def tmSliceEquiv {sig : SortedSig S} (Γ : Ctx S) (s : S) : Tm' sig Γ s ≃ Tm sig Γ s :=
+  (polyFreeMSliceEquiv (varOver Γ) sig.polyEndo s).symm
+
+/-- The bridge equivalence carries a primed variable term `Tm'.var i` to the
+legacy variable term `Tm.var i`: the leaf-naturality of `polyFreeMSliceEquiv`
+(`polyFreeMSliceEquiv_pure`) re-read across the inverting `.symm`. -/
+theorem tmSliceEquiv_var {sig : SortedSig S} {Γ : Ctx S} (i : Fin Γ.length) :
+    tmSliceEquiv Γ _ (Tm'.var (sig := sig) i) = Tm.var (sig := sig) i := by
+  have h := polyFreeMSliceEquiv_pure (varOver Γ) sig.polyEndo (Γ.get i) ⟨i, rfl⟩
+  exact ((polyFreeMSliceEquiv (varOver Γ) sig.polyEndo (Γ.get i)).symm_apply_eq).mpr h.symm
+
+/-- The bridge equivalence carries a primed operation term `Tm'.op o args` to
+the legacy operation term `Tm.op o` whose arguments are the images of `args`:
+the node-naturality of `polyFreeMSliceEquiv` (`polyFreeMSliceEquiv_node`) re-read
+across the inverting `.symm`. -/
+theorem tmSliceEquiv_op {sig : SortedSig S} {Γ : Ctx S} (o : sig.Op)
+    (args : ∀ i : Fin (sig.arity o).length, Tm' sig Γ ((sig.arity o).get i)) :
+    tmSliceEquiv Γ _ (Tm'.op o args) = Tm.op o (fun i => tmSliceEquiv Γ _ (args i)) := by
+  refine ((polyFreeMSliceEquiv (varOver Γ) sig.polyEndo (sig.result o)).symm_apply_eq).mpr ?_
+  refine Eq.trans ?_ (polyFreeMSliceEquiv_node (varOver Γ) sig.polyEndo (sig.result o)
+    ⟨o, rfl⟩ (fun i => tmSliceEquiv Γ _ (args i))).symm
+  exact congrArg
+    (FreeM.node (F := toSlice sig.polyEndo) (v := (varOver Γ).hom) ⟨sig.result o, ⟨o, rfl⟩⟩)
+    (funext fun i => (Equiv.apply_symm_apply _ _).symm)
+
+/-- The bridge equivalence intertwines primed substitution `Tm'.subst` with
+legacy substitution `Tm.subst`: the bind-naturality of `polyFreeMSliceEquiv`
+(`polyFreeMSliceEquiv_bind`) re-read across the inverting `.symm`, commuting the
+leaf transport past the equivalence with `polyFreeMSliceEquiv_transport`. -/
+theorem tmSliceEquiv_subst {sig : SortedSig S} {Γ Δ : Ctx S} {s : S}
+    (t : Tm' sig Γ s) (σ : ∀ i : Fin Γ.length, Tm' sig Δ (Γ.get i)) :
+    tmSliceEquiv Δ _ (t.subst σ) =
+      (tmSliceEquiv Γ _ t).subst (fun i => tmSliceEquiv Δ _ (σ i)) := by
+  refine ((polyFreeMSliceEquiv (varOver Δ) sig.polyEndo s).symm_apply_eq).mpr ?_
+  refine Eq.trans ?_ (polyFreeMSliceEquiv_bind (varOver Γ) (varOver Δ) sig.polyEndo s
+    ((polyFreeMSliceEquiv (varOver Γ) sig.polyEndo s).symm t)
+    (fun _ a => a.2 ▸ tmSliceEquiv Δ _ (σ a.1))).symm
+  rw [Equiv.apply_symm_apply]
+  unfold Tm'.subst
+  congr 1
+  funext y a
+  have hcomm := polyFreeMSliceEquiv_transport (varOver Δ) sig.polyEndo a.2
+    ((polyFreeMSliceEquiv (varOver Δ) sig.polyEndo (Γ.get a.1)).symm (σ a.1))
+  rw [Equiv.apply_symm_apply] at hcomm
+  exact hcomm.symm
 
 end GebLean.Ramified.Polynomial

--- a/geb-lean/GebLean/Ramified/Polynomial/Term.lean
+++ b/geb-lean/GebLean/Ramified/Polynomial/Term.lean
@@ -1,0 +1,155 @@
+import GebLean.PolyBridge.Slice
+import GebLean.Ramified.Term
+import GebLean.SliceW.FreeM
+
+/-!
+# The sorted term layer on the slice free monad
+
+A second realization of the sorted term layer with clone laws
+(`GebLean/Ramified/Term.lean`) on the vendored `geb-mathlib` slice free monad
+`SlicePFunctor.FreeM` (`GebLean/SliceW/FreeM.lean`) rather than the legacy
+`PolyFreeM`. `Tm' sig Γ` is `SlicePFunctor.FreeM Γ.get (toSlice sig.polyEndo)`;
+`Tm'.subst` is the slice free monad's `bind`; and the clone laws
+`Tm'.subst_id` and `Tm'.subst_subst` are thin instances of `bind`'s
+right-unit and associativity laws, mirroring the legacy proofs with
+`SlicePFunctor.FreeM.bind_pure`, `SlicePFunctor.FreeM.bind_assoc`,
+`SlicePFunctor.FreeM.pure_transport`, and `SlicePFunctor.FreeM.bind_transport`
+in place of the legacy `polyFreeM_bind_pure`, `polyFreeM_bind_assoc`,
+`polyFreeMPure_transport`, and `polyFreeMBind_transport`.
+
+## Main definitions
+
+* `Tm'` — terms over a signature in a context, indexed by their sort: the
+  slice free monad of `toSlice sig.polyEndo` at the context's variable
+  family `Γ.get`.
+* `Tm'.var` — a variable term (the slice free monad's `pure` at a position).
+* `Tm'.op` — an operation applied to argument terms (a `FreeM.node`).
+* `Tm'.subst` — simultaneous substitution (the slice free monad's `bind`).
+* `Tm'.reind` — reindexing of a term along an equality of its sort.
+* `Tm'.weaken` — substitution along a sort-preserving variable renaming.
+
+## Main statements
+
+* `Tm'.subst_id` — substitution by the variable tuple is the identity.
+* `Tm'.subst_subst` — substitution composes.
+* `Tm'.var_subst` — substituting a variable by a tuple selects that tuple
+  entry.
+* `Tm'.subst_reind` — substitution commutes with reindexing.
+
+## References
+
+The free-algebra conventions realized here follow D. Leivant, "Ramified
+recurrence and computational complexity III: Higher type recurrence and
+elementary complexity", Annals of Pure and Applied Logic 96 (1999) 209-229,
+DOI `10.1016/S0168-0072(98)00040-2`, section 2.1, transcribed by the legacy
+`GebLean/Ramified/Term.lean`.
+
+## Tags
+
+ramified recurrence, sorted term, substitution, clone laws, free monad,
+polynomial functor, slice category
+-/
+
+namespace GebLean.Ramified.Polynomial
+
+open GebLean.Ramified GebLean.PolyBridge SlicePFunctor
+
+variable {S : Type}
+
+/-- Terms over a signature `sig` in a context `Γ`, indexed by their sort: the
+slice free monad of `toSlice sig.polyEndo` at the context's variable family
+`Γ.get`. A second realization of `Tm sig Γ` (`GebLean/Ramified/Term.lean`),
+consuming the slice free monad (`GebLean/SliceW/FreeM.lean`) rather than
+`PolyFreeM`. -/
+def Tm' (sig : SortedSig S) (Γ : Ctx S) : S → Type :=
+  FreeM Γ.get (toSlice sig.polyEndo)
+
+/-- A variable term: the position `i` of `Γ`, as the slice free monad's `pure`
+at that position's fiber element. Its sort is `Γ.get i`. -/
+def Tm'.var {sig : SortedSig S} {Γ : Ctx S} (i : Fin Γ.length) :
+    Tm' sig Γ (Γ.get i) :=
+  FreeM.pure ⟨i, rfl⟩
+
+/-- An operation `o` applied to a tuple of argument terms, at the operation's
+result sort: the slice free monad's `node` at the shape `⟨sig.result o,
+⟨o, rfl⟩⟩` of `toSlice sig.polyEndo`, whose directions are the arity
+positions. -/
+def Tm'.op {sig : SortedSig S} {Γ : Ctx S} (o : sig.Op)
+    (args : ∀ i : Fin (sig.arity o).length, Tm' sig Γ ((sig.arity o).get i)) :
+    Tm' sig Γ (sig.result o) :=
+  FreeM.node (F := toSlice sig.polyEndo) ⟨sig.result o, ⟨o, rfl⟩⟩ args
+
+/-- Simultaneous substitution: replace each variable of `t` by the
+corresponding term of the tuple `σ`. Realized as the slice free monad's
+`bind`, reading `σ` as a map of the source variable family into terms over
+the target context; the leaf function transports each `σ i` along the fiber
+equality of the variable being replaced. -/
+def Tm'.subst {sig : SortedSig S} {Γ Δ : Ctx S} {s : S}
+    (t : Tm' sig Γ s) (σ : ∀ i : Fin Γ.length, Tm' sig Δ (Γ.get i)) :
+    Tm' sig Δ s :=
+  t.bind (fun _ a => a.2 ▸ σ a.1)
+
+/-- Substitution by the variable tuple is the identity (the right-unit clone
+law). An instance of the slice free monad's right-unit law
+`SlicePFunctor.FreeM.bind_pure`, after identifying the transported variable
+tuple with the monad's `pure`; mirrors the legacy `Tm.subst_id`
+(`GebLean/Ramified/Term.lean`). -/
+theorem Tm'.subst_id {sig : SortedSig S} {Γ : Ctx S} {s : S} (t : Tm' sig Γ s) :
+    t.subst Tm'.var = t := by
+  unfold Tm'.subst
+  refine Eq.trans ?_ (FreeM.bind_pure t)
+  congr 1
+  funext y a
+  obtain ⟨v, hv⟩ := a
+  exact FreeM.pure_transport hv v rfl
+
+/-- Substitution composes: substituting by `σ` then `τ` equals substituting by
+the pointwise composite (the associativity clone law). An instance of the
+slice free monad's associativity law `SlicePFunctor.FreeM.bind_assoc`, using
+`SlicePFunctor.FreeM.bind_transport` to move the transport past the inner
+bind; mirrors the legacy `Tm.subst_subst` (`GebLean/Ramified/Term.lean`). -/
+theorem Tm'.subst_subst {sig : SortedSig S} {Γ Δ E : Ctx S} {s : S}
+    (t : Tm' sig Γ s) (σ : ∀ i : Fin Γ.length, Tm' sig Δ (Γ.get i))
+    (τ : ∀ i : Fin Δ.length, Tm' sig E (Δ.get i)) :
+    (t.subst σ).subst τ = t.subst (fun i => (σ i).subst τ) := by
+  unfold Tm'.subst
+  rw [FreeM.bind_assoc]
+  congr 1
+  funext y a
+  exact FreeM.bind_transport a.2 (σ a.1) _
+
+/-- Substituting a variable term by a tuple selects that tuple's entry at the
+variable's position (the free monad's left-unit law
+`SlicePFunctor.FreeM.pure_bind`; the transport at `rfl` vanishes
+definitionally). -/
+theorem Tm'.var_subst {sig : SortedSig S} {Γ Δ : Ctx S}
+    (i : Fin Γ.length) (σ : ∀ j : Fin Γ.length, Tm' sig Δ (Γ.get j)) :
+    (Tm'.var i).subst σ = σ i := by
+  unfold Tm'.subst Tm'.var
+  rw [FreeM.pure_bind]
+
+/-- Reindex a term along an equality of its sort. -/
+def Tm'.reind {sig : SortedSig S} {Γ : Ctx S} {a b : S} (h : a = b)
+    (t : Tm' sig Γ a) : Tm' sig Γ b := h ▸ t
+
+/-- Reindexing along `rfl` is the identity. -/
+@[simp] theorem Tm'.reind_rfl {sig : SortedSig S} {Γ : Ctx S} {a : S}
+    (t : Tm' sig Γ a) : Tm'.reind rfl t = t := rfl
+
+/-- Substitution commutes with reindexing of its input term. -/
+theorem Tm'.subst_reind {sig : SortedSig S} {Γ Δ : Ctx S} {a b : S}
+    (h : a = b) (t : Tm' sig Γ a)
+    (σ : ∀ j : Fin Γ.length, Tm' sig Δ (Γ.get j)) :
+    (Tm'.reind h t).subst σ = Tm'.reind h (t.subst σ) := by
+  subst h; rfl
+
+/-- Weakening along a sort-preserving variable renaming `f`: substitution at
+the variable tuple that sends position `i` to the variable `f i`, transported
+along the sort equality `h`. A special case of `Tm'.subst`
+(variable-to-variable substitution). -/
+def Tm'.weaken {sig : SortedSig S} {Γ Δ : Ctx S} {s : S}
+    (f : Fin Γ.length → Fin Δ.length) (h : ∀ i, Δ.get (f i) = Γ.get i)
+    (t : Tm' sig Γ s) : Tm' sig Δ s :=
+  t.subst (fun i => Tm'.reind (h i) (Tm'.var (f i)))
+
+end GebLean.Ramified.Polynomial

--- a/geb-lean/GebLean/SliceW.lean
+++ b/geb-lean/GebLean/SliceW.lean
@@ -1,4 +1,5 @@
 import GebLean.SliceW.Iso
+import GebLean.SliceW.Translate
 
 /-!
 # Native free-monad layer on the slice W-type
@@ -7,4 +8,6 @@ Directory index for the native development on the vendored slice W-type
 (`Geb.Mathlib.Data.PFunctor.Slice.W`), independent of the polynomial-algebra
 and ramified layers. `Iso` supplies container isomorphisms of slice
 endofunctors and the equivalence they induce on the associated W-types.
+`Translate` supplies the free-monad augmentation `Y + F(-)` of a slice
+endofunctor.
 -/

--- a/geb-lean/GebLean/SliceW.lean
+++ b/geb-lean/GebLean/SliceW.lean
@@ -1,3 +1,4 @@
+import GebLean.SliceW.FreeM
 import GebLean.SliceW.Iso
 import GebLean.SliceW.Translate
 
@@ -9,5 +10,6 @@ Directory index for the native development on the vendored slice W-type
 and ramified layers. `Iso` supplies container isomorphisms of slice
 endofunctors and the equivalence they induce on the associated W-types.
 `Translate` supplies the free-monad augmentation `Y + F(-)` of a slice
-endofunctor.
+endofunctor. `FreeM` supplies the free monad's carrier and constructors as
+the fibers and node shapes of the translate augmentation's W-type.
 -/

--- a/geb-lean/GebLean/SliceW.lean
+++ b/geb-lean/GebLean/SliceW.lean
@@ -1,0 +1,10 @@
+import GebLean.SliceW.Iso
+
+/-!
+# Native free-monad layer on the slice W-type
+
+Directory index for the native development on the vendored slice W-type
+(`Geb.Mathlib.Data.PFunctor.Slice.W`), independent of the polynomial-algebra
+and ramified layers. `Iso` supplies container isomorphisms of slice
+endofunctors and the equivalence they induce on the associated W-types.
+-/

--- a/geb-lean/GebLean/SliceW/FreeM.lean
+++ b/geb-lean/GebLean/SliceW/FreeM.lean
@@ -18,12 +18,19 @@ fiber. `FreeM v F i` is that fiber; `pure` and `node` are the two shapes of
   over `i`.
 * `SlicePFunctor.FreeM.node` — the node constructor, from an `F`-shape and a
   family of subtrees indexed by its positions.
+* `SlicePFunctor.FreeM.bindW` — the grafting substitution on the underlying
+  `translate`-trees: a single `W.elim` replacing each leaf by its substitute.
+* `SlicePFunctor.FreeM.bind` — the free-monad bind, `bindW` on the underlying
+  tree with the index-preservation witness.
 
 ## Main statements
 
 * `SlicePFunctor.FreeM.val_pure` / `SlicePFunctor.FreeM.val_node` — the
   underlying-tree characterization of `pure` and `node`, as `W.mk` on the
   corresponding summand of `translate v F`.
+* `SlicePFunctor.FreeM.pure_bind` / `SlicePFunctor.FreeM.bind_node` — the
+  computation rules for `bind`: the left-unit law on `pure`, and recursion into
+  children on `node`.
 
 ## References
 
@@ -39,9 +46,10 @@ container, PFunctor
 
 namespace SlicePFunctor
 
-universe uY uA uB uI
+universe uY uY' uA uB uI
 
-variable {I : Type uI} {Y : Type uY} {v : Y → I} {F : SlicePFunctor.{uA, uB, uI, uI} I I}
+variable {I : Type uI} {Y : Type uY} {Y' : Type uY'} {v : Y → I} {v' : Y' → I}
+variable {F : SlicePFunctor.{uA, uB, uI, uI} I I}
 
 /-- The free-monad carrier at `i`: the fiber of `(translate v F).wIndex` over
 `i`, i.e. the `translate v F`-trees indexed at `i`. -/
@@ -81,6 +89,48 @@ theorem val_node (a : F.A) (c : (b : F.B a) → FreeM v F (F.rCurried a b)) :
     (node a c).1 = W.mk (F := translate v F) ⟨⟨Sum.inr a, fun b => (c b).1⟩,
       ((translate v F).toSliceDomPFunctor.compatible_iff _ _ _).mpr fun b => (c b).2⟩ :=
   rfl
+
+/-- The grafting substitution on `translate v F`-trees underlying `bind`: a
+single `W.elim` into `(translate v' F).W`. A leaf `Sum.inl y` is replaced by
+the underlying tree of the substitute `f (v y) ⟨y, rfl⟩`; a node `Sum.inr a` is
+rebuilt with the same shape and already-substituted children, its compatibility
+re-read for `translate v' F` (whose positions and direction-input map agree
+with those of `translate v F` at `Sum.inr`). -/
+def bindW (f : ∀ j, { a : Y // v a = j } → FreeM v' F j) :
+    (translate v F).W → (translate v' F).W :=
+  W.elim (translate v F) ((translate v' F).W) (translate v' F).wIndex
+    (fun z => match z with
+      | ⟨⟨Sum.inl y, _⟩, _⟩ => (f (v y) ⟨y, rfl⟩).1
+      | ⟨⟨Sum.inr a, c⟩, hc⟩ =>
+          W.mk (F := translate v' F) ⟨⟨Sum.inr a, c⟩,
+            ((translate v' F).toSliceDomPFunctor.compatible_iff _ _ _).mpr
+              (((translate v F).toSliceDomPFunctor.compatible_iff _ _ _).mp hc)⟩)
+    (funext fun z => match z with
+      | ⟨⟨Sum.inl y, _⟩, _⟩ => (f (v y) ⟨y, rfl⟩).2
+      | ⟨⟨Sum.inr _, _⟩, _⟩ => rfl)
+
+/-- The free-monad bind: substitute along `f` into the tree `t`. The index is
+preserved, since both the leaf substitutes and the rebuilt nodes lie over the
+same index as the shape they replace. -/
+def bind {i : I} (t : FreeM v F i)
+    (f : ∀ j, { a : Y // v a = j } → FreeM v' F j) : FreeM v' F i :=
+  ⟨bindW f t.1,
+    (congrFun (W.comp_elim (translate v F) ((translate v' F).W)
+      (translate v' F).wIndex _ _) t.1).trans t.2⟩
+
+/-- Left unit: binding a leaf `pure a` applies the substitution `f` at `a`. -/
+theorem pure_bind {i : I} (a : { y : Y // v y = i })
+    (f : ∀ j, { a : Y // v a = j } → FreeM v' F j) :
+    (FreeM.pure a).bind f = f i a := by
+  obtain ⟨y, hy⟩ := a
+  subst hy
+  exact Subtype.ext rfl
+
+/-- Binding commutes with `node`: it recurses into each child. -/
+theorem bind_node (a : F.A) (c : (b : F.B a) → FreeM v F (F.rCurried a b))
+    (f : ∀ j, { a : Y // v a = j } → FreeM v' F j) :
+    (FreeM.node a c).bind f = FreeM.node a (fun b => (c b).bind f) :=
+  Subtype.ext rfl
 
 end FreeM
 

--- a/geb-lean/GebLean/SliceW/FreeM.lean
+++ b/geb-lean/GebLean/SliceW/FreeM.lean
@@ -1,0 +1,87 @@
+import Geb.Mathlib.Data.PFunctor.Slice.W
+import GebLean.SliceW.Translate
+
+/-!
+# The free-monad carrier and constructors on a slice endofunctor
+
+The free monad on a slice endofunctor `F` over `I`, with leaves `Y` glued in
+along `v : Y → I`, is the W-type of the translate augmentation
+`translate v F` (Gambino–Kock 2013), restricted to a fixed index `i` by its
+fiber. `FreeM v F i` is that fiber; `pure` and `node` are the two shapes of
+`translate v F` read back as the free monad's leaf and node constructors.
+
+## Main definitions
+
+* `SlicePFunctor.FreeM` — the free-monad carrier: the fiber of
+  `(translate v F).wIndex` over `i`.
+* `SlicePFunctor.FreeM.pure` — the leaf constructor, from a leaf datum lying
+  over `i`.
+* `SlicePFunctor.FreeM.node` — the node constructor, from an `F`-shape and a
+  family of subtrees indexed by its positions.
+
+## Main statements
+
+* `SlicePFunctor.FreeM.val_pure` / `SlicePFunctor.FreeM.val_node` — the
+  underlying-tree characterization of `pure` and `node`, as `W.mk` on the
+  corresponding summand of `translate v F`.
+
+## References
+
+N. Gambino and J. Kock, "Polynomial functors and polynomial monads",
+Mathematical Proceedings of the Cambridge Philosophical Society 154 (2013)
+153-192, DOI `10.1017/S0305004112000394`.
+
+## Tags
+
+free monad, W-type, initial algebra, polynomial functor, slice category,
+container, PFunctor
+-/
+
+namespace SlicePFunctor
+
+universe uY uA uB uI
+
+variable {I : Type uI} {Y : Type uY} {v : Y → I} {F : SlicePFunctor.{uA, uB, uI, uI} I I}
+
+/-- The free-monad carrier at `i`: the fiber of `(translate v F).wIndex` over
+`i`, i.e. the `translate v F`-trees indexed at `i`. -/
+def FreeM (v : Y → I) (F : SlicePFunctor.{uA, uB, uI, uI} I I) (i : I) :=
+  { w : (translate v F).W // (translate v F).wIndex w = i }
+
+namespace FreeM
+
+/-- The leaf constructor: a leaf datum `a` lying over `i` (i.e. `v a.1 = i`)
+gives the nullary `Sum.inl` node of `translate v F`. -/
+def pure {i : I} (a : { y : Y // v y = i }) : FreeM v F i :=
+  ⟨W.mk ⟨⟨Sum.inl a.1, fun e => e.elim⟩, funext fun e => e.elim⟩, by
+    rw [W.wIndex_mk]
+    exact a.2⟩
+
+/-- The node constructor: an `F`-shape `a` together with a family of subtrees
+`c`, one per position of `a`, each lying over the direction-input map's value
+at that position, gives the `Sum.inr` node of `translate v F`. -/
+def node (a : F.A) (c : (b : F.B a) → FreeM v F (F.rCurried a b)) : FreeM v F (F.q a) :=
+  ⟨W.mk ⟨⟨Sum.inr a, fun b => (c b).1⟩,
+      (SliceDomPFunctor.compatible_iff _ _ _ _).mpr fun b => (c b).2⟩, by
+    rw [W.wIndex_mk]
+    exact translate_q_inr a⟩
+
+/-- The underlying tree of `pure a` is the `Sum.inl` node of `translate v F`
+at `a.1`, with vacuous (`PEmpty`) children. -/
+@[simp]
+theorem val_pure {i : I} (a : { y : Y // v y = i }) :
+    (pure a).1 = W.mk (F := translate v F) ⟨⟨Sum.inl a.1, fun e => e.elim⟩,
+      funext fun e => e.elim⟩ :=
+  rfl
+
+/-- The underlying tree of `node a c` is the `Sum.inr` node of `translate v F`
+at `a`, with children `c` reduced to their underlying trees. -/
+@[simp]
+theorem val_node (a : F.A) (c : (b : F.B a) → FreeM v F (F.rCurried a b)) :
+    (node a c).1 = W.mk (F := translate v F) ⟨⟨Sum.inr a, fun b => (c b).1⟩,
+      (SliceDomPFunctor.compatible_iff _ _ _ _).mpr fun b => (c b).2⟩ :=
+  rfl
+
+end FreeM
+
+end SlicePFunctor

--- a/geb-lean/GebLean/SliceW/FreeM.lean
+++ b/geb-lean/GebLean/SliceW/FreeM.lean
@@ -31,6 +31,12 @@ fiber. `FreeM v F i` is that fiber; `pure` and `node` are the two shapes of
 * `SlicePFunctor.FreeM.pure_bind` / `SlicePFunctor.FreeM.bind_node` — the
   computation rules for `bind`: the left-unit law on `pure`, and recursion into
   children on `node`.
+* `SlicePFunctor.FreeM.bindW_pure` / `SlicePFunctor.FreeM.bind_pure` — the
+  right-unit law, at the underlying-tree level and wrapped for `bind`.
+* `SlicePFunctor.FreeM.bindW_bindW` / `SlicePFunctor.FreeM.bind_assoc` — the
+  associativity law, at the underlying-tree level and wrapped for `bind`.
+* `SlicePFunctor.FreeM.pure_transport` / `SlicePFunctor.FreeM.bind_transport` —
+  compatibility of index transport with `pure` and `bind`.
 
 ## References
 
@@ -46,9 +52,10 @@ container, PFunctor
 
 namespace SlicePFunctor
 
-universe uY uY' uA uB uI
+universe uY uY' uY'' uA uB uI
 
-variable {I : Type uI} {Y : Type uY} {Y' : Type uY'} {v : Y → I} {v' : Y' → I}
+variable {I : Type uI} {Y : Type uY} {Y' : Type uY'} {Y'' : Type uY''}
+variable {v : Y → I} {v' : Y' → I} {v'' : Y'' → I}
 variable {F : SlicePFunctor.{uA, uB, uI, uI} I I}
 
 /-- The free-monad carrier at `i`: the fiber of `(translate v F).wIndex` over
@@ -131,6 +138,72 @@ theorem bind_node (a : F.A) (c : (b : F.B a) → FreeM v F (F.rCurried a b))
     (f : ∀ j, { a : Y // v a = j } → FreeM v' F j) :
     (FreeM.node a c).bind f = FreeM.node a (fun b => (c b).bind f) :=
   Subtype.ext rfl
+
+/-- Right unit at the tree level: grafting each leaf to its own `pure` is the
+identity on `translate v F`-trees. Structural induction with a `Sum` shape
+split; the leaf branch collapses to the `pure` tree (children into `PEmpty`
+agree by elimination) and the node branch recurses through the hypotheses. -/
+theorem bindW_pure (z : (translate v F).W) :
+    bindW (fun _ a => FreeM.pure a) z = z :=
+  W.induction (F := translate v F)
+    (motive := fun z => bindW (fun _ a => FreeM.pure a) z = z)
+    (fun x ih => by
+      obtain ⟨⟨a, c⟩, hc⟩ := x
+      cases a with
+      | inl y =>
+          exact congrArg W.mk
+            (Subtype.ext (Sigma.ext rfl (heq_of_eq (funext fun e => e.elim))))
+      | inr a' =>
+          exact congrArg W.mk
+            (Subtype.ext (Sigma.ext rfl (heq_of_eq (funext fun b => ih b)))))
+    z
+
+/-- Right unit: binding a tree with the identity substitution returns it. -/
+theorem bind_pure {i : I} (t : FreeM v F i) :
+    t.bind (fun _ a => FreeM.pure a) = t :=
+  Subtype.ext (bindW_pure t.1)
+
+/-- Associativity at the tree level: grafting along `f` then `g` equals grafting
+along the pointwise composite `fun j a => (f j a).bind g`. Structural induction
+with a `Sum` shape split; the leaf branch reduces both sides to
+`((f (v y) ⟨y, rfl⟩).bind g).1` and the node branch recurses through the
+hypotheses. -/
+theorem bindW_bindW (f : ∀ j, { a : Y // v a = j } → FreeM v' F j)
+    (g : ∀ j, { b : Y' // v' b = j } → FreeM v'' F j) (z : (translate v F).W) :
+    bindW g (bindW f z) = bindW (fun j a => (f j a).bind g) z :=
+  W.induction (F := translate v F)
+    (motive := fun z => bindW g (bindW f z) = bindW (fun j a => (f j a).bind g) z)
+    (fun x ih => by
+      obtain ⟨⟨a, c⟩, hc⟩ := x
+      cases a with
+      | inl y => rfl
+      | inr a' =>
+          exact congrArg W.mk
+            (Subtype.ext (Sigma.ext rfl (heq_of_eq (funext fun b => ih b)))))
+    z
+
+/-- Associativity: rebinding `t` along `f` then `g` factors through the
+pointwise composite. -/
+theorem bind_assoc {i : I} (t : FreeM v F i)
+    (f : ∀ j, { a : Y // v a = j } → FreeM v' F j)
+    (g : ∀ j, { b : Y' // v' b = j } → FreeM v'' F j) :
+    (t.bind f).bind g = t.bind (fun j a => (f j a).bind g) :=
+  Subtype.ext (bindW_bindW f g t.1)
+
+/-- Transporting a `pure` leaf along an index equality re-reads its fiber
+witness: it is the `pure` of the same datum lying over the target index. -/
+theorem pure_transport {i i' : I} (h : i = i') (y : Y) (hy : v y = i) :
+    h ▸ (FreeM.pure ⟨y, hy⟩ : FreeM v F i) = FreeM.pure ⟨y, hy.trans h⟩ := by
+  subst h
+  rfl
+
+/-- Transport commutes with `bind`: binding a transported tree equals
+transporting the bind. -/
+theorem bind_transport {i i' : I} (h : i = i') (t : FreeM v F i)
+    (f : ∀ j, { a : Y // v a = j } → FreeM v' F j) :
+    (h ▸ t).bind f = h ▸ (t.bind f) := by
+  subst h
+  rfl
 
 end FreeM
 

--- a/geb-lean/GebLean/SliceW/FreeM.lean
+++ b/geb-lean/GebLean/SliceW/FreeM.lean
@@ -62,7 +62,7 @@ def pure {i : I} (a : { y : Y // v y = i }) : FreeM v F i :=
 at that position, gives the `Sum.inr` node of `translate v F`. -/
 def node (a : F.A) (c : (b : F.B a) → FreeM v F (F.rCurried a b)) : FreeM v F (F.q a) :=
   ⟨W.mk ⟨⟨Sum.inr a, fun b => (c b).1⟩,
-      (SliceDomPFunctor.compatible_iff _ _ _ _).mpr fun b => (c b).2⟩, by
+      ((translate v F).toSliceDomPFunctor.compatible_iff _ _ _).mpr fun b => (c b).2⟩, by
     rw [W.wIndex_mk]
     exact translate_q_inr a⟩
 
@@ -79,7 +79,7 @@ at `a`, with children `c` reduced to their underlying trees. -/
 @[simp]
 theorem val_node (a : F.A) (c : (b : F.B a) → FreeM v F (F.rCurried a b)) :
     (node a c).1 = W.mk (F := translate v F) ⟨⟨Sum.inr a, fun b => (c b).1⟩,
-      (SliceDomPFunctor.compatible_iff _ _ _ _).mpr fun b => (c b).2⟩ :=
+      ((translate v F).toSliceDomPFunctor.compatible_iff _ _ _).mpr fun b => (c b).2⟩ :=
   rfl
 
 end FreeM

--- a/geb-lean/GebLean/SliceW/Iso.lean
+++ b/geb-lean/GebLean/SliceW/Iso.lean
@@ -1,0 +1,216 @@
+import Geb.Mathlib.Data.PFunctor.Slice.W
+import Mathlib.Logic.Equiv.Defs
+
+/-!
+# Isomorphisms of slice polynomial functors and W-type transport
+
+An isomorphism `SlicePFunctor.Iso F G` of slice endofunctors over `I` is a
+container isomorphism: a shape equivalence `F.A ≃ G.A`, a fibrewise position
+equivalence `F.B a ≃ G.B (shapeEquiv a)`, and the compatibility of the
+shape-output and direction-input maps. Such an isomorphism induces an
+equivalence of the associated W-types (initial algebras), fibrewise over `I`.
+The transport `wMap` is a single slice-W eliminator; the inverse is the
+`wMap` of the reversed isomorphism, and the two round trips are structural
+inductions.
+
+## Main definitions
+
+* `SlicePFunctor.Iso` — the container isomorphism of slice endofunctors.
+* `SlicePFunctor.Iso.symm` — the reversed isomorphism.
+* `SlicePFunctor.Iso.wMap` — the induced map on W-types, by `W.elim`.
+* `SlicePFunctor.Iso.wEquiv` — the induced equivalence of W-types.
+* `SlicePFunctor.Iso.wEquivFiber` — the induced equivalence of W-type fibres
+  over a fixed index.
+
+## Main statements
+
+* `SlicePFunctor.Iso.wIndex_wMap` — `wMap` lies over `I`.
+* `SlicePFunctor.Iso.wMap_mk` — `wMap` is a morphism of constructors.
+* `SlicePFunctor.Iso.symm_wMap_wMap`, `SlicePFunctor.Iso.wMap_symm_wMap` — the
+  two round trips.
+
+## Implementation notes
+
+`symm`'s position field is the reversed forward equivalence composed with an
+`Equiv.cast` re-typing its domain along `shapeEquiv.apply_symm_apply`. The
+round trips therefore reduce, at each node, to transport identities for the
+position composites (`posEquiv_symm_comp` / `posEquiv_symm_comp'`), proved
+through the `HEq` helpers `posEquiv_heq_cast` and `symm_posEquiv_symm_heq`.
+
+## References
+
+M. Abbott, T. Altenkirch, N. Ghani, "Containers: Constructing strictly
+positive types", Theoretical Computer Science 342 (2005) 3-27, DOI
+`10.1016/j.tcs.2005.06.002`.
+
+N. Gambino and J. Kock, "Polynomial functors and polynomial monads",
+Mathematical Proceedings of the Cambridge Philosophical Society 154 (2013)
+153-192, DOI `10.1017/S0305004112000394`.
+
+## Tags
+
+polynomial functor, W-type, initial algebra, container, isomorphism, slice
+category, PFunctor
+-/
+
+namespace SlicePFunctor
+
+universe uA uB uI
+
+/-- A container isomorphism of slice endofunctors over `I`: a shape
+equivalence, a fibrewise position equivalence, and the compatibility of the
+shape-output map `q` and the direction-input map `r`. -/
+structure Iso {I : Type uI} (F G : SlicePFunctor.{uA, uB, uI, uI} I I) where
+  /-- The equivalence of shapes. -/
+  shapeEquiv : F.A ≃ G.A
+  /-- The fibrewise equivalence of positions, over each shape. -/
+  posEquiv : ∀ a, F.B a ≃ G.B (shapeEquiv a)
+  /-- The shape-output maps agree along the shape equivalence. -/
+  q_comm : ∀ a, G.q (shapeEquiv a) = F.q a
+  /-- The direction-input maps agree along the shape and position
+  equivalences. -/
+  r_comm : ∀ a b, G.r ⟨shapeEquiv a, posEquiv a b⟩ = F.r ⟨a, b⟩
+
+namespace Iso
+
+variable {I : Type uI} {F G : SlicePFunctor.{uA, uB, uI, uI} I I}
+
+/-- The reversed isomorphism. The position field at `a'` reverses the forward
+position equivalence at `shapeEquiv.symm a'` and re-types its domain from
+`G.B (shapeEquiv (shapeEquiv.symm a'))` to `G.B a'`. -/
+def symm (e : Iso F G) : Iso G F where
+  shapeEquiv := e.shapeEquiv.symm
+  posEquiv := fun a' =>
+    (Equiv.cast (congrArg G.B (e.shapeEquiv.apply_symm_apply a')).symm).trans
+      (e.posEquiv (e.shapeEquiv.symm a')).symm
+  q_comm := fun a' => by
+    rw [← e.q_comm (e.shapeEquiv.symm a'), e.shapeEquiv.apply_symm_apply]
+  r_comm := fun a' b' => by
+    rw [← e.r_comm (e.shapeEquiv.symm a')]
+    simp only [Equiv.trans_apply, Equiv.apply_symm_apply]
+    exact congrArg G.r (Sigma.ext (e.shapeEquiv.apply_symm_apply a')
+      (Equiv.cast_apply _ b' ▸ cast_heq _ b'))
+
+/-- `HEq` congruence for `posEquiv` along a shape equality. -/
+theorem posEquiv_heq_cast (e : Iso F G) {a₀ a : F.A} (h : a₀ = a) (b : F.B a₀) :
+    e.posEquiv a₀ b ≍ e.posEquiv a (cast (congrArg F.B h) b) := by
+  subst h
+  rfl
+
+/-- The reversed position equivalence washes out its cast under `HEq`. -/
+theorem symm_posEquiv_symm_heq (e : Iso F G) (a' : G.A)
+    (b' : F.B (e.shapeEquiv.symm a')) :
+    (e.symm.posEquiv a').symm b' ≍ e.posEquiv (e.shapeEquiv.symm a') b' := by
+  simp only [symm]
+  exact cast_heq _ _
+
+/-- The reversed-then-forward position composite is the cast induced by
+`shapeEquiv.symm_apply_apply`; a transport identity used in the round trips. -/
+theorem posEquiv_symm_comp (e : Iso F G) (a : F.A)
+    (b' : F.B (e.shapeEquiv.symm (e.shapeEquiv a))) :
+    (e.posEquiv a).symm ((e.symm.posEquiv (e.shapeEquiv a)).symm b')
+      = cast (congrArg F.B (e.shapeEquiv.symm_apply_apply a)) b' := by
+  rw [Equiv.symm_apply_eq]
+  apply eq_of_heq
+  refine (symm_posEquiv_symm_heq e (e.shapeEquiv a) b').trans ?_
+  exact posEquiv_heq_cast e (e.shapeEquiv.symm_apply_apply a) b'
+
+/-- The forward-then-reversed position composite is the cast induced by
+`shapeEquiv.apply_symm_apply`; the transport identity for the other round
+trip. The reversed equivalence's cast cancels the introduced one. -/
+theorem posEquiv_symm_comp' (e : Iso F G) (a' : G.A)
+    (b'' : G.B (e.shapeEquiv (e.shapeEquiv.symm a'))) :
+    (e.symm.posEquiv a').symm ((e.posEquiv (e.shapeEquiv.symm a')).symm b'')
+      = cast (congrArg G.B (e.shapeEquiv.apply_symm_apply a')) b'' := by
+  apply eq_of_heq
+  exact ((symm_posEquiv_symm_heq e a' ((e.posEquiv (e.shapeEquiv.symm a')).symm b'')).trans
+    (heq_of_eq (Equiv.apply_symm_apply _ b''))).trans (cast_heq _ b'').symm
+
+/-- The map on W-types induced by an isomorphism, a single slice-W eliminator
+into the algebra `(G.W, G.wIndex)`: each node re-indexes its shape by
+`shapeEquiv` and its children by `(posEquiv a).symm`. -/
+def wMap (e : Iso F G) : F.W → G.W :=
+  W.elim F G.W G.wIndex
+    (fun z =>
+      W.mk ⟨⟨e.shapeEquiv z.1.1, fun b' => z.1.2 ((e.posEquiv z.1.1).symm b')⟩,
+        (G.toSliceDomPFunctor.compatible_iff G.wIndex _ _).mpr (fun b' => by
+          dsimp only
+          rw [(F.toSliceDomPFunctor.compatible_iff G.wIndex z.1.1 z.1.2).mp z.2
+            ((e.posEquiv z.1.1).symm b'), ← e.r_comm z.1.1 ((e.posEquiv z.1.1).symm b'),
+            Equiv.apply_symm_apply])⟩)
+    (by
+      funext z
+      rw [Function.comp_apply, W.wIndex_mk]
+      exact e.q_comm z.1.1)
+
+/-- `wMap` lies over `I`: its index is that of its argument. -/
+theorem wIndex_wMap (e : Iso F G) (z : F.W) : G.wIndex (e.wMap z) = F.wIndex z :=
+  congrFun (W.comp_elim F G.W G.wIndex _ _) z
+
+/-- `wMap` is a morphism of constructors: it carries `W.mk` at `a` to `W.mk` at
+`shapeEquiv a` with the children re-indexed and mapped. -/
+@[simp]
+theorem wMap_mk (e : Iso F G) (x : F.toSliceDomPFunctor.Obj F.wIndex) :
+    e.wMap (W.mk x) =
+      W.mk ⟨⟨e.shapeEquiv x.1.1,
+          fun b' => e.wMap (x.1.2 ((e.posEquiv x.1.1).symm b'))⟩,
+        (G.toSliceDomPFunctor.compatible_iff G.wIndex _ _).mpr (fun b' => by
+          rw [e.wIndex_wMap,
+            (F.toSliceDomPFunctor.compatible_iff F.wIndex x.1.1 x.1.2).mp x.2
+              ((e.posEquiv x.1.1).symm b'),
+            ← e.r_comm x.1.1 ((e.posEquiv x.1.1).symm b'), Equiv.apply_symm_apply])⟩ :=
+  rfl
+
+/-- `symm.wMap` after `wMap` is the identity. -/
+theorem symm_wMap_wMap (e : Iso F G) (z : F.W) : e.symm.wMap (e.wMap z) = z :=
+  W.induction (F := F)
+    (motive := fun z => e.symm.wMap (e.wMap z) = z)
+    (fun x ih => by
+      change e.symm.wMap (e.wMap (W.mk x)) = W.mk x
+      rw [wMap_mk, wMap_mk]
+      refine congrArg W.mk (Subtype.ext (Sigma.ext ?_ ?_))
+      · exact e.shapeEquiv.symm_apply_apply x.1.1
+      · refine Function.hfunext (congrArg F.B (e.shapeEquiv.symm_apply_apply x.1.1)) ?_
+        intro b' b hb
+        apply heq_of_eq
+        dsimp only
+        rw [ih ((e.posEquiv x.1.1).symm ((e.symm.posEquiv (e.shapeEquiv x.1.1)).symm b')),
+          posEquiv_symm_comp]
+        exact congrArg _ (cast_eq_iff_heq.mpr hb))
+    z
+
+/-- `wMap` after `symm.wMap` is the identity. -/
+theorem wMap_symm_wMap (e : Iso F G) (z : G.W) : e.wMap (e.symm.wMap z) = z :=
+  W.induction (F := G)
+    (motive := fun z => e.wMap (e.symm.wMap z) = z)
+    (fun x ih => by
+      change e.wMap (e.symm.wMap (W.mk x)) = W.mk x
+      rw [wMap_mk, wMap_mk]
+      refine congrArg W.mk (Subtype.ext (Sigma.ext ?_ ?_))
+      · exact e.shapeEquiv.apply_symm_apply x.1.1
+      · refine Function.hfunext (congrArg G.B (e.shapeEquiv.apply_symm_apply x.1.1)) ?_
+        intro b'' b hb
+        apply heq_of_eq
+        dsimp only
+        rw [ih ((e.symm.posEquiv x.1.1).symm ((e.posEquiv (e.symm.shapeEquiv x.1.1)).symm b''))]
+        exact congrArg _ ((posEquiv_symm_comp' e x.1.1 b'').trans (cast_eq_iff_heq.mpr hb)))
+    z
+
+/-- The equivalence of W-types induced by an isomorphism. -/
+def wEquiv (e : Iso F G) : F.W ≃ G.W where
+  toFun := e.wMap
+  invFun := e.symm.wMap
+  left_inv := e.symm_wMap_wMap
+  right_inv := e.wMap_symm_wMap
+
+/-- The induced equivalence of W-type fibres over a fixed index `i`. -/
+def wEquivFiber (e : Iso F G) (i : I) :
+    { w : F.W // F.wIndex w = i } ≃ { w' : G.W // G.wIndex w' = i } where
+  toFun w := ⟨e.wMap w.1, (e.wIndex_wMap w.1).trans w.2⟩
+  invFun w' := ⟨e.symm.wMap w'.1, (e.symm.wIndex_wMap w'.1).trans w'.2⟩
+  left_inv w := Subtype.ext (e.symm_wMap_wMap w.1)
+  right_inv w' := Subtype.ext (e.wMap_symm_wMap w'.1)
+
+end Iso
+
+end SlicePFunctor

--- a/geb-lean/GebLean/SliceW/Translate.lean
+++ b/geb-lean/GebLean/SliceW/Translate.lean
@@ -1,0 +1,91 @@
+import Geb.Mathlib.Data.PFunctor.Slice.Basic
+
+/-!
+# The translate augmentation of a slice endofunctor
+
+Given a slice endofunctor `F` over `I` and a map `v : Y → I` from a leaf
+type `Y`, the translate `translate v F` is the slice endofunctor `Y + F(-)`
+over `I`: a fresh nullary shape for each `y : Y` whose shape-output map is
+`v y`, alongside `F`'s own shapes with their positions and maps unchanged.
+This is the augmentation `Y + F(-)` of Gambino–Kock 2013, whose initial
+algebra (once the associated W-type is in hand) is the free monad on `F`
+with leaves `Y`.
+
+## Main definitions
+
+* `SlicePFunctor.translate` — the augmented slice endofunctor `Y + F(-)`.
+
+## Main statements
+
+* `SlicePFunctor.translate_A`, `translate_B_inl`, `translate_B_inr`,
+  `translate_q_inl`, `translate_q_inr`, `translate_r_inr` — the
+  characterization of each field of `translate v F` in terms of `v` and `F`.
+
+## References
+
+N. Gambino and J. Kock, "Polynomial functors and polynomial monads",
+Mathematical Proceedings of the Cambridge Philosophical Society 154 (2013)
+153-192, DOI `10.1017/S0305004112000394`.
+
+## Tags
+
+polynomial functor, slice category, free monad, container, PFunctor
+-/
+
+namespace SlicePFunctor
+
+universe uY uA uB uI
+
+/-- The translate of a slice endofunctor `F` over `I` along a leaf map
+`v : Y → I`: the slice endofunctor `Y + F(-)`. Shapes are `Y ⊕ F.A`; a left
+shape `y` is nullary (`PEmpty` positions) and outputs `v y`, a right shape
+`a` keeps `F`'s positions, direction-input map, and shape-output map. -/
+def translate {I : Type uI} {Y : Type uY} (v : Y → I)
+    (F : SlicePFunctor.{uA, uB, uI, uI} I I) : SlicePFunctor.{max uY uA, uB, uI, uI} I I where
+  A := Y ⊕ F.A
+  B := fun a => match a with
+    | .inl _ => PEmpty
+    | .inr a => F.B a
+  r := fun x => match x with
+    | ⟨.inl _, e⟩ => e.elim
+    | ⟨.inr a, b⟩ => F.r ⟨a, b⟩
+  q := Sum.elim v F.q
+
+variable {I : Type uI} {Y : Type uY} {v : Y → I} {F : SlicePFunctor.{uA, uB, uI, uI} I I}
+
+/-- The shape type of `translate v F` is `Y ⊕ F.A`. The ascription orients
+`Sum`'s universe unification along `translate`'s own `max uY uA`; without it
+the elaborator matches `Sum`'s implicit levels against `(translate v F).A`'s
+level in its normalized (alphabetical) order `max uA uY` and fails on `Y`. -/
+@[simp]
+theorem translate_A : (translate v F).A = (Y ⊕ F.A : Type (max uY uA)) :=
+  rfl
+
+/-- A left shape `y` of `translate v F` is nullary. -/
+@[simp]
+theorem translate_B_inl (y : Y) : (translate v F).B (.inl y) = PEmpty :=
+  rfl
+
+/-- A right shape `a` of `translate v F` keeps `F`'s positions at `a`. -/
+@[simp]
+theorem translate_B_inr (a : F.A) : (translate v F).B (.inr a) = F.B a :=
+  rfl
+
+/-- The shape-output map of `translate v F` at a left shape `y` is `v y`. -/
+@[simp]
+theorem translate_q_inl (y : Y) : (translate v F).q (.inl y) = v y :=
+  rfl
+
+/-- The shape-output map of `translate v F` at a right shape `a` is `F.q a`. -/
+@[simp]
+theorem translate_q_inr (a : F.A) : (translate v F).q (.inr a) = F.q a :=
+  rfl
+
+/-- The direction-input map of `translate v F` at a right shape `a` and
+position `b` is `F.r ⟨a, b⟩`. -/
+@[simp]
+theorem translate_r_inr (a : F.A) (b : F.B a) :
+    (translate v F).r ⟨.inr a, b⟩ = F.r ⟨a, b⟩ :=
+  rfl
+
+end SlicePFunctor

--- a/geb-lean/GebLeanTests.lean
+++ b/geb-lean/GebLeanTests.lean
@@ -31,6 +31,7 @@ import GebLeanTests.TestTreeCalcReduction
 import GebLeanTests.PLang.BTPair
 import GebLeanTests.PolyBridge.Slice
 import GebLeanTests.PolyBridge.WEquiv
+import GebLeanTests.PolyBridge.FreeMEquiv
 import GebLeanTests.Ramified
 import GebLeanTests.SliceW.FreeM
 import GebLeanTests.SliceW.Iso

--- a/geb-lean/GebLeanTests.lean
+++ b/geb-lean/GebLeanTests.lean
@@ -33,6 +33,7 @@ import GebLeanTests.PolyBridge.Slice
 import GebLeanTests.PolyBridge.WEquiv
 import GebLeanTests.Ramified
 import GebLeanTests.SliceW.Iso
+import GebLeanTests.SliceW.Translate
 import GebLeanTests.Utilities.ERAMajorants
 import GebLeanTests.Utilities.ERArith
 import GebLeanTests.Utilities.ERCourseOfValues

--- a/geb-lean/GebLeanTests.lean
+++ b/geb-lean/GebLeanTests.lean
@@ -32,6 +32,7 @@ import GebLeanTests.PLang.BTPair
 import GebLeanTests.PolyBridge.Slice
 import GebLeanTests.PolyBridge.WEquiv
 import GebLeanTests.Ramified
+import GebLeanTests.SliceW.Iso
 import GebLeanTests.Utilities.ERAMajorants
 import GebLeanTests.Utilities.ERArith
 import GebLeanTests.Utilities.ERCourseOfValues

--- a/geb-lean/GebLeanTests.lean
+++ b/geb-lean/GebLeanTests.lean
@@ -32,6 +32,7 @@ import GebLeanTests.PLang.BTPair
 import GebLeanTests.PolyBridge.Slice
 import GebLeanTests.PolyBridge.WEquiv
 import GebLeanTests.Ramified
+import GebLeanTests.SliceW.FreeM
 import GebLeanTests.SliceW.Iso
 import GebLeanTests.SliceW.Translate
 import GebLeanTests.Utilities.ERAMajorants

--- a/geb-lean/GebLeanTests/PolyBridge/FreeMEquiv.lean
+++ b/geb-lean/GebLeanTests/PolyBridge/FreeMEquiv.lean
@@ -1,0 +1,27 @@
+import GebLean.PolyBridge.FreeMEquiv
+import GebLean.Ramified.AlgSig
+
+/-! Smoke test for `GebLean.PolyBridge.polyFreeMSliceEquiv`: the fiberwise
+equivalence between the legacy free monad `PolyFreeM V natAlgSig.polyEndo
+PUnit.unit` and the slice free monad `SlicePFunctor.FreeM V.hom
+(toSlice natAlgSig.polyEndo) PUnit.unit`, for a two-element variable family
+`V` over `PUnit`. A sample `polyFreeMPure` leaf round-trips through the
+equivalence. -/
+
+open CategoryTheory GebLean GebLean.Ramified GebLean.PolyBridge
+
+/-- A two-element variable family over `PUnit`: the leaf map from `Bool`. -/
+def sampleVars : Over PUnit.{1} :=
+  Over.mk (fun _ : Bool => PUnit.unit)
+
+/-- A sample leaf: the free-monad `pure` of the variable `true`. -/
+def sampleLeaf : PolyFreeM sampleVars natAlgSig.polyEndo PUnit.unit :=
+  polyFreeMPure sampleVars natAlgSig.polyEndo ⟨true, rfl⟩
+
+/-- The equivalence and its inverse compose to the identity on the sample
+leaf. -/
+example :
+    (polyFreeMSliceEquiv sampleVars natAlgSig.polyEndo PUnit.unit).symm
+        ((polyFreeMSliceEquiv sampleVars natAlgSig.polyEndo PUnit.unit) sampleLeaf) =
+      sampleLeaf :=
+  (polyFreeMSliceEquiv sampleVars natAlgSig.polyEndo PUnit.unit).symm_apply_apply sampleLeaf

--- a/geb-lean/GebLeanTests/PolyBridge/FreeMEquiv.lean
+++ b/geb-lean/GebLeanTests/PolyBridge/FreeMEquiv.lean
@@ -25,3 +25,42 @@ example :
         ((polyFreeMSliceEquiv sampleVars natAlgSig.polyEndo PUnit.unit) sampleLeaf) =
       sampleLeaf :=
   (polyFreeMSliceEquiv sampleVars natAlgSig.polyEndo PUnit.unit).symm_apply_apply sampleLeaf
+
+/-- A leaf-child substitution: replace each variable by its own `pure`. -/
+def sampleBindF :
+    ∀ y, { a : sampleVars.left // sampleVars.hom a = y } →
+      PolyFreeM sampleVars natAlgSig.polyEndo y :=
+  fun _ a => polyFreeMPure sampleVars natAlgSig.polyEndo a
+
+/-- Transport naturality at the identity reindexing on the sample leaf. -/
+example :
+    polyFreeMSliceEquiv sampleVars natAlgSig.polyEndo PUnit.unit sampleLeaf =
+      polyFreeMSliceEquiv sampleVars natAlgSig.polyEndo PUnit.unit sampleLeaf :=
+  polyFreeMSliceEquiv_transport sampleVars natAlgSig.polyEndo rfl sampleLeaf
+
+/-- Pure naturality: the equivalence carries the sample leaf to the slice
+free-monad `pure`. -/
+example :
+    polyFreeMSliceEquiv sampleVars natAlgSig.polyEndo PUnit.unit sampleLeaf =
+      SlicePFunctor.FreeM.pure ⟨true, rfl⟩ :=
+  polyFreeMSliceEquiv_pure sampleVars natAlgSig.polyEndo PUnit.unit ⟨true, rfl⟩
+
+/-- Node naturality: the equivalence carries a unary node with one leaf child to
+the slice free-monad `node`. -/
+example :
+    polyFreeMSliceEquiv sampleVars natAlgSig.polyEndo PUnit.unit
+        (PolyFix.mk PUnit.unit (Sum.inr true) (fun _ => sampleLeaf)) =
+      SlicePFunctor.FreeM.node (F := toSlice natAlgSig.polyEndo) (v := sampleVars.hom)
+        ⟨PUnit.unit, true⟩
+        (fun e => polyFreeMSliceEquiv sampleVars natAlgSig.polyEndo _ ((fun _ => sampleLeaf) e)) :=
+  polyFreeMSliceEquiv_node sampleVars natAlgSig.polyEndo PUnit.unit true (fun _ => sampleLeaf)
+
+/-- Bind naturality: the equivalence intertwines legacy and slice `bind` on the
+sample leaf. -/
+example :
+    polyFreeMSliceEquiv sampleVars natAlgSig.polyEndo PUnit.unit
+        (polyFreeMBind sampleVars sampleVars natAlgSig.polyEndo sampleLeaf sampleBindF) =
+      (polyFreeMSliceEquiv sampleVars natAlgSig.polyEndo PUnit.unit sampleLeaf).bind
+        (fun y a => polyFreeMSliceEquiv sampleVars natAlgSig.polyEndo y (sampleBindF y a)) :=
+  polyFreeMSliceEquiv_bind sampleVars sampleVars natAlgSig.polyEndo PUnit.unit sampleLeaf
+    sampleBindF

--- a/geb-lean/GebLeanTests/Ramified/Polynomial.lean
+++ b/geb-lean/GebLeanTests/Ramified/Polynomial.lean
@@ -1,5 +1,6 @@
 import GebLeanTests.Ramified.Polynomial.FreeAlg
 import GebLeanTests.Ramified.Polynomial.RType
+import GebLeanTests.Ramified.Polynomial.Term
 
 /-!
 # Ramified-recurrence polynomial-stack test index

--- a/geb-lean/GebLeanTests/Ramified/Polynomial/Term.lean
+++ b/geb-lean/GebLeanTests/Ramified/Polynomial/Term.lean
@@ -1,0 +1,62 @@
+import GebLean
+import GebLean.Ramified.Polynomial.Term
+
+/-!
+# Tests for the sorted term layer on the slice free monad
+
+Proof-level checks over a two-sorted toy signature (`SortedSig Bool`, one
+operation per sort with mixed arity) that `GebLean.Ramified.Polynomial.Tm'.var`
+substitutes correctly at each context position
+(`GebLean.Ramified.Polynomial.Tm'.var_subst`), and that
+`GebLean.Ramified.Polynomial.Tm'.subst_id` and
+`GebLean.Ramified.Polynomial.Tm'.subst_subst` instantiate on a concrete term.
+-/
+
+namespace GebLeanTests.Ramified.Polynomial.Term
+
+open GebLean.Ramified GebLean.Ramified.Polynomial
+
+/-- A two-sorted signature over `Bool`: operation `false` (result sort
+`false`) takes one argument of sort `true`; operation `true` (result sort
+`true`) takes two arguments of sort `false`. -/
+def twoSortedSig : SortedSig Bool :=
+  { Op := Bool
+  , arity := fun b => if b then [false, false] else [true]
+  , result := fun b => b }
+
+/-- A context of two variables: position `0` at sort `false`, position `1`
+at sort `true`. -/
+abbrev ctx : Ctx Bool := [false, true]
+
+/-- The subterm `op false (var 1)`, at sort `false`. -/
+def sub1 : Tm' twoSortedSig ctx false :=
+  Tm'.op (sig := twoSortedSig) (Γ := ctx) false (Fin.cons (Tm'.var 1) finZeroElim)
+
+/-- The term `op true (var 0) sub1`, at sort `true`. -/
+def t : Tm' twoSortedSig ctx true :=
+  Tm'.op (sig := twoSortedSig) (Γ := ctx) true (Fin.cons (Tm'.var 0) (Fin.cons sub1 finZeroElim))
+
+/-- Substituting the variable at position `0` by a tuple `σ` selects `σ 0`. -/
+example (σ : ∀ i : Fin ctx.length, Tm' twoSortedSig ctx (ctx.get i)) :
+    (Tm'.var (0 : Fin ctx.length)).subst σ = σ 0 :=
+  Tm'.var_subst 0 σ
+
+/-- Substituting the variable at position `1` by a tuple `σ` selects `σ 1`. -/
+example (σ : ∀ i : Fin ctx.length, Tm' twoSortedSig ctx (ctx.get i)) :
+    (Tm'.var (1 : Fin ctx.length)).subst σ = σ 1 :=
+  Tm'.var_subst 1 σ
+
+/-- The right-unit clone law on the concrete term `t`. -/
+example : t.subst Tm'.var = t := Tm'.subst_id t
+
+/-- The substitution tuple sending position `0` to `sub1` and position `1` to
+`var 1`. -/
+def sigma : ∀ i : Fin ctx.length, Tm' twoSortedSig ctx (ctx.get i) :=
+  Fin.cons sub1 (Fin.cons (Tm'.var 1) finZeroElim)
+
+/-- The associativity clone law on the concrete term `t`. -/
+example :
+    (t.subst sigma).subst sigma = t.subst (fun i => (sigma i).subst sigma) :=
+  Tm'.subst_subst t sigma sigma
+
+end GebLeanTests.Ramified.Polynomial.Term

--- a/geb-lean/GebLeanTests/Ramified/Polynomial/Term.lean
+++ b/geb-lean/GebLeanTests/Ramified/Polynomial/Term.lean
@@ -59,4 +59,36 @@ example :
     (t.subst sigma).subst sigma = t.subst (fun i => (sigma i).subst sigma) :=
   Tm'.subst_subst t sigma sigma
 
+/-- The argument tuple of `sub1`: its single argument at position `0` is
+`var 1`. -/
+def sub1args :
+    ∀ i : Fin (twoSortedSig.arity false).length,
+      Tm' twoSortedSig ctx ((twoSortedSig.arity false).get i) :=
+  Fin.cons (Tm'.var 1) finZeroElim
+
+/-- The bridge equivalence carries a primed variable term to the legacy
+`Tm.var`. -/
+example :
+    tmSliceEquiv ctx _ (Tm'.var (sig := twoSortedSig) (1 : Fin ctx.length)) =
+      Tm.var (sig := twoSortedSig) 1 :=
+  tmSliceEquiv_var (sig := twoSortedSig) (Γ := ctx) 1
+
+/-- The bridge equivalence carries a primed operation term to the legacy
+`Tm.op` with arguments mapped through the equivalence. -/
+example :
+    tmSliceEquiv ctx _ (Tm'.op (sig := twoSortedSig) (Γ := ctx) false sub1args) =
+      Tm.op (sig := twoSortedSig) false (fun i => tmSliceEquiv ctx _ (sub1args i)) :=
+  tmSliceEquiv_op (sig := twoSortedSig) (Γ := ctx) false sub1args
+
+/-- The bridge equivalence intertwines primed substitution with legacy
+`Tm.subst` on the concrete term `t`. -/
+example :
+    tmSliceEquiv ctx _ (t.subst sigma) =
+      (tmSliceEquiv ctx _ t).subst (fun i => tmSliceEquiv ctx _ (sigma i)) :=
+  tmSliceEquiv_subst t sigma
+
+/-- The transported round trip: the inverse of `tmSliceEquiv` recovers `t`. -/
+example : (tmSliceEquiv ctx _).symm (tmSliceEquiv ctx _ t) = t :=
+  Equiv.symm_apply_apply (tmSliceEquiv ctx _) t
+
 end GebLeanTests.Ramified.Polynomial.Term

--- a/geb-lean/GebLeanTests/SliceW/FreeM.lean
+++ b/geb-lean/GebLeanTests/SliceW/FreeM.lean
@@ -43,7 +43,8 @@ example :
 example : nodeWithLeaves.1 =
     W.mk (F := translate SliceWTranslateTest.v SliceWIsoTest.F)
       ⟨⟨Sum.inr true, fun _ => pureLeaf.1⟩,
-        (SliceDomPFunctor.compatible_iff _ _ _ _).mpr fun _ => pureLeaf.2⟩ := by
+        ((translate SliceWTranslateTest.v SliceWIsoTest.F).toSliceDomPFunctor.compatible_iff
+          _ _ _).mpr fun _ => pureLeaf.2⟩ := by
   rfl
 
 end SliceWFreeMTest

--- a/geb-lean/GebLeanTests/SliceW/FreeM.lean
+++ b/geb-lean/GebLeanTests/SliceW/FreeM.lean
@@ -1,0 +1,49 @@
+import GebLean.SliceW.FreeM
+import GebLeanTests.SliceW.Iso
+import GebLeanTests.SliceW.Translate
+
+/-! Smoke test for `SlicePFunctor.FreeM`, `FreeM.pure`, and `FreeM.node`, on
+the toy translate functor of `GebLeanTests.SliceW.Translate` (the toy slice
+endofunctor `F` of `GebLeanTests.SliceW.Iso`, translated along the constant
+leaf map `v : Bool → PUnit`). -/
+
+namespace SliceWFreeMTest
+
+open SlicePFunctor
+
+/-- A `pure` leaf, from the leaf datum `true` (`v true = PUnit.unit` by
+`rfl`). -/
+def pureLeaf : FreeM SliceWTranslateTest.v SliceWIsoTest.F PUnit.unit :=
+  FreeM.pure ⟨true, rfl⟩
+
+/-- `pureLeaf`'s fiber proof: its underlying tree's index is `PUnit.unit`. -/
+example :
+    (translate SliceWTranslateTest.v SliceWIsoTest.F).wIndex pureLeaf.1 = PUnit.unit :=
+  pureLeaf.2
+
+/-- `pureLeaf`'s underlying tree, via `val_pure`. -/
+example :
+    pureLeaf.1 = W.mk (F := translate SliceWTranslateTest.v SliceWIsoTest.F)
+      ⟨⟨Sum.inl true, fun e => e.elim⟩, funext fun e => e.elim⟩ := by
+  rfl
+
+/-- A `node` at the unary `true` shape of the toy functor `F`, with `pureLeaf`
+as its single child. -/
+def nodeWithLeaves : FreeM SliceWTranslateTest.v SliceWIsoTest.F (SliceWIsoTest.F.q true) :=
+  FreeM.node true (fun _ => pureLeaf)
+
+/-- `nodeWithLeaves`'s fiber proof: its underlying tree's index is
+`F.q true`. -/
+example :
+    (translate SliceWTranslateTest.v SliceWIsoTest.F).wIndex nodeWithLeaves.1
+      = SliceWIsoTest.F.q true :=
+  nodeWithLeaves.2
+
+/-- `nodeWithLeaves`'s underlying tree, via `val_node`. -/
+example : nodeWithLeaves.1 =
+    W.mk (F := translate SliceWTranslateTest.v SliceWIsoTest.F)
+      ⟨⟨Sum.inr true, fun _ => pureLeaf.1⟩,
+        (SliceDomPFunctor.compatible_iff _ _ _ _).mpr fun _ => pureLeaf.2⟩ := by
+  rfl
+
+end SliceWFreeMTest

--- a/geb-lean/GebLeanTests/SliceW/FreeM.lean
+++ b/geb-lean/GebLeanTests/SliceW/FreeM.lean
@@ -64,4 +64,15 @@ example : nodeWithLeaves.bind pureSubst = nodeWithLeaves := by
   rw [nodeWithLeaves, FreeM.bind_node]
   simp only [hleaf]
 
+/-- Right unit: binding a one-node tree with the identity substitution
+`pureSubst` returns the tree, by `bind_pure`. -/
+example : nodeWithLeaves.bind pureSubst = nodeWithLeaves :=
+  FreeM.bind_pure nodeWithLeaves
+
+/-- Associativity: rebinding a one-node tree factors through the pointwise
+composite, by `bind_assoc`. -/
+example : (nodeWithLeaves.bind pureSubst).bind pureSubst =
+    nodeWithLeaves.bind (fun j a => (pureSubst j a).bind pureSubst) :=
+  FreeM.bind_assoc nodeWithLeaves pureSubst pureSubst
+
 end SliceWFreeMTest

--- a/geb-lean/GebLeanTests/SliceW/FreeM.lean
+++ b/geb-lean/GebLeanTests/SliceW/FreeM.lean
@@ -47,4 +47,21 @@ example : nodeWithLeaves.1 =
           _ _ _).mpr fun _ => pureLeaf.2⟩ := by
   rfl
 
+/-- The identity substitution: every leaf maps to its own `pure`. -/
+def pureSubst : ∀ j, { a : Bool // SliceWTranslateTest.v a = j } →
+    FreeM SliceWTranslateTest.v SliceWIsoTest.F j :=
+  fun _ a => FreeM.pure a
+
+/-- Left unit: binding a `pure` leaf with `pureSubst` returns the leaf, by
+`pure_bind`. -/
+example : pureLeaf.bind pureSubst = pureLeaf :=
+  FreeM.pure_bind ⟨true, rfl⟩ pureSubst
+
+/-- Binding a one-node tree with `pureSubst` reduces, by `bind_node` then
+`pure_bind` on the child, back to the tree. No kernel reduction of trees. -/
+example : nodeWithLeaves.bind pureSubst = nodeWithLeaves := by
+  have hleaf : pureLeaf.bind pureSubst = pureLeaf := FreeM.pure_bind ⟨true, rfl⟩ pureSubst
+  rw [nodeWithLeaves, FreeM.bind_node]
+  simp only [hleaf]
+
 end SliceWFreeMTest

--- a/geb-lean/GebLeanTests/SliceW/Iso.lean
+++ b/geb-lean/GebLeanTests/SliceW/Iso.lean
@@ -1,0 +1,47 @@
+import GebLean.SliceW.Iso
+
+/-! Smoke test for `SlicePFunctor.Iso` and its induced W-equivalence. A toy
+slice endofunctor over `Unit` (shapes `Bool`, the false shape nullary and the
+true shape unary) is related to itself by the identity isomorphism; a sample
+two-level tree transports under `wMap` with its index preserved and round-trips
+through `wEquiv`. -/
+
+namespace SliceWIsoTest
+
+open SlicePFunctor
+
+/-- Toy slice endofunctor over `Unit`: shapes `Bool`, with the false shape
+nullary (`Empty` positions) and the true shape unary (`Unit` positions). -/
+def F : SlicePFunctor.{0, 0, 0, 0} Unit Unit where
+  A := Bool
+  B := fun b => match b with | true => Unit | false => Empty
+  r := fun _ => ()
+  q := fun _ => ()
+
+/-- The identity isomorphism `F ≅ F`. -/
+def e : SlicePFunctor.Iso F F where
+  shapeEquiv := Equiv.refl _
+  posEquiv := fun _ => Equiv.refl _
+  q_comm := fun _ => rfl
+  r_comm := fun _ _ => rfl
+
+/-- A leaf: the nullary false shape with no children. -/
+def leaf : F.W :=
+  W.mk ⟨⟨false, fun b => b.elim⟩,
+    (F.toSliceDomPFunctor.compatible_iff F.wIndex false _).mpr (fun b => b.elim)⟩
+
+/-- A two-level tree: the unary true shape with the leaf as its single child. -/
+def tree : F.W :=
+  W.mk ⟨⟨true, fun _ => leaf⟩,
+    (F.toSliceDomPFunctor.compatible_iff F.wIndex true _).mpr (fun _ => rfl)⟩
+
+/-- `wMap` preserves the tree's index. -/
+example : F.wIndex (e.wMap tree) = F.wIndex tree :=
+  e.wIndex_wMap tree
+
+/-- The equivalence and its inverse compose to the identity on the sample
+tree. -/
+example : e.wEquiv.symm (e.wEquiv tree) = tree :=
+  e.wEquiv.symm_apply_apply tree
+
+end SliceWIsoTest

--- a/geb-lean/GebLeanTests/SliceW/Translate.lean
+++ b/geb-lean/GebLeanTests/SliceW/Translate.lean
@@ -1,0 +1,26 @@
+import GebLean.SliceW.Translate
+import GebLeanTests.SliceW.Iso
+
+/-! Smoke test for `SlicePFunctor.translate`. The toy slice endofunctor `F`
+of `GebLeanTests.SliceW.Iso` is translated along a constant leaf map
+`v : Bool → PUnit`; the shape-output map on each summand recovers `v` (left)
+or `F.q` (right). -/
+
+namespace SliceWTranslateTest
+
+open SlicePFunctor
+
+/-- The leaf-data map for the translated shapes: constant into `F`'s index
+type. -/
+def v : Bool → PUnit := fun _ => PUnit.unit
+
+/-- The left summand's shape-output map is `v`. -/
+example : (translate v SliceWIsoTest.F).q (.inl true) = v true := by
+  simp
+
+/-- The right summand's shape-output map is `F`'s. -/
+example (a : SliceWIsoTest.F.A) :
+    (translate v SliceWIsoTest.F).q (.inr a) = SliceWIsoTest.F.q a := by
+  simp
+
+end SliceWTranslateTest

--- a/geb-lean/docs/areas/polynomial-functors.md
+++ b/geb-lean/docs/areas/polynomial-functors.md
@@ -218,6 +218,28 @@ existence and combinators:
   initial-algebra carrier `PolyFix P` (`PolyAlg.lean`) and the
   W-type of the translated slice functor
   (`Geb.Mathlib.Data.PFunctor.Slice.W`).
+- [`GebLean/SliceW/`](../../GebLean/SliceW.lean) — the native free-monad
+  layer on the vendored slice W-type
+  (`Geb.Mathlib.Data.PFunctor.Slice.W`), independent of the
+  polynomial-algebra and ramified layers.
+  [`Translate.lean`](../../GebLean/SliceW/Translate.lean) builds the
+  free-monad augmentation `translate v F = Y + F(-)` of a slice
+  endofunctor (Gambino–Kock 2013).
+  [`FreeM.lean`](../../GebLean/SliceW/FreeM.lean) supplies the free
+  monad's carrier `SlicePFunctor.FreeM v F i` (the fiber of `translate v
+  F`'s W-type over `i`), its `pure`/`node`/`bind` constructors, and the
+  monad laws with their transport compatibility.
+  [`Iso.lean`](../../GebLean/SliceW/Iso.lean) supplies container
+  isomorphisms `SlicePFunctor.Iso F G` of slice endofunctors and the
+  W-type equivalence `wEquivFiber` they induce fiberwise.
+- [`GebLean/PolyBridge/FreeMEquiv.lean`](../../GebLean/PolyBridge/FreeMEquiv.lean)
+  — the container isomorphism `translateSliceIso` identifying `toSlice
+  (polyTranslate V P)` with `SlicePFunctor.translate V.hom (toSlice P)`,
+  and the fiberwise free-monad equivalence `polyFreeMSliceEquiv :
+  PolyFreeM V P x ≃ SlicePFunctor.FreeM V.hom (toSlice P) x` composing
+  `polyFixSliceEquiv` with `Iso.wEquivFiber`; its transport, `pure`,
+  `node`, and `bind` naturality lemmas relate the legacy free monad's
+  operations to the slice free monad's.
 
 ### Polynomial presentations and copresheaf cover
 

--- a/geb-lean/docs/areas/ramified-recurrence.md
+++ b/geb-lean/docs/areas/ramified-recurrence.md
@@ -221,6 +221,13 @@ The directory index is
   — the ramified types `RType'` and their operations reimplemented
   on `FreeAlg'`, and the bridge equivalence `rTypeSliceEquiv : RType'
   ≃ RType`, with a compatibility lemma per operation across it.
+- [`GebLean/Ramified/Polynomial/Term.lean`](../../GebLean/Ramified/Polynomial/Term.lean)
+  — the sorted term layer `Tm'` on the slice free monad
+  `SlicePFunctor.FreeM`, with `var`, `op`, and `subst` (the free
+  monad's `pure`, `node`, and `bind`) and the clone laws as instances
+  of the monad laws, and the bridge equivalence `tmSliceEquiv : Tm' sig
+  Γ s ≃ Tm sig Γ s`, with a compatibility lemma for `var`, `op`, and
+  `subst` across it.
 
 ## Statement inventory
 

--- a/geb-lean/docs/superpowers/notes/2026-07-20-ramified-polynomial-phaseB-handoff.md
+++ b/geb-lean/docs/superpowers/notes/2026-07-20-ramified-polynomial-phaseB-handoff.md
@@ -1,0 +1,271 @@
+# Handoff: ramified-on-vendored-polynomial-functors, Phase B
+
+<!-- START doctoc generated TOC please keep comment here to allow auto update -->
+<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
+
+- [How to use this document](#how-to-use-this-document)
+- [Workstream overview](#workstream-overview)
+- [Binding constraints and conventions (all phases)](#binding-constraints-and-conventions-all-phases)
+- [Phase A — delivered (on `main`)](#phase-a--delivered-on-main)
+  - [Phase A learnings and idioms (reuse in B)](#phase-a-learnings-and-idioms-reuse-in-b)
+- [Phase B — the free-monad bridge and `Tm'`](#phase-b--the-free-monad-bridge-and-tm)
+  - [The legacy target (what B reimplements)](#the-legacy-target-what-b-reimplements)
+  - [The vendored approach (fixed by spec s4.2 / s11)](#the-vendored-approach-fixed-by-spec-s42--s11)
+  - [Design questions for the B.0 sub-plan to resolve](#design-questions-for-the-b0-sub-plan-to-resolve)
+- [Process to follow for Phase B](#process-to-follow-for-phase-b)
+- [Pointers](#pointers)
+
+<!-- END doctoc generated TOC please keep comment here to allow auto update -->
+
+## How to use this document
+
+A fresh session picking up this workstream should read this end to end,
+then read the spec and plan (linked below). Phase A is merged to `main`;
+this document carries the workstream context, the Phase A deliverables
+and learnings, and the Phase B starting point.
+
+## Workstream overview
+
+Goal: provide a second implementation of the `Ramified` recursive layer
+(`FreeAlg`, `RType`, `Tm`) on the vendored geb-mathlib polynomial-functor
+stack (`Geb.Mathlib.Data.PFunctor.Slice.W`), connected to the existing
+`GebLean.PolyAlg`-based implementation by transport-grade equivalences,
+and — as the terminal step — to rebuild the first-order presentation
+layer on the primed types so the existing inter-definability with
+elementary-recursive arithmetic (`ERMor`) transfers by an equivalence of
+categories, reusing (not redoing) the ER definability/soundness proofs.
+
+Authoritative documents (on `main`):
+
+- Spec: `docs/superpowers/specs/2026-07-19-ramified-polynomial-design.md`
+  (revision 4; converged through 3 adversarial-review rounds).
+- Plan: `docs/superpowers/plans/2026-07-19-ramified-polynomial-plan.md`
+  (revision 3; master plan, Phase A detailed, Phases B/C boundary-fixed
+  with mandatory sub-plans).
+- Reviews: `…-plan.review-1.md`, `.review-2.md`, `.review-3.md`.
+
+Phase structure:
+
+- Phase A (DONE, merged as PR #265): the W-type bridge and the `FreeAlg'`
+  / `RType'` instantiation.
+- Phase B (NEXT, this handoff): the free-monad bridge and `Tm'`.
+- Phase C: inter-definability on the primed type system (rebuild the
+  primed `Presentation'` / `SynCatFO'`, relate `RMRecCat' ≌ RMRecCat`,
+  transfer the endpoints). User-decided to be the full presentation
+  rebuild, not a free transport (spec section 6, review-2 P2).
+
+## Binding constraints and conventions (all phases)
+
+- No `noncomputable` anywhere; `Classical.choice` in proofs only. The
+  axiom gate (`lake build GebLeanAxiomChecks`) accepts only `propext` /
+  `Quot.sound` / `Classical.choice`; `sorryAx` and any other axiom fail.
+- Recursor-only elimination of the recursive tree datatypes: on the
+  vendored side `SlicePFunctor.W.elim` / `.RecProp` / `.induction`; on
+  the legacy side (only where a bridge must consume it) `PolyFix.ind`.
+  Forbidden over the tree types: the `induction` / `cases` / recursive
+  `rcases` tactics, structural `match`-with-self-calls, `termination_by`,
+  well-founded recursion, and `WType.rec` / a native `.rec` in
+  computational content. `Nat.rec` / induction on `Nat` / `Bool` / `Fin`
+  is fine (not tree types); a non-recursive `match` on a finite shape is
+  fine.
+- No novelty claims in `.lean` comments/docstrings — cite only the
+  literature transcribed (novelty annotations live in spec/plan only).
+- File headers: match the existing `GebLean` convention — plain
+  `import ...`, no `module` keyword, no copyright/author header, then a
+  mandatory `/-! -/` module docstring (`# Title`, summary,
+  `## Main definitions`, `## Main statements`, `## References`,
+  `## Tags`); `/-- -/` on every `def`/`theorem`. (`lean-coding.md`
+  prescribes the `module` keyword, but only ~5/375 non-vendored files
+  use it; matching neighbours is correct and was accepted at review.)
+- Tests: mirror each source module under `GebLeanTests/`, register it in
+  the aggregators (`GebLeanTests.lean`, `GebLeanTests/Ramified.lean`).
+  Route numeric/semantic assertions through proven `@[simp]` lemmas —
+  NOT kernel reduction of composite `W`-trees (project memory: Gödel /
+  ER interpreters are not `#guard`-safe).
+- Build only with `lake build <Module>` / `lake test`; never
+  `lake env lean` or `lake clean`. Pre-commit for any `.lean` commit:
+  `bash scripts/pre-commit.sh`; full gate before push:
+  `bash scripts/pre-push.sh`.
+- VCS: `jj` (colocated), not raw mutating `git` (a hook blocks it).
+  Commit with `jj commit -m` (mathlib message convention: `<type>(<scope>):
+  <imperative lowercase subject>`, no trailing period, ≤72 chars). NO
+  `jj git push` without user line-by-line review.
+
+## Phase A — delivered (on `main`)
+
+The generic bridge and the single-sorted instantiation. New modules:
+
+- `GebLean/PolyBridge/Slice.lean` —
+  `toSlice {X} (P : PolyEndo X) : SlicePFunctor X X` (shapes
+  `Σ x, polyBetweenIndex X X P x`; `q = fst`; positions
+  `(polyBetweenFamily …).left`; `r =` the family hom), with `@[simp]`
+  `toSlice_A/_B/_q/_r`.
+- `GebLean/PolyBridge/WEquiv.lean` — THE GENERIC BRIDGE, general in `X`:
+  `toSliceFib`/`toSliceW`/`wIndex_toSliceW`, `ofSliceW`, round-trips
+  `ofSliceW_toSliceW`/`toSliceW_ofSliceW`, the fiberwise
+  `polyFixSliceEquiv {X} (P : PolyEndo X) (x : X) : PolyFix P x ≃
+  { w : (toSlice P).W // wIndex w = x }`, and constructor naturality
+  `polyFixSliceEquiv_mk`. Helpers `transport_snd`, `toSliceW_transport`,
+  `ofSliceW_fst`. (`elim_polyFixSliceEquiv` was intentionally omitted —
+  no consumer.)
+- `GebLean/Ramified/Polynomial/FreeAlg.lean` — `FreeAlg' A :=
+  { w : (toSlice A.polyEndo).W // wIndex w = PUnit.unit }`; `FreeAlg'.mk`;
+  the tupling paramorphism `FreeAlg'.tupleFold` / `FreeAlg'.recurse`
+  (same signature as legacy `FreeAlg.recurse`) with the reconstruction
+  identity `FreeAlg'.tupleFold_snd` and the reduction rule
+  `FreeAlg'.recurse_mk` (a proved theorem, NOT `rfl`);
+  `freeAlgSliceEquiv (A) : FreeAlg' A ≃ FreeAlg A` (= `polyFixSliceEquiv
+  A.polyEndo PUnit.unit |>.symm`); `natToFreeAlg'` / `freeAlgToNat'`
+  (native, combinator-style) and `natFreeAlgEquiv' : FreeAlg' natAlgSig
+  ≃ ℕ`.
+- `GebLean/Ramified/Polynomial/RType.lean` — `RType' := FreeAlg' rTypeSig`,
+  `RType'.o/arrow/omega`, `rTypeSliceEquiv : RType' ≃ RType`, the ten
+  operations reimplemented by kind (shape/IsObj one-level; `interp` via
+  `W.elim` at `Type`; `IsTower`/`IsSimple` via `W.RecProp`;
+  `objTarget`/`domains` paramorphic via `FreeAlg'.recurse`;
+  `omegaShift`/`ord` catamorphic; `tower` via `Nat.rec`), each with a
+  compatibility lemma (`rTypeSliceEquiv_shape/_omegaShift/_objTarget/
+  _domains/_interp/_ord/_tower/_isObj/_isTower/_isSimple`). A reusable
+  `FreeAlg'.induction` wrapper lives here.
+
+Equivalence chain (all directions verified): `toSlice` →
+`polyFixSliceEquiv` → `freeAlgSliceEquiv` (`.symm`) → `rTypeSliceEquiv`
+→ `natFreeAlgEquiv'`.
+
+### Phase A learnings and idioms (reuse in B)
+
+- The A.0 spike (validate the hardest constructions sorry-free BEFORE
+  writing the real files) was decisive. Do the same in B: spike the
+  augmented-signature free-monad construction on a concrete signature
+  before committing file structure.
+- `polyFixSliceEquiv` is GENERAL in `X` — it applies directly to a
+  multi-sorted `PolyEndo S`. Only `FreeAlg'`/`RType'` specialised to
+  `X = PUnit` (using `Subsingleton.elim` to discharge every `Compatible`
+  side goal). `Tm'` is MULTI-SORTED (`X = S`, the sort type), so it must
+  use the general fiber machinery — the `Subsingleton.elim` shortcut is
+  NOT available; expect the genuine compatibility proofs.
+- `PolyFix.ind`'s iota reduces DEFINITIONALLY on `mk`, so `W.elim_mk`
+  (itself `rfl`) fires without an explicit `rw`.
+- Cast idiom for the backward map: retype the raw equality first —
+  `show (node.1.2 e).1 = (polyBetweenFamily …).hom e from congrFun
+  node.2 e) ▸ …` — a bare `▸` fails to locate the sides. `hg` for the
+  `W.elim` over-map is `funext fun _ => rfl` when `cod` is trivial.
+- Use `change` (not `show`) to beta-reduce recursor motives (avoids the
+  `linter.style.show` linter).
+- A paramorphism from the catamorphic `W.elim`: fold into `C × μ` and
+  project `.1`; the `.2` reconstructs the subtree; its reduction rule
+  needs a reconstruction-identity lemma proved by `W.induction`
+  (NOT definitional).
+- `@[simp]` only on constructor-compatibility lemmas (push the equiv
+  through constructors); operation/naturality compat lemmas must NOT be
+  `@[simp]` (they collide with the `_mk` reductions under `simpNF`).
+- Two plan-text imprecisions found and fixed in-code (fold into the plan
+  before B if editing): `freeAlgSliceEquiv` needs `.symm`
+  (`polyFixSliceEquiv` is `FreeAlg A ≃ FreeAlg' A`); and for
+  `RType'`-valued ops the well-typed compat form is the naturality
+  `rTypeSliceEquiv (op' t) = op (rTypeSliceEquiv t)` (with `.map` for
+  `domains`), not `op' t = op (rTypeSliceEquiv t)`.
+- Optional Phase-A minors left for a future pass (non-blocking): the
+  unused `wIndex_toSliceW`; `FreeAlg'.induction`'s placement in
+  `RType.lean` rather than `FreeAlg.lean`.
+
+## Phase B — the free-monad bridge and `Tm'`
+
+Branch (plan phase-map): `feat/ramified-poly-freemonad`. First task is
+B.0: write and converge the Phase B sub-plan
+(`docs/superpowers/plans/2026-07-19-ramified-poly-freemonad-subplan.md`)
+via brainstorming + writing-plans + adversarial review + user review,
+THEN execute via subagent-driven development.
+
+### The legacy target (what B reimplements)
+
+`GebLean/Ramified/Term.lean`:
+
+- `Tm (sig : SortedSig S) (Γ : Ctx S) : S → Type := PolyFreeM (varOver Γ)
+  sig.polyEndo` — terms are the free monad of the multi-sorted signature
+  endofunctor at the context's variable family.
+- `Tm.var` (free-monad unit / `polyFreeMPure`), `Tm.op` (a `PolyFix`
+  node), `Tm.subst` (free-monad bind / `polyFreeMBind`), `Tm.reind`,
+  `Tm.weaken`.
+- Clone laws `Tm.subst_id`, `Tm.subst_subst`, `Tm.var_subst`,
+  `Tm.subst_reind` (the free monad's right-unit, associativity,
+  left-unit).
+
+Underlying legacy primitive: `PolyFreeM V P` in `GebLean/PolyAlg.lean` —
+the free monad, realized as `PolyFix` of the signature endofunctor
+augmented with variable leaves (`Sum.inl` leaves / `Sum.inr` nodes; see
+`polyFixToPolyFreeM`/`polyFreeMToPolyFix`, `PolyFreeMLeafPos`,
+`PolyFreeMLeafFiber`, `polyFreeMPure`, `polyFreeMBind`, and the monad
+laws `polyFreeM_bind_pure` / `polyFreeM_bind_assoc`).
+
+### The vendored approach (fixed by spec s4.2 / s11)
+
+- Build the AUGMENTED signature endofunctor: `sig.polyEndo : PolyEndo S`
+  extended by variable leaves from `varOver Γ` (leaves have no
+  children). Its slice W-type (via the SAME `toSlice` /
+  `polyFixSliceEquiv` machinery from Phase A, now at `X = S`) is the free
+  monad `polyFreeMSlice`.
+- `polyFreeMSliceEquiv` — the carrier equivalence, reusing
+  `polyFixSliceEquiv` on the augmented `PolyEndo`.
+- `Tm'`, `Tm'.var`, `Tm'.op`, `Tm'.subst`; substitution compatibility
+  `Tm'.subst ↔ Tm.subst` across the equivalence; the clone laws for `Tm'`
+  transported or reproved via the recursor.
+- Start from the PLAIN augmented `SlicePFunctor.W` (single-context free
+  monad). The `PresheafPFunctor` presheaf-monad presentation is DEFERRED
+  (spec s11) — do not reach for it unless full presheaf-monad
+  substitution is wanted.
+
+### Design questions for the B.0 sub-plan to resolve
+
+1. How to present the augmented signature (nodes `sig.polyEndo` + leaves
+   `varOver Γ`) as a single `PolyEndo S`, so `toSlice`/`polyFixSliceEquiv`
+   apply. Mirror how legacy `PolyFreeM` augments `P` (the `Sum` leaf/node
+   split) — build a `polyFreeMSlice` generic in `(V, P)`, analogous to
+   Phase A's generic `freeAlgSliceEquiv`.
+2. Whether to bridge at the generic free-monad level (a reusable
+   `polyFreeMSliceEquiv {V P}`) and instantiate for `Tm'`, mirroring the
+   generic-then-instantiate structure of Phase A.
+3. How `Tm'.subst` maps to the vendored monad multiplication / bind, and
+   whether the clone laws transport across `polyFreeMSliceEquiv` or are
+   reproved via `W.induction` (multi-sorted — no `Subsingleton` shortcut).
+4. The variable-family/context handling (`varOver Γ = Over.mk Γ.get`) on
+   the slice side.
+
+Phase C (later) consumes the `Tm'` equivalence and `Tm'.subst`
+compatibility to rebuild `SynCat'`/`SynCatFO'` (whether `SynCat'` uses
+legacy `Tm` over the primed signature or the vendored `Tm'` is itself a
+C.0 decision).
+
+## Process to follow for Phase B
+
+1. `superpowers:brainstorming` the free-monad design (start from the
+   source: the legacy `Tm`/`PolyFreeM` construction and the vendored
+   slice W-type), resolving the design questions above; produce the
+   Phase B sub-plan design.
+2. `superpowers:writing-plans` → the B.0 sub-plan with bite-sized tasks.
+3. Adversarial review of the sub-plan (fresh-context reviewers verifying
+   every named declaration against source; re-fetch the mathlib upstream
+   guides) BEFORE the user-review handoff; converge to zero-defect.
+4. User line-by-line review of the sub-plan.
+5. `superpowers:subagent-driven-development` — spike first, then a fresh
+   implementer + task review per task, then a whole-branch review. Cheap
+   models for transcription (post-spike), capable models for the hard
+   proofs and the final review.
+
+## Pointers
+
+- Spec / plan / reviews: see "Workstream overview" above.
+- Phase A ledger (SDD progress, with per-task commits and the discovered
+  plan corrections):
+  `.superpowers/sdd/progress-ramified-polynomial.md` (parent `geb/`
+  dir; git-ignored scratch — recover from `git log` if lost).
+- Area docs updated in Phase A: `docs/areas/polynomial-functors.md`
+  (`GebLean/PolyBridge/`), `docs/areas/ramified-recurrence.md`
+  (`GebLean/Ramified/Polynomial/`).
+- Phase A modules: `GebLean/PolyBridge/{Slice,WEquiv}.lean`,
+  `GebLean/Ramified/Polynomial/{FreeAlg,RType}.lean` and their tests.
+- Vendored stack: `vendor/geb-mathlib/Geb/Mathlib/Data/PFunctor/Slice/
+  {Basic,W}.lean` (and `Presheaf/`, `IndRec/` for the deferred layers).
+- Legacy free monad: `GebLean/PolyAlg.lean` (`PolyFreeM`,
+  `polyFreeMPure`, `polyFreeMBind`); legacy terms:
+  `GebLean/Ramified/Term.lean`.

--- a/geb-lean/docs/superpowers/plans/2026-07-19-ramified-poly-freemonad-subplan.md
+++ b/geb-lean/docs/superpowers/plans/2026-07-19-ramified-poly-freemonad-subplan.md
@@ -4,7 +4,7 @@
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
 
 - [Global constraints](#global-constraints)
-- [Task B.1: de-risking spike (iso-induced W-map and native bind)](#task-b1-de-risking-spike-iso-induced-w-map-and-native-bind)
+- [Task B.1: validation spike (iso-induced W-map and native bind)](#task-b1-validation-spike-iso-induced-w-map-and-native-bind)
 - [Task B.2: `SlicePFunctor` isomorphisms and the induced W-equivalence](#task-b2-slicepfunctor-isomorphisms-and-the-induced-w-equivalence)
 - [Task B.3: the `translate` augmentation](#task-b3-the-translate-augmentation)
 - [Task B.4: `FreeM` carrier and constructors](#task-b4-freem-carrier-and-constructors)
@@ -65,8 +65,8 @@ test`; `jj` commits.
 - Tests route numeric/semantic assertions through proven lemmas, not
   kernel reduction of composite W-trees.
 - Universe polymorphism as far as it compiles: `SliceW` modules follow
-  the vendored `{uA, uB, uI}` scheme where frictionless; the bridge
-  and term modules may fix `{u, u, u, u}` as Phase A does.
+  the vendored `{uA, uB, uI}` scheme; the bridge and term modules may
+  fix `{u, u, u, u}` as Phase A does.
 - Build with `lake build <Module>` / `lake test` only; never
   `lake env lean`, never `lake clean`. Pre-commit gate for every task:
   `bash scripts/pre-commit.sh`.
@@ -85,25 +85,26 @@ test`; `jj` commits.
 
 ---
 
-## Task B.1: de-risking spike (iso-induced W-map and native bind)
+## Task B.1: validation spike (iso-induced W-map and native bind)
 
-A short throwaway spike (scratch file, not committed) validating the
-two constructions the design marks hardest, before real tasks depend
-on them.
+A short spike (scratch file, deleted before any commit) validating
+the two constructions the design marks hardest, sorry-free, before
+real tasks depend on them.
 
 - [ ] **Step 1:** In a scratch module importing
   `Geb.Mathlib.Data.PFunctor.Slice.W`, define a toy pair of isomorphic
   `SlicePFunctor PUnit PUnit`s (e.g. shapes `Bool` versus
   `Unit ⊕ Unit`, positions `Fin 2` at one shape) and build the induced
   W-map by `SlicePFunctor.W.elim` into the target `(W, wIndex)`
-  algebra, confirming the `Compatible` re-indexing across the position
-  equivalence and the `hg` side condition discharge.
+  algebra, confirming — sorry-free — the `Compatible` re-indexing
+  across the position equivalence and the `hg` side condition
+  discharge.
 - [ ] **Step 2:** Define a toy `translate`-style augmented functor
   (leaf shapes `Bool` over `PUnit`, node shapes from the toy functor)
   and build `bind` as a single `W.elim` with a `Sum` shape split,
-  confirming: the leaf case's `hg` discharge from the substituted
-  tree's fiber property, and the node case's `Compatible` transfer
-  (the target functor has identical `B`/`r` at `Sum.inr`).
+  confirming — sorry-free — the leaf case's `hg` discharge from the
+  substituted tree's fiber property, and the node case's `Compatible`
+  transfer (the target functor has identical `B`/`r` at `Sum.inr`).
 - [ ] **Step 3:** Record working term shapes (motives, `hg` proofs,
   transport idioms) as notes in the Task B.2 and B.5 implementation
   steps if they differ from what is written there; delete the scratch
@@ -124,8 +125,10 @@ on them.
 
 **Interfaces:**
 
-- Consumes: `SlicePFunctor` fields `A`/`B`/`q`/`r`, `rCurried`,
-  `toSliceDomPFunctor`, `Compatible`, `compatible_iff`, `obj`
+- Consumes: `SlicePFunctor` fields `A`/`B`/`q`/`r`,
+  `toSliceDomPFunctor`, `obj`, and the `SliceDomPFunctor`
+  declarations `Compatible`, `compatible_iff`, `rCurried` (reached by
+  dot notation through `toSliceDomPFunctor`)
   (`Geb.Mathlib.Data.PFunctor.Slice.Basic`); `W`, `wIndex`, `W.mk`,
   `W.elim`, `W.elim_mk`, `W.comp_elim`, `W.wIndex_mk`, `W.induction`
   (`Geb.Mathlib.Data.PFunctor.Slice.W`); `Equiv` (mathlib).
@@ -135,9 +138,16 @@ on them.
     `posEquiv : ∀ a, F.B a ≃ G.B (shapeEquiv a)`,
     `q_comm : ∀ a, G.q (shapeEquiv a) = F.q a`,
     `r_comm : ∀ a b, G.r ⟨shapeEquiv a, posEquiv a b⟩ = F.r ⟨a, b⟩`.
-  - `def SlicePFunctor.Iso.symm : Iso F G → Iso G F` (equivalences
-    reversed; `q_comm`/`r_comm` by rewriting along the forward fields
-    at `shapeEquiv.symm a` / `(posEquiv _).symm b`).
+  - `def SlicePFunctor.Iso.symm : Iso F G → Iso G F` — the shape
+    equivalence reversed; the position field is NOT a bare reversal:
+    at `a' : G.A` it must land in `F.B (shapeEquiv.symm a')`, while
+    the reversed forward field has domain
+    `G.B (shapeEquiv (shapeEquiv.symm a'))`, so it is the reversal
+    composed with the transport (`Equiv.cast` of
+    `congrArg G.B (shapeEquiv.apply_symm_apply a')`, or an equivalent
+    `▸` re-typing); the same transport threads through `symm`'s
+    `q_comm`/`r_comm` proofs (rewriting along the forward fields) and
+    later through the round trips.
   - `def SlicePFunctor.Iso.wMap (e : Iso F G) : F.W → G.W` — a single
     `W.elim` into the algebra `(G.W, G.wIndex)`: at a node
     `⟨⟨a, c⟩, hc⟩` build
@@ -147,8 +157,10 @@ on them.
     `(e.posEquiv a).apply_symm_apply`); `hg` by `funext`, `wIndex_mk`,
     and `q_comm`.
   - `theorem SlicePFunctor.Iso.wIndex_wMap (e : Iso F G) (z : F.W) :`
-    `G.wIndex (e.wMap z) = F.wIndex z` — from `W.comp_elim` and
-    `q_comm` (pointwise application of the `comp_elim` equation).
+    `G.wIndex (e.wMap z) = F.wIndex z` — the pointwise application of
+    `W.comp_elim`, whose conclusion is exactly
+    `G.wIndex ∘ e.wMap = F.wIndex` (`q_comm` is consumed inside `hg`,
+    not here).
   - `theorem SlicePFunctor.Iso.wMap_mk` (`@[simp]`) — constructor
     naturality: `e.wMap (W.mk ⟨⟨a, c⟩, hc⟩)` equals the `W.mk` node at
     `e.shapeEquiv a` with children `fun b' => e.wMap (c ((e.posEquiv
@@ -259,8 +271,9 @@ jj commit -m "feat(slicew): add the translate augmentation of a slice endofuncto
 **Interfaces:**
 
 - Consumes: `translate` and its `@[simp]` lemmas (Task B.3); `W`,
-  `wIndex`, `W.mk`, `W.wIndex_mk`, `compatible_iff`
-  (vendored stack).
+  `wIndex`, `W.mk`, `W.wIndex_mk` (vendored stack);
+  `SliceDomPFunctor.compatible_iff` (dot notation through
+  `toSliceDomPFunctor`).
 - Produces:
   - `def SlicePFunctor.FreeM (v : Y → I) (F : SlicePFunctor I I)`
     `(i : I) := { w : (translate v F).W // (translate v F).wIndex w = i }`.
@@ -274,17 +287,19 @@ jj commit -m "feat(slicew): add the translate augmentation of a slice endofuncto
     `W.mk ⟨⟨Sum.inr a, fun b => (c b).1⟩, _⟩` where the compatibility
     is `(compatible_iff …).mpr fun b => (c b).2` (children's fiber
     proofs), and the fiber proof is `wIndex_mk` then `translate_q_inr`.
-  - `@[simp] theorem SlicePFunctor.FreeM.pure_val` and
-    `node_val` — the underlying-tree characterizations (`(pure a).1 =
-    W.mk …`, `(node a c).1 = W.mk …`), each `rfl`; these are the
-    constructor-level lemmas later tasks rewrite with.
+  - `@[simp] theorem SlicePFunctor.FreeM.val_pure` and
+    `val_node` — the underlying-tree characterizations (`(pure a).1 =
+    W.mk …`, `(node a c).1 = W.mk …`), each `rfl`, named
+    projection-first per the mathlib convention (`Fin.val_mk`
+    precedent); these are the constructor-level lemmas later tasks
+    rewrite with.
 
 **Steps:**
 
 - [ ] **Step 1: Write the failing test.** With the toy translate
   functor from Task B.3's test: build `FreeM.pure ⟨true, rfl⟩` and a
   `FreeM.node` with leaf children; assert their `.2` fiber properties
-  and the `pure_val`/`node_val` equations by `simp`/`rfl`.
+  and the `val_pure`/`val_node` equations by `simp`/`rfl`.
 - [ ] **Step 2: Run to verify it fails.** Run
   `lake build GebLeanTests.SliceW.FreeM`. Expected: failure, `FreeM`
   not found.
@@ -443,12 +458,14 @@ jj commit -m "feat(slicew): prove the free-monad laws and transport lemmas"
   `translate` (Task B.3); `FreeM` (Task B.4); `toSlice`, `toSlice_*`
   (Phase A); `polyFixSliceEquiv` (Phase A); `polyTranslate`,
   `polyTranslateIndex`, `polyTranslateFamily`, `overEmpty`,
-  `PolyFreeM` (`GebLean/PolyAlg.lean`); `Equiv.sigmaSumDistrib` or
-  equivalent mathlib pieces (`Equiv.sumSigmaDistrib` — verify the
-  exact mathlib name with `lean_local_search` / `loogle` before use;
-  build by hand from `Equiv.ofBijective`-free explicit `toFun`/
-  `invFun` if no fit exists), `Equiv.sigmaFiberEquiv` (mathlib:
-  `Σ x, { a // f a = x } ≃ …` — verify orientation).
+  `PolyFreeM` (`GebLean/PolyAlg.lean`); the mathlib equivalences
+  `Equiv.sigmaSumDistrib`
+  (`(Σ i, α i ⊕ β i) ≃ (Σ i, α i) ⊕ (Σ i, β i)`), `Equiv.sumCongr`,
+  and `Equiv.sigmaFiberEquiv` (`(Σ y, { x // f x = y }) ≃ α`) — all
+  three verified present in this checkout
+  (`Mathlib/Logic/Equiv/Sum.lean`); do not use
+  `Equiv.sumSigmaDistrib` (the sigma-indexed-by-a-sum variant, which
+  does not fit).
 - Produces:
   - `def translateSliceIso {X : Type u} (V : Over X) (P : PolyEndo X) :`
     `SlicePFunctor.Iso (toSlice (polyTranslate V P))`
@@ -477,11 +494,13 @@ jj commit -m "feat(slicew): prove the free-monad laws and transport lemmas"
 - [ ] **Step 2: Run to verify it fails.** Run
   `lake build GebLeanTests.PolyBridge.FreeMEquiv`. Expected: failure,
   names not found.
-- [ ] **Step 3: Implement `translateSliceIso`.** Search mathlib for
-  the sigma-sum distribution and sigma-fiber-contraction equivalences
-  first (`lean_local_search`, `loogle`); compose them, or write the
-  explicit `toFun`/`invFun` pair (both directions are `rfl`-inverse
-  case splits). Prove `q_comm`/`r_comm` by shape split.
+- [ ] **Step 3: Implement `translateSliceIso`.** Compose the shape
+  equivalence as `Equiv.sigmaSumDistrib` followed by
+  `Equiv.sumCongr (Equiv.sigmaFiberEquiv V.hom) (Equiv.refl _)` (or
+  write the explicit `toFun`/`invFun` pair if the composite's
+  definitional behaviour obstructs the later `q_comm`/`r_comm`
+  proofs; both directions are `rfl`-inverse case splits). Prove
+  `q_comm`/`r_comm` by shape split.
 - [ ] **Step 4: Implement `polyFreeMSliceEquiv`** as the two-leg
   composite.
 - [ ] **Step 5: Run to verify it passes.** Run
@@ -507,6 +526,12 @@ jj commit -m "feat(polybridge): relate the legacy free monad to the slice free m
   `pure_bind`, `bind_node` (Tasks B.4–B.5); `polyFreeMPure`,
   `polyFreeMBind`, `PolyFix.ind` (`GebLean/PolyAlg.lean`).
 - Produces (none `@[simp]`; operation-level):
+  - `theorem polyFreeMSliceEquiv_transport (V P) {x x' : X}`
+    `(h : x = x') (t : PolyFreeM V P x) :`
+    `polyFreeMSliceEquiv V P x' (h ▸ t) = h ▸ polyFreeMSliceEquiv V P x t`
+    — by `subst h; rfl` (the transport-naturality of the equivalence,
+    mirroring Phase A's `toSliceW_transport`; consumed by Task B.10's
+    `tmSliceEquiv_subst`).
   - `theorem polyFreeMSliceEquiv_pure (V P x)`
     `(a : { v : V.left // V.hom v = x }) :`
     `polyFreeMSliceEquiv V P x (polyFreeMPure V P a) = FreeM.pure a` —
@@ -534,8 +559,8 @@ jj commit -m "feat(polybridge): relate the legacy free monad to the slice free m
   naturality lemma at the Task B.7 sample data.
 - [ ] **Step 2: Run to verify it fails.** Run
   `lake build GebLeanTests.PolyBridge.FreeMEquiv`. Expected: failure.
-- [ ] **Step 3: Implement** the three lemmas in order (each consumes
-  the previous).
+- [ ] **Step 3: Implement** the four lemmas in order (transport
+  first; each later lemma consumes earlier ones).
 - [ ] **Step 4: Run to verify it passes.** Run
   `lake build GebLeanTests.PolyBridge.FreeMEquiv`. Expected: success.
 - [ ] **Step 5: Gate.** Run `bash scripts/pre-commit.sh`.
@@ -646,9 +671,10 @@ jj commit -m "feat(ramified): add the sorted term layer on the slice free monad"
     `tmSliceEquiv Γ _ (t.subst σ) =`
     `(tmSliceEquiv Γ _ t).subst (fun i => tmSliceEquiv Γ _ (σ i))` —
     from `polyFreeMSliceEquiv_bind` via the equivalence laws, moving
-    the leaf-function transport with `FreeM.pure_transport` /
-    `polyFreeMPure_transport` as needed (the legacy and primed leaf
-    functions both transport by `a.2 ▸ σ a.1`).
+    the leaf-function transport with `polyFreeMSliceEquiv_transport`
+    (Task B.8) — the legacy and primed leaf functions both transport
+    by `a.2 ▸ σ a.1`, and the transport must be commuted past the
+    equivalence to match them.
 - None of the three are `@[simp]`.
 
 **Steps:**

--- a/geb-lean/docs/superpowers/plans/2026-07-19-ramified-poly-freemonad-subplan.md
+++ b/geb-lean/docs/superpowers/plans/2026-07-19-ramified-poly-freemonad-subplan.md
@@ -1,0 +1,685 @@
+# Phase B sub-plan: native slice free monad and `Tm'`
+
+<!-- START doctoc generated TOC please keep comment here to allow auto update -->
+<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
+
+- [Global constraints](#global-constraints)
+- [Task B.1: de-risking spike (iso-induced W-map and native bind)](#task-b1-de-risking-spike-iso-induced-w-map-and-native-bind)
+- [Task B.2: `SlicePFunctor` isomorphisms and the induced W-equivalence](#task-b2-slicepfunctor-isomorphisms-and-the-induced-w-equivalence)
+- [Task B.3: the `translate` augmentation](#task-b3-the-translate-augmentation)
+- [Task B.4: `FreeM` carrier and constructors](#task-b4-freem-carrier-and-constructors)
+- [Task B.5: `FreeM.bind` and its computation rules](#task-b5-freembind-and-its-computation-rules)
+- [Task B.6: free-monad laws and transport lemmas](#task-b6-free-monad-laws-and-transport-lemmas)
+- [Task B.7: the augmentation isomorphism and `polyFreeMSliceEquiv`](#task-b7-the-augmentation-isomorphism-and-polyfreemsliceequiv)
+- [Task B.8: bridge naturality (`pure`, `node`, `bind`)](#task-b8-bridge-naturality-pure-node-bind)
+- [Task B.9: the `Tm'` term layer with clone laws](#task-b9-the-tm-term-layer-with-clone-laws)
+- [Task B.10: `tmSliceEquiv`, compatibility, and documentation](#task-b10-tmsliceequiv-compatibility-and-documentation)
+- [Task B.11: whole-branch verification](#task-b11-whole-branch-verification)
+
+<!-- END doctoc generated TOC please keep comment here to allow auto update -->
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use
+> superpowers:subagent-driven-development (recommended) or
+> superpowers:executing-plans to implement this plan task-by-task.
+> Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Build the free monad natively on the vendored slice W-type
+(`translate`, `FreeM`, monad laws), bridge it to the legacy
+`PolyFreeM`, and rebuild the sorted term layer as `Tm'` with clone
+laws and compatibility across the bridge.
+
+**Architecture:** Per the approved design
+([../specs/2026-07-20-ramified-poly-freemonad-design.md](../specs/2026-07-20-ramified-poly-freemonad-design.md)):
+a legacy-free `GebLean/SliceW/` layer (isomorphisms with induced
+W-equivalence; the `translate` augmentation; the `FreeM` free monad
+with laws by `W.induction`), a bridge module instantiating a generic
+iso-to-W-equivalence at the concrete augmentation isomorphism, and a
+term module instantiating `FreeM` at `(Γ.get, toSlice sig.polyEndo)`.
+
+**Tech Stack:** Lean 4 + mathlib; vendored
+`Geb.Mathlib.Data.PFunctor.Slice.{Basic,W}`; `lake build` / `lake
+test`; `jj` commits.
+
+## Global constraints
+
+- No `noncomputable`; `Classical.choice` in proofs only; the axiom
+  gate (`lake build GebLeanAxiomChecks`) accepts only `propext` /
+  `Quot.sound` / `Classical.choice`.
+- Recursor-only elimination of tree types: `SlicePFunctor.W.elim` /
+  `W.induction` / `W.RecProp` on the vendored side; `PolyFix.ind` only
+  in the bridge. Forbidden on tree types: `induction` / `cases`
+  tactics, structural `match` with self-calls, `termination_by`,
+  well-founded recursion, `WType.rec` in computational content. A
+  non-recursive `match` on a finite shape (e.g. a `Sum` split) is
+  permitted.
+- `GebLean/SliceW/*` imports the vendored stack only — no
+  `GebLean.PolyAlg`, no `GebLean.Ramified.*` (upstream-promotable).
+- File headers: plain `import ...` (no `module` keyword), no
+  copyright header, mandatory `/-! -/` module docstring (`# Title`,
+  summary, `## Main definitions`, `## Main statements`,
+  `## References`, `## Tags`); `/-- -/` on every `def`/`theorem`; no
+  novelty claims in `.lean` text (citations only).
+- `@[simp]` on constructor-compatibility and field-characterization
+  lemmas only; operation/naturality compatibility lemmas are NOT
+  `@[simp]` (Phase A `simpNF` finding).
+- Tests route numeric/semantic assertions through proven lemmas, not
+  kernel reduction of composite W-trees.
+- Universe polymorphism as far as it compiles: `SliceW` modules follow
+  the vendored `{uA, uB, uI}` scheme where frictionless; the bridge
+  and term modules may fix `{u, u, u, u}` as Phase A does.
+- Build with `lake build <Module>` / `lake test` only; never
+  `lake env lean`, never `lake clean`. Pre-commit gate for every task:
+  `bash scripts/pre-commit.sh`.
+- Commits with `jj commit -m "<type>(<scope>): <imperative lowercase
+  subject>"` (no trailing period, subject ≤ 72 characters). No
+  `jj git push` without user line-by-line review.
+- References for transcriptions: N. Gambino, J. Kock, "Polynomial
+  functors and polynomial monads", Math. Proc. Camb. Phil. Soc. 154
+  (2013), DOI `10.1017/S0305004112000394` (free monad as the initial
+  algebra of the translation); M. Abbott, T. Altenkirch, N. Ghani,
+  "Containers: constructing strictly positive types", TCS 342 (2005),
+  DOI `10.1016/j.tcs.2005.06.002` (container isomorphisms);
+  D. Leivant, "Ramified recurrence and computational complexity III",
+  APAL 96 (1999), DOI `10.1016/S0168-0072(98)00040-2`, section 2.1
+  (term layer).
+
+---
+
+## Task B.1: de-risking spike (iso-induced W-map and native bind)
+
+A short throwaway spike (scratch file, not committed) validating the
+two constructions the design marks hardest, before real tasks depend
+on them.
+
+- [ ] **Step 1:** In a scratch module importing
+  `Geb.Mathlib.Data.PFunctor.Slice.W`, define a toy pair of isomorphic
+  `SlicePFunctor PUnit PUnit`s (e.g. shapes `Bool` versus
+  `Unit ⊕ Unit`, positions `Fin 2` at one shape) and build the induced
+  W-map by `SlicePFunctor.W.elim` into the target `(W, wIndex)`
+  algebra, confirming the `Compatible` re-indexing across the position
+  equivalence and the `hg` side condition discharge.
+- [ ] **Step 2:** Define a toy `translate`-style augmented functor
+  (leaf shapes `Bool` over `PUnit`, node shapes from the toy functor)
+  and build `bind` as a single `W.elim` with a `Sum` shape split,
+  confirming: the leaf case's `hg` discharge from the substituted
+  tree's fiber property, and the node case's `Compatible` transfer
+  (the target functor has identical `B`/`r` at `Sum.inr`).
+- [ ] **Step 3:** Record working term shapes (motives, `hg` proofs,
+  transport idioms) as notes in the Task B.2 and B.5 implementation
+  steps if they differ from what is written there; delete the scratch
+  module.
+
+## Task B.2: `SlicePFunctor` isomorphisms and the induced W-equivalence
+
+**Files:**
+
+- Create: `GebLean/SliceW/Iso.lean`
+- Create: `GebLeanTests/SliceW/Iso.lean`
+- Create: `GebLean/SliceW.lean` (directory index; `import` this
+  module)
+- Modify: `GebLean.lean` (add `import GebLean.SliceW` in alphabetical
+  position)
+- Modify: `GebLeanTests.lean` (add
+  `import GebLeanTests.SliceW.Iso`)
+
+**Interfaces:**
+
+- Consumes: `SlicePFunctor` fields `A`/`B`/`q`/`r`, `rCurried`,
+  `toSliceDomPFunctor`, `Compatible`, `compatible_iff`, `obj`
+  (`Geb.Mathlib.Data.PFunctor.Slice.Basic`); `W`, `wIndex`, `W.mk`,
+  `W.elim`, `W.elim_mk`, `W.comp_elim`, `W.wIndex_mk`, `W.induction`
+  (`Geb.Mathlib.Data.PFunctor.Slice.W`); `Equiv` (mathlib).
+- Produces:
+  - `structure SlicePFunctor.Iso (F G : SlicePFunctor I I)` with
+    fields `shapeEquiv : F.A ≃ G.A`,
+    `posEquiv : ∀ a, F.B a ≃ G.B (shapeEquiv a)`,
+    `q_comm : ∀ a, G.q (shapeEquiv a) = F.q a`,
+    `r_comm : ∀ a b, G.r ⟨shapeEquiv a, posEquiv a b⟩ = F.r ⟨a, b⟩`.
+  - `def SlicePFunctor.Iso.symm : Iso F G → Iso G F` (equivalences
+    reversed; `q_comm`/`r_comm` by rewriting along the forward fields
+    at `shapeEquiv.symm a` / `(posEquiv _).symm b`).
+  - `def SlicePFunctor.Iso.wMap (e : Iso F G) : F.W → G.W` — a single
+    `W.elim` into the algebra `(G.W, G.wIndex)`: at a node
+    `⟨⟨a, c⟩, hc⟩` build
+    `W.mk ⟨⟨e.shapeEquiv a, fun b' => c ((e.posEquiv a).symm b')⟩, _⟩`,
+    with the compatibility from `hc` pointwise (`compatible_iff`) and
+    `r_comm` at `(e.posEquiv a).symm b'` (rewriting through
+    `(e.posEquiv a).apply_symm_apply`); `hg` by `funext`, `wIndex_mk`,
+    and `q_comm`.
+  - `theorem SlicePFunctor.Iso.wIndex_wMap (e : Iso F G) (z : F.W) :`
+    `G.wIndex (e.wMap z) = F.wIndex z` — from `W.comp_elim` and
+    `q_comm` (pointwise application of the `comp_elim` equation).
+  - `theorem SlicePFunctor.Iso.wMap_mk` (`@[simp]`) — constructor
+    naturality: `e.wMap (W.mk ⟨⟨a, c⟩, hc⟩)` equals the `W.mk` node at
+    `e.shapeEquiv a` with children `fun b' => e.wMap (c ((e.posEquiv
+    a).symm b'))`; from `W.elim_mk`.
+  - `theorem SlicePFunctor.Iso.symm_wMap_wMap (e : Iso F G) (z : F.W) :`
+    `e.symm.wMap (e.wMap z) = z` and
+    `theorem SlicePFunctor.Iso.wMap_symm_wMap (e : Iso F G) (z : G.W) :`
+    `e.wMap (e.symm.wMap z) = z` — both by `W.induction`, using
+    `wMap_mk` and the `Equiv` round-trip lemmas
+    (`Equiv.symm_apply_apply`, `Equiv.apply_symm_apply`); expect
+    `Subtype.ext`/`Sigma.ext`-with-`heq_of_eq` closing shapes as in
+    Phase A's `toSliceW_ofSliceW`.
+  - `def SlicePFunctor.Iso.wEquiv (e : Iso F G) : F.W ≃ G.W` —
+    packaging `wMap`/`symm.wMap` with the two round trips.
+  - `def SlicePFunctor.Iso.wEquivFiber (e : Iso F G) (i : I) :`
+    `{ w : F.W // F.wIndex w = i } ≃ { w' : G.W // G.wIndex w' = i }`
+    — `wEquiv` restricted along `wIndex_wMap` (both directions use
+    `wIndex_wMap` of `e` and `e.symm`).
+
+**Steps:**
+
+- [ ] **Step 1: Write the failing test.** In
+  `GebLeanTests/SliceW/Iso.lean`, define the spike's toy isomorphic
+  pair and assert: `wIndex_wMap` on a sample tree built by `W.mk`, and
+  the round trip `e.wEquiv.symm (e.wEquiv t) = t` via
+  `Equiv.symm_apply_apply`.
+- [ ] **Step 2: Run to verify it fails.** Run
+  `lake build GebLeanTests.SliceW.Iso`. Expected: failure,
+  `SlicePFunctor.Iso` not found.
+- [ ] **Step 3: Implement.** Write the module docstring (references:
+  Abbott–Altenkirch–Ghani 2005 for container isomorphisms;
+  Gambino–Kock 2013 for the W-type as initial algebra). Define the
+  structure and declarations in the interface order above (one at a
+  time, building between declarations). Create `GebLean/SliceW.lean`
+  with a module docstring naming the directory's purpose, and wire the
+  aggregator imports.
+- [ ] **Step 4: Run to verify it passes.** Run
+  `lake build GebLeanTests.SliceW.Iso`. Expected: success.
+- [ ] **Step 5: Gate.** Run `bash scripts/pre-commit.sh`. Expected:
+  all three stages pass.
+- [ ] **Step 6: Commit.**
+
+```bash
+jj commit -m "feat(slicew): add slice-functor isomorphisms with W-type transport"
+```
+
+## Task B.3: the `translate` augmentation
+
+**Files:**
+
+- Create: `GebLean/SliceW/Translate.lean`
+- Create: `GebLeanTests/SliceW/Translate.lean`
+- Modify: `GebLean/SliceW.lean` (`import` this module)
+- Modify: `GebLeanTests.lean` (add
+  `import GebLeanTests.SliceW.Translate`)
+
+**Interfaces:**
+
+- Consumes: `SlicePFunctor` (`Geb.Mathlib.Data.PFunctor.Slice.Basic`);
+  `PEmpty`.
+- Produces:
+  - `def SlicePFunctor.translate (v : Y → I) (F : SlicePFunctor I I) :`
+    `SlicePFunctor I I` with underlying `PFunctor`
+    `⟨Y ⊕ F.A, fun a => match a with | .inl _ => PEmpty | .inr a => F.B a⟩`,
+    `q := Sum.elim v F.q`,
+    `r := fun x => match x with`
+    `| ⟨.inl _, e⟩ => e.elim | ⟨.inr a, b⟩ => F.r ⟨a, b⟩`.
+    (The `match`es are non-recursive shape splits, permitted. Let the
+    elaborator place `PEmpty`'s universe; annotate only if unification
+    fails.)
+  - `@[simp]` characterization lemmas `translate_A`,
+    `translate_B_inl` (`= PEmpty`), `translate_B_inr` (`= F.B a`),
+    `translate_q_inl` (`= v y`), `translate_q_inr` (`= F.q a`),
+    `translate_r_inr` (`= F.r ⟨a, b⟩`), each by `rfl`. No
+    `translate_r_inl` (the position type is empty).
+
+**Steps:**
+
+- [ ] **Step 1: Write the failing test.** Assert, for a toy
+  `v : Bool → PUnit` and the Task B.2 toy functor, that
+  `(translate v F).q (.inl true) = v true` and
+  `(translate v F).q (.inr a) = F.q a` by `simp`/`rfl` through the
+  characterization lemmas.
+- [ ] **Step 2: Run to verify it fails.** Run
+  `lake build GebLeanTests.SliceW.Translate`. Expected: failure,
+  `translate` not found.
+- [ ] **Step 3: Implement** the definition and the six `@[simp]`
+  lemmas, with the module docstring citing Gambino–Kock 2013 (the
+  translation `Y + F(−)`).
+- [ ] **Step 4: Run to verify it passes.** Run
+  `lake build GebLeanTests.SliceW.Translate`. Expected: success.
+- [ ] **Step 5: Gate.** Run `bash scripts/pre-commit.sh`.
+- [ ] **Step 6: Commit.**
+
+```bash
+jj commit -m "feat(slicew): add the translate augmentation of a slice endofunctor"
+```
+
+## Task B.4: `FreeM` carrier and constructors
+
+**Files:**
+
+- Create: `GebLean/SliceW/FreeM.lean`
+- Create: `GebLeanTests/SliceW/FreeM.lean`
+- Modify: `GebLean/SliceW.lean` (`import` this module)
+- Modify: `GebLeanTests.lean` (add `import GebLeanTests.SliceW.FreeM`)
+
+**Interfaces:**
+
+- Consumes: `translate` and its `@[simp]` lemmas (Task B.3); `W`,
+  `wIndex`, `W.mk`, `W.wIndex_mk`, `compatible_iff`
+  (vendored stack).
+- Produces:
+  - `def SlicePFunctor.FreeM (v : Y → I) (F : SlicePFunctor I I)`
+    `(i : I) := { w : (translate v F).W // (translate v F).wIndex w = i }`.
+  - `def SlicePFunctor.FreeM.pure {v : Y → I} {F} {i}`
+    `(a : { y : Y // v y = i }) : FreeM v F i` — the subtype pair of
+    `W.mk ⟨⟨Sum.inl a.1, fun e => e.elim⟩, funext fun e => e.elim⟩`
+    with fiber proof by `wIndex_mk` then `a.2`.
+  - `def SlicePFunctor.FreeM.node {v : Y → I} {F} (a : F.A)`
+    `(c : (b : F.B a) → FreeM v F (F.rCurried a b)) : FreeM v F (F.q a)`
+    — the subtype pair of
+    `W.mk ⟨⟨Sum.inr a, fun b => (c b).1⟩, _⟩` where the compatibility
+    is `(compatible_iff …).mpr fun b => (c b).2` (children's fiber
+    proofs), and the fiber proof is `wIndex_mk` then `translate_q_inr`.
+  - `@[simp] theorem SlicePFunctor.FreeM.pure_val` and
+    `node_val` — the underlying-tree characterizations (`(pure a).1 =
+    W.mk …`, `(node a c).1 = W.mk …`), each `rfl`; these are the
+    constructor-level lemmas later tasks rewrite with.
+
+**Steps:**
+
+- [ ] **Step 1: Write the failing test.** With the toy translate
+  functor from Task B.3's test: build `FreeM.pure ⟨true, rfl⟩` and a
+  `FreeM.node` with leaf children; assert their `.2` fiber properties
+  and the `pure_val`/`node_val` equations by `simp`/`rfl`.
+- [ ] **Step 2: Run to verify it fails.** Run
+  `lake build GebLeanTests.SliceW.FreeM`. Expected: failure, `FreeM`
+  not found.
+- [ ] **Step 3: Implement** the three definitions and two lemmas, one
+  at a time; module docstring cites Gambino–Kock 2013 (free monad as
+  the W-type of the translation).
+- [ ] **Step 4: Run to verify it passes.** Run
+  `lake build GebLeanTests.SliceW.FreeM`. Expected: success.
+- [ ] **Step 5: Gate.** Run `bash scripts/pre-commit.sh`.
+- [ ] **Step 6: Commit.**
+
+```bash
+jj commit -m "feat(slicew): add the free-monad carrier and constructors"
+```
+
+## Task B.5: `FreeM.bind` and its computation rules
+
+**Files:**
+
+- Modify: `GebLean/SliceW/FreeM.lean`
+- Modify: `GebLeanTests/SliceW/FreeM.lean`
+
+**Interfaces:**
+
+- Consumes: Task B.4's declarations; `W.elim`, `W.elim_mk`,
+  `W.comp_elim` (vendored stack).
+- Produces (leaf families `v : Y → I`, `v' : Y' → I` throughout — the
+  target family has its own leaf type):
+  - `def SlicePFunctor.FreeM.bindW {v : Y → I} {v' : Y' → I} {F}`
+    `(f : ∀ j, { a : Y // v a = j } → FreeM v' F j) :`
+    `(translate v F).W → (translate v' F).W` — a single
+    `W.elim (translate v F) ((translate v' F).W) (translate v' F).wIndex g hg`
+    where `g` splits the node's shape:
+    at `⟨⟨Sum.inl y, _⟩, _⟩` return `(f (v y) ⟨y, rfl⟩).1`; at
+    `⟨⟨Sum.inr a, c⟩, hc⟩` return
+    `W.mk ⟨⟨Sum.inr a, c⟩, hc'⟩` where `hc'` re-reads `hc` as
+    compatibility for `translate v' F` (`B` and `r` agree at `Sum.inr`
+    by `translate_B_inr` / `translate_r_inr`; expect this to be
+    definitional, else pointwise via `compatible_iff`); `hg` by
+    `funext` and the same split — leaf: `(f (v y) ⟨y, rfl⟩).2`; node:
+    `wIndex_mk`.
+  - `def SlicePFunctor.FreeM.bind {v : Y → I} {v' : Y' → I} {F} {i}`
+    `(t : FreeM v F i)`
+    `(f : ∀ j, { a : Y // v a = j } → FreeM v' F j) : FreeM v' F i` —
+    `⟨bindW f t.1, _⟩` with the fiber proof from
+    `congrFun (W.comp_elim …) t.1` (the `wIndex`-preservation of the
+    fold) transported along `t.2`.
+  - `theorem SlicePFunctor.FreeM.pure_bind {v : Y → I} {v' : Y' → I}`
+    `{F} {i} (a : { y : Y // v y = i }) (f) :`
+    `(FreeM.pure a).bind f = f i a` — by
+    `obtain ⟨y, hy⟩ := a; subst hy`, then `Subtype.ext` and the
+    `W.elim_mk` computation at the leaf shape (expected `rfl` after
+    the subst).
+  - `theorem SlicePFunctor.FreeM.bind_node {v : Y → I} {v' : Y' → I}`
+    `{F} (a : F.A) (c) (f) :`
+    `(FreeM.node a c).bind f = FreeM.node a (fun b => (c b).bind f)` —
+    `Subtype.ext`, `W.elim_mk` at the node shape, then `congrArg` on
+    the children family.
+
+  Neither computation rule is `@[simp]` (operation-level; Phase A
+  policy).
+
+**Steps:**
+
+- [ ] **Step 1: Write the failing test.** On the toy signature:
+  substitute a leaf into a one-node tree and assert the result equals
+  the expected tree by rewriting with `pure_bind` and `bind_node`
+  only (no kernel reduction of trees).
+- [ ] **Step 2: Run to verify it fails.** Run
+  `lake build GebLeanTests.SliceW.FreeM`. Expected: failure, `bind`
+  not found.
+- [ ] **Step 3: Implement** `bindW`, `bind`, `pure_bind`, `bind_node`,
+  one at a time.
+- [ ] **Step 4: Run to verify it passes.** Run
+  `lake build GebLeanTests.SliceW.FreeM`. Expected: success.
+- [ ] **Step 5: Gate.** Run `bash scripts/pre-commit.sh`.
+- [ ] **Step 6: Commit.**
+
+```bash
+jj commit -m "feat(slicew): add free-monad bind with computation rules"
+```
+
+## Task B.6: free-monad laws and transport lemmas
+
+**Files:**
+
+- Modify: `GebLean/SliceW/FreeM.lean`
+- Modify: `GebLeanTests/SliceW/FreeM.lean`
+
+**Interfaces:**
+
+- Consumes: Tasks B.4–B.5; `W.induction` (vendored stack).
+- Produces:
+  - `theorem SlicePFunctor.FreeM.bindW_pure {v : Y → I} {F}`
+    `(z : (translate v F).W) :`
+    `bindW (fun _ a => FreeM.pure a) z = z` — by `W.induction` with a
+    `Sum` shape split: leaf nodes reduce to the `pure` tree (children
+    families into `PEmpty` are equal by `funext` + elimination); node
+    case by `congrArg` with the induction hypotheses (the
+    `Sigma.ext rfl (heq_of_eq …)` closing shape of Phase A).
+  - `theorem SlicePFunctor.FreeM.bind_pure {v : Y → I} {F} {i}`
+    `(t : FreeM v F i) : t.bind (fun _ a => FreeM.pure a) = t` —
+    `Subtype.ext (bindW_pure t.1)`.
+  - `theorem SlicePFunctor.FreeM.bindW_bindW {v : Y → I} {v' : Y' → I}`
+    `{v'' : Y'' → I} {F} (f : ∀ j, { a : Y // v a = j } → FreeM v' F j)`
+    `(g : ∀ j, { b : Y' // v' b = j } → FreeM v'' F j)`
+    `(z : (translate v F).W) :`
+    `bindW g (bindW f z) = bindW (fun j a => (f j a).bind g) z` — by
+    `W.induction` with the shape split: leaf reduces both sides to
+    `((f (v y) ⟨y, rfl⟩).bind g).1`; node by `congrArg` with the
+    induction hypotheses.
+  - `theorem SlicePFunctor.FreeM.bind_assoc {v : Y → I} {v' : Y' → I}`
+    `{v'' : Y'' → I} {F} {i} (t : FreeM v F i) (f) (g) :`
+    `(t.bind f).bind g = t.bind (fun j a => (f j a).bind g)` —
+    `Subtype.ext (bindW_bindW f g t.1)`.
+  - `theorem SlicePFunctor.FreeM.pure_transport {v : Y → I} {F}`
+    `{i i' : I} (h : i = i') (y : Y) (hy : v y = i) :`
+    `h ▸ (FreeM.pure ⟨y, hy⟩ : FreeM v F i) = FreeM.pure ⟨y, hy.trans h⟩`
+    — by `subst h; rfl`.
+  - `theorem SlicePFunctor.FreeM.bind_transport {v : Y → I}`
+    `{v' : Y' → I} {F} {i i' : I} (h : i = i') (t : FreeM v F i) (f) :`
+    `(h ▸ t).bind f = h ▸ (t.bind f)` — by `subst h; rfl`.
+
+**Steps:**
+
+- [ ] **Step 1: Write the failing test.** Assert `bind_pure` and
+  `bind_assoc` instances on the Task B.5 sample trees (statement-level
+  `example`s applying the theorems, not tree computation).
+- [ ] **Step 2: Run to verify it fails.** Run
+  `lake build GebLeanTests.SliceW.FreeM`. Expected: failure, law names
+  not found.
+- [ ] **Step 3: Implement** the six lemmas in the order above (raw
+  `bindW` lemmas first, wrapped forms second, transports last).
+- [ ] **Step 4: Run to verify it passes.** Run
+  `lake build GebLeanTests.SliceW.FreeM`. Expected: success.
+- [ ] **Step 5: Gate.** Run `bash scripts/pre-commit.sh`.
+- [ ] **Step 6: Commit.**
+
+```bash
+jj commit -m "feat(slicew): prove the free-monad laws and transport lemmas"
+```
+
+## Task B.7: the augmentation isomorphism and `polyFreeMSliceEquiv`
+
+**Files:**
+
+- Create: `GebLean/PolyBridge/FreeMEquiv.lean`
+- Create: `GebLeanTests/PolyBridge/FreeMEquiv.lean`
+- Modify: `GebLean/PolyBridge.lean` (`import` this module)
+- Modify: `GebLeanTests.lean` (add
+  `import GebLeanTests.PolyBridge.FreeMEquiv`)
+
+**Interfaces:**
+
+- Consumes: `SlicePFunctor.Iso`, `Iso.wEquivFiber` (Task B.2);
+  `translate` (Task B.3); `FreeM` (Task B.4); `toSlice`, `toSlice_*`
+  (Phase A); `polyFixSliceEquiv` (Phase A); `polyTranslate`,
+  `polyTranslateIndex`, `polyTranslateFamily`, `overEmpty`,
+  `PolyFreeM` (`GebLean/PolyAlg.lean`); `Equiv.sigmaSumDistrib` or
+  equivalent mathlib pieces (`Equiv.sumSigmaDistrib` — verify the
+  exact mathlib name with `lean_local_search` / `loogle` before use;
+  build by hand from `Equiv.ofBijective`-free explicit `toFun`/
+  `invFun` if no fit exists), `Equiv.sigmaFiberEquiv` (mathlib:
+  `Σ x, { a // f a = x } ≃ …` — verify orientation).
+- Produces:
+  - `def translateSliceIso {X : Type u} (V : Over X) (P : PolyEndo X) :`
+    `SlicePFunctor.Iso (toSlice (polyTranslate V P))`
+    `(SlicePFunctor.translate V.hom (toSlice P))` — shapes:
+    `Σ x, ({ a : V.left // V.hom a = x } ⊕ polyBetweenIndex X X P x)`
+    `≃ V.left ⊕ Σ x, polyBetweenIndex X X P x` (distribute the sigma
+    over the sum, contract `Σ x, { a // V.hom a = x } ≃ V.left`);
+    positions: `PEmpty ≃ PEmpty` at leaves (identity), identity at
+    nodes; `q_comm`: definitional at nodes and at leaf positions, by
+    the leaf's stored fiber witness at leaf shapes; `r_comm`:
+    definitional at nodes, vacuous at leaves (`PEmpty` positions).
+  - `def polyFreeMSliceEquiv {X : Type u} (V : Over X) (P : PolyEndo X)`
+    `(x : X) : PolyFreeM V P x ≃ SlicePFunctor.FreeM V.hom (toSlice P) x`
+    — `(polyFixSliceEquiv (polyTranslate V P) x).trans`
+    `((translateSliceIso V P).wEquivFiber x)` (the second leg lands in
+    the `FreeM` subtype definitionally; insert an `Equiv.cast`-free
+    `show`/`change` re-typing if the elaborator needs the `FreeM`
+    name).
+
+**Steps:**
+
+- [ ] **Step 1: Write the failing test.** For `natAlgSig.polyEndo`
+  with a two-element variable family over `PUnit`, assert the round
+  trip `(polyFreeMSliceEquiv …).symm ((polyFreeMSliceEquiv …) t) = t`
+  on a small `polyFreeMPure` tree, via `Equiv.symm_apply_apply`.
+- [ ] **Step 2: Run to verify it fails.** Run
+  `lake build GebLeanTests.PolyBridge.FreeMEquiv`. Expected: failure,
+  names not found.
+- [ ] **Step 3: Implement `translateSliceIso`.** Search mathlib for
+  the sigma-sum distribution and sigma-fiber-contraction equivalences
+  first (`lean_local_search`, `loogle`); compose them, or write the
+  explicit `toFun`/`invFun` pair (both directions are `rfl`-inverse
+  case splits). Prove `q_comm`/`r_comm` by shape split.
+- [ ] **Step 4: Implement `polyFreeMSliceEquiv`** as the two-leg
+  composite.
+- [ ] **Step 5: Run to verify it passes.** Run
+  `lake build GebLeanTests.PolyBridge.FreeMEquiv`. Expected: success.
+- [ ] **Step 6: Gate.** Run `bash scripts/pre-commit.sh`.
+- [ ] **Step 7: Commit.**
+
+```bash
+jj commit -m "feat(polybridge): relate the legacy free monad to the slice free monad"
+```
+
+## Task B.8: bridge naturality (`pure`, `node`, `bind`)
+
+**Files:**
+
+- Modify: `GebLean/PolyBridge/FreeMEquiv.lean`
+- Modify: `GebLeanTests/PolyBridge/FreeMEquiv.lean`
+
+**Interfaces:**
+
+- Consumes: Task B.7; `polyFixSliceEquiv_mk` (Phase A);
+  `Iso.wMap_mk` (Task B.2); `FreeM.pure`/`node`/`bind`,
+  `pure_bind`, `bind_node` (Tasks B.4–B.5); `polyFreeMPure`,
+  `polyFreeMBind`, `PolyFix.ind` (`GebLean/PolyAlg.lean`).
+- Produces (none `@[simp]`; operation-level):
+  - `theorem polyFreeMSliceEquiv_pure (V P x)`
+    `(a : { v : V.left // V.hom v = x }) :`
+    `polyFreeMSliceEquiv V P x (polyFreeMPure V P a) = FreeM.pure a` —
+    unfold the two legs on the leaf node: `polyFixSliceEquiv_mk` then
+    `Iso.wMap_mk` at the leaf shape; close with `Subtype.ext` and a
+    `funext` on `PEmpty` children.
+  - `theorem polyFreeMSliceEquiv_node (V P x)`
+    `(p : polyBetweenIndex X X P x) (ch) :`
+    `polyFreeMSliceEquiv V P x (PolyFix.mk x (Sum.inr p) ch) =`
+    `FreeM.node ⟨x, p⟩ (fun e => polyFreeMSliceEquiv V P _ (ch e))` —
+    same two-lemma unfolding at the node shape.
+  - `theorem polyFreeMSliceEquiv_bind (V B P x) (t : PolyFreeM V P x)`
+    `(f : ∀ y, { a : V.left // V.hom a = y } → PolyFreeM B P y) :`
+    `polyFreeMSliceEquiv B P x (polyFreeMBind V B P t f) =`
+    `(polyFreeMSliceEquiv V P x t).bind`
+    `(fun y a => polyFreeMSliceEquiv B P y (f y a))` — by
+    `PolyFix.ind` on `t`: the leaf case is
+    `polyFreeMSliceEquiv_pure` + `FreeM.pure_bind`; the node case is
+    `polyFreeMSliceEquiv_node` + `FreeM.bind_node` + the induction
+    hypotheses under `congrArg`.
+
+**Steps:**
+
+- [ ] **Step 1: Write the failing test.** `example`s applying each
+  naturality lemma at the Task B.7 sample data.
+- [ ] **Step 2: Run to verify it fails.** Run
+  `lake build GebLeanTests.PolyBridge.FreeMEquiv`. Expected: failure.
+- [ ] **Step 3: Implement** the three lemmas in order (each consumes
+  the previous).
+- [ ] **Step 4: Run to verify it passes.** Run
+  `lake build GebLeanTests.PolyBridge.FreeMEquiv`. Expected: success.
+- [ ] **Step 5: Gate.** Run `bash scripts/pre-commit.sh`.
+- [ ] **Step 6: Commit.**
+
+```bash
+jj commit -m "feat(polybridge): prove free-monad naturality across the bridge"
+```
+
+## Task B.9: the `Tm'` term layer with clone laws
+
+**Files:**
+
+- Create: `GebLean/Ramified/Polynomial/Term.lean`
+- Create: `GebLeanTests/Ramified/Polynomial/Term.lean`
+- Modify: `GebLean/Ramified/Polynomial.lean` (`import` this module)
+- Modify: `GebLeanTests/Ramified/Polynomial.lean` (`import` the test)
+
+**Interfaces:**
+
+- Consumes: `FreeM` and all Task B.4–B.6 declarations; `toSlice`
+  (Phase A); `SortedSig`, `SortedSig.polyEndo`, `Ctx`, `varOver`
+  (`GebLean/Ramified/{SortedSig,Term}.lean`).
+- Produces (all mirroring `GebLean/Ramified/Term.lean` signatures):
+  - `def Tm' (sig : SortedSig S) (Γ : Ctx S) : S → Type :=`
+    `SlicePFunctor.FreeM Γ.get (toSlice sig.polyEndo)`.
+  - `def Tm'.var {sig} {Γ} (i : Fin Γ.length) : Tm' sig Γ (Γ.get i) :=`
+    `SlicePFunctor.FreeM.pure ⟨i, rfl⟩`.
+  - `def Tm'.op {sig} {Γ} (o : sig.Op)`
+    `(args : ∀ i : Fin (sig.arity o).length, Tm' sig Γ ((sig.arity o).get i)) :`
+    `Tm' sig Γ (sig.result o) :=`
+    `SlicePFunctor.FreeM.node ⟨sig.result o, ⟨o, rfl⟩⟩ args` (the
+    shape of `toSlice sig.polyEndo` at the result sort; `args`
+    coerces along the definitional `B`/`rCurried` unfoldings — insert
+    a `show`/`change` re-typing if needed).
+  - `def Tm'.subst {sig} {Γ Δ} {s} (t : Tm' sig Γ s)`
+    `(σ : ∀ i : Fin Γ.length, Tm' sig Δ (Γ.get i)) : Tm' sig Δ s :=`
+    `t.bind (fun _ a => a.2 ▸ σ a.1)`.
+  - `def Tm'.reind` (`h ▸ t`), `@[simp] theorem Tm'.reind_rfl`,
+    `def Tm'.weaken` — verbatim mirrors of the legacy forms.
+  - `theorem Tm'.var_subst (i) (σ) : (Tm'.var i).subst σ = σ i` — from
+    `FreeM.pure_bind` (the transport at `rfl` vanishes).
+  - `theorem Tm'.subst_id (t) : t.subst Tm'.var = t` — mirror of the
+    legacy proof: reduce to `FreeM.bind_pure` after rewriting the leaf
+    function with `FreeM.pure_transport` (`congr 1; funext y a;`
+    `obtain ⟨v, hv⟩ := a; exact FreeM.pure_transport …`).
+  - `theorem Tm'.subst_subst (t) (σ) (τ) :`
+    `(t.subst σ).subst τ = t.subst (fun i => (σ i).subst τ)` — mirror
+    of the legacy proof via `FreeM.bind_assoc` and
+    `FreeM.bind_transport`.
+  - `theorem Tm'.subst_reind` — `subst h; rfl` mirror.
+
+**Steps:**
+
+- [ ] **Step 1: Write the failing test.** Define a two-sorted toy
+  signature in the test file (`SortedSig Bool`, one operation per
+  sort with mixed-arity arguments), a two-entry context, and assert:
+  `Tm'.var_subst` at each position, one `Tm'.subst_id` instance, and
+  one `Tm'.subst_subst` instance — all via the clone-law theorems.
+- [ ] **Step 2: Run to verify it fails.** Run
+  `lake build GebLeanTests.Ramified.Polynomial.Term`. Expected:
+  failure, `Tm'` not found.
+- [ ] **Step 3: Implement** the definitions in interface order, then
+  the clone laws (module docstring cites Leivant 1999 section 2.1, as
+  `GebLean/Ramified/Term.lean` does).
+- [ ] **Step 4: Run to verify it passes.** Run
+  `lake build GebLeanTests.Ramified.Polynomial.Term`. Expected:
+  success.
+- [ ] **Step 5: Gate.** Run `bash scripts/pre-commit.sh`.
+- [ ] **Step 6: Commit.**
+
+```bash
+jj commit -m "feat(ramified): add the sorted term layer on the slice free monad"
+```
+
+## Task B.10: `tmSliceEquiv`, compatibility, and documentation
+
+**Files:**
+
+- Modify: `GebLean/Ramified/Polynomial/Term.lean`
+- Modify: `GebLeanTests/Ramified/Polynomial/Term.lean`
+- Modify: `docs/areas/polynomial-functors.md` (add `GebLean/SliceW/`
+  and `PolyBridge/FreeMEquiv.lean` to the area inventory)
+- Modify: `docs/areas/ramified-recurrence.md` (add
+  `GebLean/Ramified/Polynomial/Term.lean`)
+
+**Interfaces:**
+
+- Consumes: Task B.9; `polyFreeMSliceEquiv` and the three naturality
+  lemmas (Tasks B.7–B.8); `Tm`, `Tm.var`, `Tm.op`, `Tm.subst`
+  (`GebLean/Ramified/Term.lean`).
+- Produces:
+  - `def tmSliceEquiv {sig} (Γ : Ctx S) (s : S) :`
+    `Tm' sig Γ s ≃ Tm sig Γ s :=`
+    `(polyFreeMSliceEquiv (varOver Γ) sig.polyEndo s).symm` (the
+    `.symm` re-orients the bridge so the primed carrier is the
+    source; `(varOver Γ).hom = Γ.get` definitionally).
+  - `theorem tmSliceEquiv_var (i) :`
+    `tmSliceEquiv Γ _ (Tm'.var i) = Tm.var i` — from
+    `polyFreeMSliceEquiv_pure` via the equivalence laws
+    (`Equiv.symm_apply_eq`, as in Phase A's `freeAlgSliceEquiv_mk`
+    derivation).
+  - `theorem tmSliceEquiv_op (o) (args) :`
+    `tmSliceEquiv Γ _ (Tm'.op o args) =`
+    `Tm.op o (fun i => tmSliceEquiv Γ _ (args i))` — from
+    `polyFreeMSliceEquiv_node` the same way.
+  - `theorem tmSliceEquiv_subst (t) (σ) :`
+    `tmSliceEquiv Γ _ (t.subst σ) =`
+    `(tmSliceEquiv Γ _ t).subst (fun i => tmSliceEquiv Γ _ (σ i))` —
+    from `polyFreeMSliceEquiv_bind` via the equivalence laws, moving
+    the leaf-function transport with `FreeM.pure_transport` /
+    `polyFreeMPure_transport` as needed (the legacy and primed leaf
+    functions both transport by `a.2 ▸ σ a.1`).
+- None of the three are `@[simp]`.
+
+**Steps:**
+
+- [ ] **Step 1: Write the failing test.** On the Task B.9 toy
+  signature: assert `tmSliceEquiv_var`, `tmSliceEquiv_op`, and one
+  `tmSliceEquiv_subst` instance, plus one transported round trip
+  `(tmSliceEquiv …).symm (tmSliceEquiv … t) = t`.
+- [ ] **Step 2: Run to verify it fails.** Run
+  `lake build GebLeanTests.Ramified.Polynomial.Term`. Expected:
+  failure, `tmSliceEquiv` not found.
+- [ ] **Step 3: Implement** the equivalence and the three lemmas.
+- [ ] **Step 4: Update the two area documents**; run
+  `doctoc --update-only docs/` and
+  `markdownlint-cli2 'docs/**/*.md'` on the touched files.
+- [ ] **Step 5: Run to verify it passes.** Run
+  `lake build GebLeanTests.Ramified.Polynomial.Term` and `lake test`.
+  Expected: success.
+- [ ] **Step 6: Gate.** Run `bash scripts/pre-commit.sh`.
+- [ ] **Step 7: Commit.**
+
+```bash
+jj commit -m "feat(ramified): relate the primed term layer to Tm and document it"
+```
+
+## Task B.11: whole-branch verification
+
+- [ ] **Step 1:** Run `bash scripts/pre-push.sh`. Expected: every
+  stage passes (Lean triad, markdownlint, doctoc, axiom-linter test).
+- [ ] **Step 2:** Whole-branch review per
+  superpowers:requesting-code-review against the design document;
+  address findings; re-run the gate after any change.
+- [ ] **Step 3:** Hand off to the user for the push / PR decision (no
+  `jj git push` without user line-by-line review).

--- a/geb-lean/docs/superpowers/plans/2026-07-19-ramified-poly-freemonad-subplan.review-1.md
+++ b/geb-lean/docs/superpowers/plans/2026-07-19-ramified-poly-freemonad-subplan.review-1.md
@@ -1,0 +1,125 @@
+# Adversarial review 1: Phase B free-monad sub-plan
+
+<!-- START doctoc generated TOC please keep comment here to allow auto update -->
+<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
+
+- [Blockers](#blockers)
+- [Majors](#majors)
+- [Minors](#minors)
+- [Nits](#nits)
+- [Verified without defect](#verified-without-defect)
+- [Disposition](#disposition)
+- [Overall](#overall)
+
+<!-- END doctoc generated TOC please keep comment here to allow auto update -->
+
+Round 1, 2026-07-20. Two fresh-context reviewers (signature
+verification and construction feasibility; style, process, and
+coverage with the mathlib upstream guides re-fetched) against source
+at branch `feat/ramified-poly-freemonad`. Every claim below was
+re-verified against source before entry.
+
+## Blockers
+
+None.
+
+## Majors
+
+None.
+
+## Minors
+
+- M1 (Task B.2, `Iso.symm`). "Equivalences reversed" understates the
+  `posEquiv` field of `symm`: at `a' : G.A` it must land in
+  `F.B (shapeEquiv.symm a')`, but the reversed forward field has
+  domain `G.B (shapeEquiv (shapeEquiv.symm a'))`, so stating the field
+  requires a transport along `Equiv.apply_symm_apply`, which then
+  threads through `symm`'s `r_comm` proof and the round trips. Fix:
+  state the transport in the task.
+- M2 (Task B.7, Consumes). `Equiv.sumSigmaDistrib` is the
+  sigma-indexed-by-a-sum variant and does not fit; the fitting
+  composite is `Equiv.sigmaSumDistrib`
+  (`(Σ i, α i ⊕ β i) ≃ (Σ i, α i) ⊕ (Σ i, β i)`) with
+  `Equiv.sumCongr (Equiv.sigmaFiberEquiv V.hom) (Equiv.refl _)`;
+  all three verified present in this checkout's mathlib
+  (`Mathlib/Logic/Equiv/Sum.lean`). Fix: name the verified composite,
+  drop the wrong pointer and the search instruction.
+- M3 (Task B.10, `tmSliceEquiv_subst`). The named transport tools move
+  `pure` only; matching the leaf functions across
+  `polyFreeMSliceEquiv_bind` needs transport-naturality of the
+  equivalence itself, `polyFreeMSliceEquiv V P x' (h ▸ t) =
+  h ▸ polyFreeMSliceEquiv V P x t` (one line by `subst`), absent from
+  every Produces block. The legacy analogue needed the dedicated
+  `polyFreeMBind_transport` at the corresponding step. Fix: add
+  `polyFreeMSliceEquiv_transport` to Task B.8's Produces and route
+  B.10 through it.
+- M4 (Task B.4, lemma names). `pure_val` / `node_val` put the
+  projection last; the mathlib convention (left-hand side determines
+  the name, projection first, as in `Fin.val_mk` / `Subtype.coe_mk`)
+  gives `val_pure` / `val_node`. Fix: rename.
+- M5 (Task B.1, acceptance criterion). The design requires the spike
+  constructions validated sorry-free; the task's steps do not state
+  the criterion. Fix: add "sorry-free" to Steps 1–2.
+
+## Nits
+
+- N1 (Task B.2, `wIndex_wMap`). `W.comp_elim` alone yields the
+  statement (`p ∘ elim … = F.wIndex` pointwise); `q_comm` is consumed
+  inside `hg`, not in this derivation. Fix: drop "and `q_comm`".
+- N2 (Tasks B.2/B.4, Consumes). `Compatible`, `compatible_iff`,
+  `rCurried` live in namespace `SliceDomPFunctor`, reached by dot
+  notation through `toSliceDomPFunctor`. Fix: attribute them
+  correctly.
+- N3 (Global constraints). "where frictionless" is a metaphor; the
+  design's phrasing is "as far as it compiles". Fix: use the design's
+  phrasing.
+- N4 (Task B.1, heading and intro). "De-risking" and "throwaway" are
+  colloquial. Fix: "validation spike"; "scratch file, deleted before
+  any commit".
+- N5 (coverage, plan-not-in-design). `Iso.symm`, `wMap_mk`,
+  `val_pure`/`val_node`, `FreeM.bind_node`, `Tm'.reind_rfl` are
+  consistent elaborations of the design; `bind_node` is load-bearing
+  for the Task B.8 bridge proof, so the design document is amended to
+  record it. No design deliverable lacks a plan task.
+- N6 (filename). The plan file ends `-subplan.md` with date
+  2026-07-19 while the design is dated 2026-07-20; the cross-references
+  are mutually consistent and the path is fixed by the master plan and
+  handoff. No action.
+
+## Verified without defect
+
+- Every consumed declaration exists as cited across the vendored
+  `Slice/{Basic,W}.lean`, `GebLean/PolyAlg.lean`,
+  `GebLean/Ramified/{Term,SortedSig,AlgSig}.lean`, Phase A modules,
+  and the aggregators; `W.elim`'s argument list matches every
+  invocation; `Tm.subst`'s leaf function is verbatim
+  `fun _ a => a.2 ▸ σ a.1`.
+- Load-bearing feasibility: the B.2 `wMap` algebra (node type,
+  compatibility re-indexing, `hg`); `wEquivFiber` from `wEquiv` +
+  `wIndex_wMap` both ways; B.3 `translate` universe coherence
+  (`SlicePFunctor.{max uY uA, uB, uI, uI}`); B.5 `bindW`'s leaf case
+  and the definitional `B`/`r` agreement of `translate v F` and
+  `translate v' F` at `Sum.inr` (so `hc' := hc`); B.6 `bindW_pure`
+  homogeneity at `Y' = Y`, `v' = v`; the B.7 shape computation with
+  the fiber witness on the forward field; B.9 `Tm'.op`'s shape
+  arithmetic against `SortedSig.polyEndo`; the clone-law mirrors.
+- Recursor-only constraint: every construction routes through
+  `W.elim` / `W.induction` / `PolyFix.ind`; all `match`es are
+  non-recursive shape splits.
+- All nine commit subjects: allowed type, imperative present tense,
+  lowercase, no trailing period, ≤ 72 characters. All other proposed
+  names conform to the upstream naming conventions. Process gates
+  (pre-commit per task, pre-push in B.11, push gated on user review),
+  aggregator wiring, doctoc/markdownlint steps, and the three DOI
+  references are in place. Coverage against the design is complete in
+  both directions (modulo N5).
+
+## Disposition
+
+M1–M5, N1–N4 applied to the plan and N5 to the design document in the
+same commit as this review. N6 requires no action.
+
+## Overall
+
+0 blockers, 0 majors, 5 minors, 6 nits. Converged pending application
+of the disposition.

--- a/geb-lean/docs/superpowers/specs/2026-07-20-ramified-poly-freemonad-design.md
+++ b/geb-lean/docs/superpowers/specs/2026-07-20-ramified-poly-freemonad-design.md
@@ -155,6 +155,8 @@ Proved natively by `SlicePFunctor.W.induction`, with no legacy imports:
 
 - `FreeM.pure_bind` — expected definitional or near-definitional, from
   `W.elim_mk` at a leaf shape;
+- `FreeM.bind_node` — the computation rule at an operation node, from
+  `W.elim_mk`; consumed by the bridge's bind-naturality proof;
 - `FreeM.bind_pure` — right unit (stated at `Y' = Y`, `v' = v`);
 - `FreeM.bind_assoc` — associativity;
 - `FreeM.pure_transport`, `FreeM.bind_transport` — commutation of

--- a/geb-lean/docs/superpowers/specs/2026-07-20-ramified-poly-freemonad-design.md
+++ b/geb-lean/docs/superpowers/specs/2026-07-20-ramified-poly-freemonad-design.md
@@ -134,7 +134,9 @@ precedent (`GebLean/PolyBridge/Slice.lean`).
 - `FreeM.node` — the operation-node constructor: `W.mk` at an `inr`
   shape, taking the shape's compatible family of `FreeM` children.
   The piece `Tm'.op` instantiates.
-- `FreeM.bind :`
+- `FreeM.bind`, for leaf families `v : Y → I` and `v' : Y' → I` (the
+  target leaf family has its own leaf type, as the legacy
+  `polyFreeMBind` changes the leaf family from `A` to `B`):
   `FreeM v F i → (∀ j, { a : Y // v a = j } → FreeM v' F j) → FreeM v' F i`
   — a single `SlicePFunctor.W.elim` into the slice algebra
   `((translate v' F).W, wIndex)`: a leaf shape dispatches to the
@@ -153,7 +155,7 @@ Proved natively by `SlicePFunctor.W.induction`, with no legacy imports:
 
 - `FreeM.pure_bind` — expected definitional or near-definitional, from
   `W.elim_mk` at a leaf shape;
-- `FreeM.bind_pure` — right unit;
+- `FreeM.bind_pure` — right unit (stated at `Y' = Y`, `v' = v`);
 - `FreeM.bind_assoc` — associativity;
 - `FreeM.pure_transport`, `FreeM.bind_transport` — commutation of
   `pure` and `bind` with reindexing along a fiber equality, the native
@@ -181,7 +183,9 @@ that isomorphic containers have equivalent initial algebras
   shapes, distribute `Σ x, ({ a // V.hom a = x } ⊕ i)` to
   `V.left ⊕ Σ x, i`, contracting `Σ x, { a // V.hom a = x } ≃ V.left`;
   positions match leaf-to-leaf (`PEmpty` to `PEmpty`) and node-to-node
-  (identical carriers); `q` and `r` commute by computation.
+  (identical carriers); `q` and `r` commute definitionally on node
+  shapes and on positions, while on leaf shapes `q`-commutation is
+  `V.hom a = x`, discharged by the leaf shape's stored fiber witness.
 - `polyFreeMSliceEquiv (V : Over X) (P : PolyEndo X) (x : X) :`
   `PolyFreeM V P x ≃ FreeM V.hom (toSlice P) x` — the composite of
   `polyFixSliceEquiv (polyTranslate V P) x` (Phase A, applied verbatim
@@ -202,16 +206,21 @@ Novel packaging throughout.
 
 - `Tm' (sig : SortedSig S) (Γ : Ctx S) : S → Type :=`
   `FreeM Γ.get (toSlice sig.polyEndo)`.
-- `Tm'.var`, `Tm'.op`, `Tm'.subst`, `Tm'.reind`, `Tm'.weaken` — thin
-  instances of `FreeM.pure` / `FreeM.node` / `FreeM.bind`, mirroring
-  the legacy signatures (`GebLean/Ramified/Term.lean`) exactly,
-  including the substitution tuple's transport `a.2 ▸ σ a.1`, so that
-  Phase C can exchange the layers.
+- `Tm'.var`, `Tm'.op`, `Tm'.subst`, `Tm'.weaken` — thin instances of
+  `FreeM.pure` / `FreeM.node` / `FreeM.bind`, mirroring the legacy
+  signatures (`GebLean/Ramified/Term.lean`) exactly, including the
+  substitution tuple's transport `a.2 ▸ σ a.1`, so that Phase C can
+  exchange the layers. `Tm'.reind` is the bare transport `h ▸ t`, as
+  in the legacy layer.
 - Clone laws `Tm'.subst_id`, `Tm'.subst_subst`, `Tm'.var_subst`,
   `Tm'.subst_reind` — instances of the native laws and transport
   lemmas of section 4.3; the bridge is not involved.
-- `tmSliceEquiv : Tm' sig Γ s ≃ Tm sig Γ s` — `polyFreeMSliceEquiv`
-  at `(varOver Γ, sig.polyEndo)`, noting `(varOver Γ).hom = Γ.get`.
+- `tmSliceEquiv : Tm' sig Γ s ≃ Tm sig Γ s` —
+  `(polyFreeMSliceEquiv (varOver Γ) sig.polyEndo s).symm`, noting
+  `(varOver Γ).hom = Γ.get`. The `.symm` re-orients the bridge so the
+  primed carrier reads as the source, as in Phase A's
+  `freeAlgSliceEquiv` (the orientation imprecision the handoff records
+  from Phase A).
 - Compatibility lemmas `tmSliceEquiv_var` / `tmSliceEquiv_op` /
   `tmSliceEquiv_subst` — instances of the bridge naturality lemmas.
 

--- a/geb-lean/docs/superpowers/specs/2026-07-20-ramified-poly-freemonad-design.md
+++ b/geb-lean/docs/superpowers/specs/2026-07-20-ramified-poly-freemonad-design.md
@@ -1,0 +1,266 @@
+# Phase B design: the native slice free monad and `Tm'`
+
+<!-- START doctoc generated TOC please keep comment here to allow auto update -->
+<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
+
+- [1. Scope and provenance](#1-scope-and-provenance)
+- [2. Decisions](#2-decisions)
+- [3. Module layout](#3-module-layout)
+- [4. Native layer (`GebLean/SliceW/`)](#4-native-layer-gebleanslicew)
+  - [4.1 `SlicePFunctor.translate`](#41-slicepfunctortranslate)
+  - [4.2 `FreeM`: carrier and operations](#42-freem-carrier-and-operations)
+  - [4.3 Laws](#43-laws)
+  - [4.4 `SlicePFunctor` isomorphisms (`Iso.lean`)](#44-slicepfunctor-isomorphisms-isolean)
+- [5. Bridge (`GebLean/PolyBridge/FreeMEquiv.lean`)](#5-bridge-gebleanpolybridgefreemequivlean)
+- [6. Term layer (`GebLean/Ramified/Polynomial/Term.lean`)](#6-term-layer-gebleanramifiedpolynomialtermlean)
+- [7. Constraints](#7-constraints)
+- [8. Testing](#8-testing)
+- [9. Process](#9-process)
+- [References](#references)
+
+<!-- END doctoc generated TOC please keep comment here to allow auto update -->
+
+## 1. Scope and provenance
+
+This document is the Phase B sub-plan design for the
+ramified-on-vendored-polynomial-functors workstream. It refines the
+master spec
+([2026-07-19-ramified-polynomial-design.md](2026-07-19-ramified-polynomial-design.md),
+sections 4.2, 5, 11) and the master plan
+([../plans/2026-07-19-ramified-polynomial-plan.md](../plans/2026-07-19-ramified-polynomial-plan.md),
+Phase B), resolving the four design questions recorded in the Phase B
+handoff
+([../notes/2026-07-20-ramified-polynomial-phaseB-handoff.md](../notes/2026-07-20-ramified-polynomial-phaseB-handoff.md)).
+It feeds the B.0 sub-plan
+(`docs/superpowers/plans/2026-07-19-ramified-poly-freemonad-subplan.md`).
+
+Deliverable boundary (fixed by the master plan): `polyFreeMSlice` (here
+realized as `SlicePFunctor.FreeM`), `polyFreeMSliceEquiv`, `Tm'` with
+`var` / `op` / `subst`, substitution compatibility across the
+equivalence, and the clone laws for `Tm'`.
+
+## 2. Decisions
+
+Resolutions of the handoff's design questions, decided during
+brainstorming:
+
+1. **Augmented signature: native slice-level presentation.** The
+   augmentation is a new operation on the vendored side,
+   `SlicePFunctor.translate`, taking a leaf family presented as a bare
+   structure map `v : Y → I` (the presentation `Geb.Mathlib.Data.PFunctor.Slice.W`
+   uses for every slice object) and a `SlicePFunctor I I`, and forming
+   the endofunctor with leaf shapes `Y` (empty positions) and node
+   shapes inherited. The legacy-side alternative (reusing
+   `polyTranslate` under `toSlice`) was declined: the native operation
+   depends on nothing legacy, which serves the deferred migration goal
+   (master spec section 10) and upstream promotion.
+2. **Generic level: yes.** The free-monad layer is generic in
+   `(v, F)`; the term layer instantiates it. Mirrors Phase A's
+   generic-then-instantiate structure.
+3. **Substitution and laws: native.** `FreeM.bind` is a single
+   `SlicePFunctor.W.elim`; the monad laws are proved natively by
+   `SlicePFunctor.W.induction`, keeping the layer self-contained and
+   upstream-promotable. The clone laws for `Tm'` are thin instances of
+   the native laws; the bridge carries only compatibility statements.
+   The alternative (conjugating the legacy laws through the
+   equivalence) was declined because it would tie the native layer's
+   laws to `GebLean/PolyAlg.lean`.
+4. **Variable family: nothing new.** `varOver Γ = Over.mk Γ.get`
+   instantiates the bare-map presentation as `Γ.get : Fin Γ.length → S`.
+   The leaf fiber at sort `y` is `{ i : Fin Γ.length // Γ.get i = y }`,
+   the same subtype the legacy `Tm.var` inhabits at `⟨i, rfl⟩`.
+
+Placement (decided during brainstorming): the native machinery lives in
+a new narrow-and-deep directory `GebLean/SliceW/`, written to
+geb-mathlib standards with no legacy imports, so a later phase can
+promote it to geb-mathlib through the established backport flow.
+Developing it upstream-first was declined as a cross-repo scope
+expansion; extending `GebLean/PolyBridge/` was declined because the
+machinery is not bridging.
+
+Bridge route (decided during brainstorming): the comparison to the
+legacy free monad crosses two gaps. Phase A covers legacy-to-slice:
+`PolyFreeM V P` is definitionally `PolyFix (polyTranslate V P)`, so
+`polyFixSliceEquiv (polyTranslate V P) x` reaches the fiber of
+`(toSlice (polyTranslate V P)).W`. The remaining gap —
+`toSlice (polyTranslate V P)` versus the native
+`translate V.hom (toSlice P)`, isomorphic but not equal — is crossed by
+a generic single-step lemma: an isomorphism of `SlicePFunctor`s induces
+an equivalence of their W-types respecting `wIndex`. The bespoke
+fold-both-ways alternative was declined as single-use.
+
+## 3. Module layout
+
+| Module | Content | Imports |
+| --- | --- | --- |
+| `GebLean/SliceW/Iso.lean` | `SlicePFunctor` isomorphisms; induced W-type equivalence | vendored stack only |
+| `GebLean/SliceW/Translate.lean` | `SlicePFunctor.translate` | vendored stack only |
+| `GebLean/SliceW/FreeM.lean` | `FreeM` carrier, `pure` / `node` / `bind`, monad laws, transport lemmas | vendored stack only |
+| `GebLean/SliceW.lean` | directory index | the above |
+| `GebLean/PolyBridge/FreeMEquiv.lean` | concrete isomorphism, `polyFreeMSliceEquiv`, compatibility lemmas | both stacks |
+| `GebLean/Ramified/Polynomial/Term.lean` | `Tm'` layer | `SliceW`, `FreeMEquiv`, `Ramified/Term` |
+
+Tests mirror each module under `GebLeanTests/` and are registered in
+the aggregators (`GebLeanTests.lean`, `GebLeanTests/Ramified.lean`).
+
+## 4. Native layer (`GebLean/SliceW/`)
+
+### 4.1 `SlicePFunctor.translate`
+
+`translate (v : Y → I) (F : SlicePFunctor I I) : SlicePFunctor I I`:
+
+- shapes `A := Y ⊕ F.A`;
+- positions `B := Sum.rec (fun _ => PEmpty) F.B`;
+- shape-output `q := Sum.elim v F.q`;
+- direction-input `r` inherited on node positions (leaf positions are
+  empty, so their clause is `PEmpty.elim`).
+
+Transcription: the "translation" endofunctor `Y + F(−)` whose initial
+algebra carries the free monad [GambinoKock2013]; the legacy
+counterpart is `polyTranslate` (`GebLean/PolyAlg.lean`). Characterizing
+`@[simp]` lemmas for each field, following the `toSlice_A/_B/_q/_r`
+precedent (`GebLean/PolyBridge/Slice.lean`).
+
+### 4.2 `FreeM`: carrier and operations
+
+- `FreeM (v : Y → I) (F : SlicePFunctor I I) (i : I) :=`
+  `{ w : (translate v F).W // wIndex w = i }` — the fibered carrier
+  (universe level as the vendored `W` dictates),
+  following the Phase A subtype idiom (`FreeAlg'`). Transcription: the
+  free monad on a polynomial functor as the W-type of the translation
+  [GambinoKock2013].
+- `FreeM.pure : { a : Y // v a = i } → FreeM v F i` — `W.mk` at an
+  `inl` shape; the empty child family is `PEmpty.elim`.
+- `FreeM.node` — the operation-node constructor: `W.mk` at an `inr`
+  shape, taking the shape's compatible family of `FreeM` children.
+  The piece `Tm'.op` instantiates.
+- `FreeM.bind :`
+  `FreeM v F i → (∀ j, { a : Y // v a = j } → FreeM v' F j) → FreeM v' F i`
+  — a single `SlicePFunctor.W.elim` into the slice algebra
+  `((translate v' F).W, wIndex)`: a leaf shape dispatches to the
+  substitution function (its fiber property supplies the over-index
+  side condition); a node shape re-applies `W.mk`. The fiber property
+  of the result comes from `SlicePFunctor.W.comp_elim`. No structural
+  recursion; recursor-only elimination throughout.
+
+Compatibility side goals are genuine (the index type `I` is arbitrary;
+no `Subsingleton.elim` shortcut). Novel packaging: the free-monad
+structure maps realized on the vendored eliminator.
+
+### 4.3 Laws
+
+Proved natively by `SlicePFunctor.W.induction`, with no legacy imports:
+
+- `FreeM.pure_bind` — expected definitional or near-definitional, from
+  `W.elim_mk` at a leaf shape;
+- `FreeM.bind_pure` — right unit;
+- `FreeM.bind_assoc` — associativity;
+- `FreeM.pure_transport`, `FreeM.bind_transport` — commutation of
+  `pure` and `bind` with reindexing along a fiber equality, the native
+  analogues of `polyFreeMPure_transport` / `polyFreeMBind_transport`
+  (`GebLean/PolyAlg.lean`), consumed by the clone-law instances.
+
+Transcription: the free-monad laws [GambinoKock2013]; statement forms
+follow the legacy `polyFreeM_pure_bind` / `polyFreeM_bind_pure` /
+`polyFreeM_bind_assoc`.
+
+### 4.4 `SlicePFunctor` isomorphisms (`Iso.lean`)
+
+A structure packaging: an equivalence of shape types commuting with
+`q`, and per-shape equivalences of position types commuting with `r`.
+The induced map on W-types is a `SlicePFunctor.W.elim` in each
+direction; the round trips are closed by `SlicePFunctor.W.induction`;
+the equivalence respects `wIndex`. Novel packaging of the standard fact
+that isomorphic containers have equivalent initial algebras
+[AbbottAltenkirchGhani2005].
+
+## 5. Bridge (`GebLean/PolyBridge/FreeMEquiv.lean`)
+
+- The concrete isomorphism
+  `toSlice (polyTranslate V P) ≅ translate V.hom (toSlice P)`: on
+  shapes, distribute `Σ x, ({ a // V.hom a = x } ⊕ i)` to
+  `V.left ⊕ Σ x, i`, contracting `Σ x, { a // V.hom a = x } ≃ V.left`;
+  positions match leaf-to-leaf (`PEmpty` to `PEmpty`) and node-to-node
+  (identical carriers); `q` and `r` commute by computation.
+- `polyFreeMSliceEquiv (V : Over X) (P : PolyEndo X) (x : X) :`
+  `PolyFreeM V P x ≃ FreeM V.hom (toSlice P) x` — the composite of
+  `polyFixSliceEquiv (polyTranslate V P) x` (Phase A, applied verbatim
+  since `PolyFreeM V P` is definitionally `PolyFix (polyTranslate V P)`)
+  with the fiber restriction of the induced W-equivalence.
+- Compatibility lemmas, in the naturality form validated in Phase A
+  (`equiv (op' t) = op (equiv t)`):
+  - `pure`-naturality: `polyFreeMSliceEquiv` carries `polyFreeMPure`
+    to `FreeM.pure`;
+  - `node`-naturality: it carries a `PolyFix.mk` node at `Sum.inr` to
+    `FreeM.node`;
+  - `bind`-naturality: it carries `polyFreeMBind` to `FreeM.bind`,
+    proved by `PolyFix.ind` on the legacy side.
+
+Novel packaging throughout.
+
+## 6. Term layer (`GebLean/Ramified/Polynomial/Term.lean`)
+
+- `Tm' (sig : SortedSig S) (Γ : Ctx S) : S → Type :=`
+  `FreeM Γ.get (toSlice sig.polyEndo)`.
+- `Tm'.var`, `Tm'.op`, `Tm'.subst`, `Tm'.reind`, `Tm'.weaken` — thin
+  instances of `FreeM.pure` / `FreeM.node` / `FreeM.bind`, mirroring
+  the legacy signatures (`GebLean/Ramified/Term.lean`) exactly,
+  including the substitution tuple's transport `a.2 ▸ σ a.1`, so that
+  Phase C can exchange the layers.
+- Clone laws `Tm'.subst_id`, `Tm'.subst_subst`, `Tm'.var_subst`,
+  `Tm'.subst_reind` — instances of the native laws and transport
+  lemmas of section 4.3; the bridge is not involved.
+- `tmSliceEquiv : Tm' sig Γ s ≃ Tm sig Γ s` — `polyFreeMSliceEquiv`
+  at `(varOver Γ, sig.polyEndo)`, noting `(varOver Γ).hom = Γ.get`.
+- Compatibility lemmas `tmSliceEquiv_var` / `tmSliceEquiv_op` /
+  `tmSliceEquiv_subst` — instances of the bridge naturality lemmas.
+
+Novel packaging: the free-algebra term conventions of Leivant III
+section 2.1 [Leivant1999] presented through the vendored stack.
+
+## 7. Constraints
+
+All Phase A constraints continue to bind: no `noncomputable`
+(`Classical.choice` in proofs only; the axiom gate accepts only
+`propext` / `Quot.sound` / `Classical.choice`); recursor-only
+elimination of the recursive tree types (`W.elim` / `W.induction` /
+`W.RecProp` on the vendored side, `PolyFix.ind` only in the bridge);
+`@[simp]` on constructor-compatibility lemmas only (operation
+naturality lemmas are not `@[simp]`, per the Phase A `simpNF`
+finding); universe polymorphism as far as it compiles; file headers
+and docstrings per the existing `GebLean` convention; no novelty
+claims in `.lean` comments (citations only).
+
+## 8. Testing
+
+- Mirrored test modules for `SliceW/Iso`, `SliceW/Translate`,
+  `SliceW/FreeM`, `PolyBridge/FreeMEquiv`, and
+  `Ramified/Polynomial/Term`, registered in the aggregators.
+- Semantic assertions route through proven `@[simp]` lemmas
+  (constructor naturality, reduction rules), never kernel reduction of
+  composite W-trees.
+- A concrete multi-sorted smoke signature exercises `Tm'.var` /
+  `Tm'.op` / `Tm'.subst` and the clone laws at more than one sort, so
+  the genuinely multi-sorted side conditions are covered.
+
+## 9. Process
+
+Per the Phase A learnings: execution starts with a spike validating
+the two hardest constructions sorry-free before real files are laid
+out — the induced W-equivalence of `Iso.lean` and `FreeM.bind` via
+`W.elim` — on a concrete signature. Then subagent-driven development
+with a fresh implementer and reviewer per task and a whole-branch
+review.
+
+## References
+
+- N. Gambino, J. Kock, "Polynomial functors and polynomial monads",
+  Mathematical Proceedings of the Cambridge Philosophical Society 154
+  (2013) 153-192. DOI `10.1017/S0305004112000394`.
+- M. Abbott, T. Altenkirch, N. Ghani, "Containers: constructing
+  strictly positive types", Theoretical Computer Science 342 (2005)
+  3-27. DOI `10.1016/j.tcs.2005.06.002`.
+- D. Leivant, "Ramified recurrence and computational complexity III:
+  Higher type recurrence and elementary complexity", Annals of Pure
+  and Applied Logic 96 (1999) 209-229.
+  DOI `10.1016/S0168-0072(98)00040-2`.

--- a/geb-lean/docs/superpowers/specs/2026-07-20-ramified-poly-freemonad-design.review-1.md
+++ b/geb-lean/docs/superpowers/specs/2026-07-20-ramified-poly-freemonad-design.review-1.md
@@ -1,0 +1,91 @@
+# Adversarial review 1: Phase B free-monad sub-plan design
+
+<!-- START doctoc generated TOC please keep comment here to allow auto update -->
+<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
+
+- [Majors](#majors)
+- [Minors](#minors)
+- [Nits](#nits)
+- [Verified without defect](#verified-without-defect)
+- [Disposition](#disposition)
+- [Overall](#overall)
+
+<!-- END doctoc generated TOC please keep comment here to allow auto update -->
+
+Round 1, 2026-07-20. One fresh-context reviewer (declaration
+verification, definitional-fact checking, construction realizability,
+consistency, style) against source at branch
+`feat/ramified-poly-freemonad`. Every claim below was re-verified
+against source before entry.
+
+## Majors
+
+None.
+
+## Minors
+
+- M1 (section 6, `tmSliceEquiv` direction). The document declares
+  `tmSliceEquiv : Tm' sig Γ s ≃ Tm sig Γ s` as `polyFreeMSliceEquiv`
+  at `(varOver Γ, sig.polyEndo)`, but section 5's
+  `polyFreeMSliceEquiv V P x : PolyFreeM V P x ≃ FreeM V.hom (toSlice P) x`
+  instantiates to `Tm sig Γ s ≃ Tm' sig Γ s` — the opposite
+  orientation; `.symm` is required. The Phase A precedent is
+  `freeAlgSliceEquiv` (`GebLean/Ramified/Polynomial/FreeAlg.lean`),
+  and the handoff records the same imprecision from Phase A. Fix:
+  state the `.symm`.
+- M2 (section 5, commutation claim). "`q` and `r` commute by
+  computation" holds definitionally on node shapes and on positions,
+  but on leaf shapes `q`-commutation is `V.hom a = x`, discharged by
+  the leaf shape's stored fiber witness
+  (`GebLean/PolyAlg.lean`, `polyTranslateIndex`), not by reduction.
+  Fix: state the leaf-shape case separately.
+- M3 (section 4.2, `FreeM.bind` leaf family). The signature introduces
+  `v'` without a binder; a literal reading places `v'` over the same
+  leaf type `Y`, which cannot instantiate `Tm'.subst` between distinct
+  contexts (`Fin Γ.length` versus `Fin Δ.length`; the legacy
+  `polyFreeMBind` likewise changes the leaf family). Fix: declare
+  `v' : Y' → I` over its own leaf type, with `bind_pure` stated at
+  `Y' = Y`, `v' = v`.
+
+## Nits
+
+- N1 (section 6, `Tm'.reind` classification). `Tm.reind` is the bare
+  transport `h ▸ t` (`GebLean/Ramified/Term.lean`), not an instance of
+  `FreeM.pure` / `FreeM.node` / `FreeM.bind`. Fix: list it separately
+  as the transport it is.
+
+## Verified without defect
+
+- All named declarations exist with the stated meanings and
+  signatures, across `GebLean/PolyAlg.lean`,
+  `GebLean/Ramified/Term.lean`, `GebLean/PolyBridge/{Slice,WEquiv}.lean`,
+  `GebLean/Ramified/Polynomial/FreeAlg.lean`, and the vendored
+  `Geb/Mathlib/Data/PFunctor/Slice/{Basic,W}.lean` (including
+  `W.elim`'s `(g, hg)` signature and `W.comp_elim` / `W.elim_mk` /
+  `W.induction` / `W.RecProp`).
+- `PolyFreeM` is an `abbrev` for `PolyFix (polyTranslate · ·)`, so the
+  definitional claim holds; `(varOver Γ).hom = Γ.get` is definitional
+  on this toolchain; leaf positions of `toSlice (polyTranslate V P)`
+  are `PEmpty`; the section 5 shape distribution and the contraction
+  `Σ x, { a // V.hom a = x } ≃ V.left` are correct with no universe
+  obstruction.
+- `FreeM.bind` as a single `W.elim` into `((translate v' F).W, wIndex)`
+  is type-correct in outline (non-recursive `Sum` split; `Compatible`
+  transfers at `inr`; `hg` provable by `funext` with the leaf fiber
+  property; result fiber from `comp_elim`); the section 4.4 induced
+  W-equivalence is constructible from `W.elim` both ways plus
+  `W.induction` round trips, respecting `wIndex` via `comp_elim`.
+- Consistent with the master plan's fixed Phase B deliverables, the
+  handoff's constraints, and master spec sections 4.2 / 5 / 10 / 11;
+  the Gambino–Kock 2013 citation covers the free monad as the initial
+  algebra of the translation; markdown style rules hold.
+
+## Disposition
+
+All four findings applied to the design document in the same commit as
+this review.
+
+## Overall
+
+0 blockers, 0 majors, 3 minors, 1 nit. Converged pending application
+of M1–M3, N1.


### PR DESCRIPTION
Dependent polynomial free monads using infrastructure  derived from mathib's `PFunctor`, and equivalences with existing `PolyFreeM`  implementation.