### PR TITLE
refactor(ramified): build the signature isomorphisms from a sum combi…

### DIFF
--- a/geb-lean/GebLean/Ramified/Polynomial/HigherOrderEquiv.lean
+++ b/geb-lean/GebLean/Ramified/Polynomial/HigherOrderEquiv.lean
@@ -20,8 +20,11 @@ the syntactic-category equivalence `PresentationEquiv.synCatEquiv`
 
 * `identOpSliceEquiv` — the identifier-operation equivalence: the sigma
   congruence over the context, result-sort, and identifier bridges.
+* `identSigEquiv`, `identConstSigEquiv` — the identifier summand signature
+  isomorphisms.
 * `higherOrderSigEquiv` — the signature isomorphism between the primed and
-  legacy higher-order signatures.
+  legacy higher-order signatures, the `SortedSigEquiv.sum` of `baseSigEquiv`
+  with the two identifier summands.
 * `higherOrderPresEquiv` — the presentation equivalence between the primed and
   legacy higher-order presentations.
 * `rmRecCatSliceEquiv` — the equivalence of syntactic categories
@@ -60,39 +63,31 @@ def identOpSliceEquiv (A : AlgSig) :
   Equiv.sigmaCongr (Equiv.listEquivOfEquiv rTypeSliceEquiv) (fun _Γ' =>
     Equiv.sigmaCongr rTypeSliceEquiv (fun _τ' => identSliceEquiv))
 
-/-- The signature isomorphism between the primed and legacy higher-order
-signatures: `rTypeSliceEquiv` on sorts, and summand-wise on operations the
-object-sort subtype congruence at the constructor summand, the sort congruence
-at the application summand, and `identOpSliceEquiv` at both identifier
-summands. Arities transport by `List.map_replicate` at the constructors and
-`rTypeSliceEquiv_arrow` at application; the constant summand's result sort
-transports by `rTypeSliceEquiv_curried`. -/
-def higherOrderSigEquiv (A : AlgSig) :
-    SortedSigEquiv (higherOrder' A).sig (higherOrder A).sig where
+/-- The signature isomorphism between the primed and legacy saturated
+identifier summands: `rTypeSliceEquiv` on sorts and `identOpSliceEquiv` on
+operations, the arity and result being the transported identifier index. -/
+def identSigEquiv (A : AlgSig) : SortedSigEquiv (identSig' A) (identSig A) where
   sortEquiv := rTypeSliceEquiv
-  opEquiv :=
-    Equiv.sumCongr (Equiv.sumCongr (Equiv.sumCongr
-      (Equiv.prodCongr
-        (Equiv.subtypeEquiv rTypeSliceEquiv (fun a => Iff.of_eq (rTypeSliceEquiv_isObj a)))
-        (Equiv.refl A.B))
-      (Equiv.prodCongr rTypeSliceEquiv rTypeSliceEquiv)) (identOpSliceEquiv A))
-      (identOpSliceEquiv A)
-  arity_comm := by
-    rintro (((c | a) | i) | i)
-    · change List.replicate (A.ar c.2) (rTypeSliceEquiv c.1.val)
-        = List.map rTypeSliceEquiv (List.replicate (A.ar c.2) c.1.val)
-      exact List.map_replicate.symm
-    · change [RType.arrow (rTypeSliceEquiv a.1) (rTypeSliceEquiv a.2), rTypeSliceEquiv a.1]
-        = [rTypeSliceEquiv (RType'.arrow a.1 a.2), rTypeSliceEquiv a.1]
-      rw [rTypeSliceEquiv_arrow]
-    · rfl
-    · rfl
-  result_comm := by
-    rintro (((c | a) | i) | i)
-    · rfl
-    · rfl
-    · rfl
-    · exact (rTypeSliceEquiv_curried i.1 i.2.1).symm
+  opEquiv := identOpSliceEquiv A
+  arity_comm := fun _ => rfl
+  result_comm := fun _ => rfl
+
+/-- The signature isomorphism between the primed and legacy identifier-constant
+summands: `rTypeSliceEquiv` on sorts and `identOpSliceEquiv` on operations, with
+the result sort transported by `rTypeSliceEquiv_curried`. -/
+def identConstSigEquiv (A : AlgSig) :
+    SortedSigEquiv (identConstSig' A) (identConstSig A) where
+  sortEquiv := rTypeSliceEquiv
+  opEquiv := identOpSliceEquiv A
+  arity_comm := fun _ => rfl
+  result_comm := fun i => (rTypeSliceEquiv_curried i.1 i.2.1).symm
+
+/-- The signature isomorphism between the primed and legacy higher-order
+signatures: the summand-wise sum of `baseSigEquiv`, `identSigEquiv`, and
+`identConstSigEquiv`. -/
+def higherOrderSigEquiv (A : AlgSig) :
+    SortedSigEquiv (higherOrder' A).sig (higherOrder A).sig :=
+  ((baseSigEquiv A).sum (identSigEquiv A) rfl).sum (identConstSigEquiv A) rfl
 
 /-- The presentation equivalence between the primed and legacy higher-order
 presentations: the signature isomorphism `higherOrderSigEquiv` together with the

--- a/geb-lean/GebLean/Ramified/Polynomial/IdentEquiv.lean
+++ b/geb-lean/GebLean/Ramified/Polynomial/IdentEquiv.lean
@@ -36,8 +36,10 @@ translations `tmSliceEquiv` (`GebLean/Ramified/Polynomial/Term.lean`) and
 
 * `identCtxEquiv` — the index equivalence `List RType' × RType' ≃
   List RType × RType`.
+* `constructorSigEquiv`, `appSigEquiv`, `baseSigEquiv`, `holeSigEquiv`,
+  `holeConstSigEquiv` — the summand signature isomorphisms.
 * `defnSigEquiv` — the signature isomorphism of the base signatures of an
-  explicit definition's body.
+  explicit definition's body, their `SortedSigEquiv.sum`.
 * `defnShapeEquiv`, `mrecShapeEquiv`, `frecShapeEquiv` — the schema-former
   data equivalences.
 * `identShapeEquiv` — the identifier shape-type equivalence.
@@ -108,37 +110,68 @@ equivalence `List.map rTypeSliceEquiv` and `rTypeSliceEquiv`. -/
 def identCtxEquiv : List RType' × RType' ≃ List RType × RType :=
   Equiv.prodCongr (Equiv.listEquivOfEquiv rTypeSliceEquiv) rTypeSliceEquiv
 
-/-- The signature isomorphism between the primed and legacy base signatures
-of an explicit definition's body: `rTypeSliceEquiv` on sorts, the summand-wise
-congruence on operations (the object-sort subtype congruence and the
-application, hole, and hole-constant congruences), with arities and result
-sorts transported by `List.map_replicate`, `rTypeSliceEquiv_arrow`, and
-`rTypeSliceEquiv_curried`. -/
-def defnSigEquiv (A : AlgSig) (n : Nat) (h : Fin n → List RType' × RType') :
-    SortedSigEquiv (defnSig' A n h) (defnSig A n (fun j => identCtxEquiv (h j))) where
+/-- The signature isomorphism between the primed and legacy constructor
+summands: `rTypeSliceEquiv` on sorts and the object-sort subtype congruence on
+operations, with the arity transported by `List.map_replicate`. -/
+def constructorSigEquiv (A : AlgSig) :
+    SortedSigEquiv (constructorSig A RType'.IsObj) (constructorSig A RType.IsObj) where
   sortEquiv := rTypeSliceEquiv
   opEquiv :=
-    Equiv.sumCongr (Equiv.sumCongr (Equiv.sumCongr
-      (Equiv.prodCongr
-        (Equiv.subtypeEquiv rTypeSliceEquiv (fun a => Iff.of_eq (rTypeSliceEquiv_isObj a)))
-        (Equiv.refl A.B))
-      (Equiv.prodCongr rTypeSliceEquiv rTypeSliceEquiv)) (Equiv.refl (Fin n))) (Equiv.refl (Fin n))
-  arity_comm := by
-    rintro (((c | a) | j) | j)
-    · change List.replicate (A.ar c.2) (rTypeSliceEquiv c.1.val)
-        = List.map rTypeSliceEquiv (List.replicate (A.ar c.2) c.1.val)
-      exact List.map_replicate.symm
-    · change [RType.arrow (rTypeSliceEquiv a.1) (rTypeSliceEquiv a.2), rTypeSliceEquiv a.1]
-        = [rTypeSliceEquiv (RType'.arrow a.1 a.2), rTypeSliceEquiv a.1]
-      rw [rTypeSliceEquiv_arrow]
-    · rfl
-    · rfl
-  result_comm := by
-    rintro (((c | a) | j) | j)
-    · rfl
-    · rfl
-    · rfl
-    · exact (rTypeSliceEquiv_curried (h j).1 (h j).2).symm
+    Equiv.prodCongr
+      (Equiv.subtypeEquiv rTypeSliceEquiv (fun a => Iff.of_eq (rTypeSliceEquiv_isObj a)))
+      (Equiv.refl A.B)
+  arity_comm := fun c => by
+    change List.replicate (A.ar c.2) (rTypeSliceEquiv c.1.val)
+      = List.map rTypeSliceEquiv (List.replicate (A.ar c.2) c.1.val)
+    exact List.map_replicate.symm
+  result_comm := fun _ => rfl
+
+/-- The signature isomorphism between the primed and legacy application
+summands: `rTypeSliceEquiv` on sorts and its square on operations, with the
+arity transported by `rTypeSliceEquiv_arrow`. -/
+def appSigEquiv : SortedSigEquiv appSig' appSig where
+  sortEquiv := rTypeSliceEquiv
+  opEquiv := Equiv.prodCongr rTypeSliceEquiv rTypeSliceEquiv
+  arity_comm := fun a => by
+    change [RType.arrow (rTypeSliceEquiv a.1) (rTypeSliceEquiv a.2), rTypeSliceEquiv a.1]
+      = [rTypeSliceEquiv (RType'.arrow a.1 a.2), rTypeSliceEquiv a.1]
+    rw [rTypeSliceEquiv_arrow]
+  result_comm := fun _ => rfl
+
+/-- The signature isomorphism on the base summands shared by the higher-order
+signature and an explicit definition's body signature: the sum of
+`constructorSigEquiv` and `appSigEquiv`. -/
+def baseSigEquiv (A : AlgSig) :
+    SortedSigEquiv ((constructorSig A RType'.IsObj).sum appSig')
+      ((constructorSig A RType.IsObj).sum appSig) :=
+  (constructorSigEquiv A).sum appSigEquiv rfl
+
+/-- The signature isomorphism between the primed and legacy saturated hole
+summands: `rTypeSliceEquiv` on sorts and the identity on the hole index, the
+arity and result being the transported hole data. -/
+def holeSigEquiv (n : Nat) (h : Fin n → List RType' × RType') :
+    SortedSigEquiv (holeSig' n h) (holeSig n (fun j => identCtxEquiv (h j))) where
+  sortEquiv := rTypeSliceEquiv
+  opEquiv := Equiv.refl (Fin n)
+  arity_comm := fun _ => rfl
+  result_comm := fun _ => rfl
+
+/-- The signature isomorphism between the primed and legacy curried hole
+summands: `rTypeSliceEquiv` on sorts and the identity on the hole index, with
+the result sort transported by `rTypeSliceEquiv_curried`. -/
+def holeConstSigEquiv (n : Nat) (h : Fin n → List RType' × RType') :
+    SortedSigEquiv (holeConstSig' n h) (holeConstSig n (fun j => identCtxEquiv (h j))) where
+  sortEquiv := rTypeSliceEquiv
+  opEquiv := Equiv.refl (Fin n)
+  arity_comm := fun _ => rfl
+  result_comm := fun j => (rTypeSliceEquiv_curried (h j).1 (h j).2).symm
+
+/-- The signature isomorphism between the primed and legacy base signatures
+of an explicit definition's body: the summand-wise sum of `baseSigEquiv`,
+`holeSigEquiv`, and `holeConstSigEquiv`. -/
+def defnSigEquiv (A : AlgSig) (n : Nat) (h : Fin n → List RType' × RType') :
+    SortedSigEquiv (defnSig' A n h) (defnSig A n (fun j => identCtxEquiv (h j))) :=
+  ((baseSigEquiv A).sum (holeSigEquiv n h) rfl).sum (holeConstSigEquiv n h) rfl
 
 /-- The explicit-definition data as a sigma of its number of holes, hole
 indices, and body. -/

--- a/geb-lean/GebLean/Ramified/SigEquiv.lean
+++ b/geb-lean/GebLean/Ramified/SigEquiv.lean
@@ -22,6 +22,8 @@ action on terms of a signature isomorphism (a reduct along an isomorphism).
 
 * `SortedSigEquiv` — an isomorphism of multi-sorted signatures.
 * `SortedSigEquiv.symm` — the inverse signature isomorphism.
+* `SortedSigEquiv.sum` — the sum of two signature isomorphisms sharing a sort
+  equivalence, over `SortedSig.sum`.
 * `SortedSigEquiv.tmMap` — the term translation along a signature isomorphism.
 * `SortedSigEquiv.tmEquiv` — the term translation packaged as an equivalence.
 
@@ -118,6 +120,26 @@ def symm (e : SortedSigEquiv sig sig') : SortedSigEquiv sig' sig where
     have h := e.result_comm (e.opEquiv.symm o')
     rw [Equiv.apply_symm_apply] at h
     rw [h, Equiv.symm_apply_apply]
+
+/-- The sum of two signature isomorphisms sharing a sort equivalence: the
+operation equivalence is the disjoint union of the summands', and the arity and
+result compatibilities are inherited summand-wise. The signature-isomorphism
+counterpart of `SortedSig.sum`. -/
+def sum {sig₂ : SortedSig S} {sig₂' : SortedSig S'} (e : SortedSigEquiv sig sig')
+    (e₂ : SortedSigEquiv sig₂ sig₂') (h : e₂.sortEquiv = e.sortEquiv) :
+    SortedSigEquiv (sig.sum sig₂) (sig'.sum sig₂') where
+  sortEquiv := e.sortEquiv
+  opEquiv := Equiv.sumCongr e.opEquiv e₂.opEquiv
+  arity_comm := by
+    rintro (o | o₂)
+    · exact e.arity_comm o
+    · rw [← h]
+      exact e₂.arity_comm o₂
+  result_comm := by
+    rintro (o | o₂)
+    · exact e.result_comm o
+    · rw [← h]
+      exact e₂.result_comm o₂
 
 /-- The term translation along a signature isomorphism, by `PolyFix.ind`: a
 variable node becomes the reindexed translated variable; an operation node


### PR DESCRIPTION
…nator

`higherOrderSigEquiv` and `defnSigEquiv` each spelled out a three-deep `Equiv.sumCongr` skeleton with byte-identical `arity_comm` and `result_comm` bodies at the shared constructor and application summands. Add `SortedSigEquiv.sum`, name each summand isomorphism, and assemble both signature isomorphisms from them.