### PR TITLE
chore(deps): refresh vendored geb-mathlib

### DIFF
--- a/geb-lean/docs/geb-mathlib-backport-notes.md
+++ b/geb-lean/docs/geb-mathlib-backport-notes.md
@@ -54,9 +54,12 @@ genuinely new (decide the adaptation, add a category here).
   in `Presheaf/Basic.lean`. The affected definitions in
   `IndRec/Basic.lean` are `IR.Shape`, `IR.pFunctor`, `IR.Obj`,
   `IR.ObjFst`, `IR.Dest`, `IR.Alg`, the top-level `IR`, and
-  `IR.interpObjIota`.
-- Prose adaptation: the module docstrings of `Presheaf/Basic.lean` and
-  `IndRec/Basic.lean` describe the suppression as
+  `IR.interpObjIota`. The affected theorems in `IndRec/Category.lean`
+  are `IR.comp_isoOfEq_hom` and `IR.isoOfEq_symm_hom_comp`; there the
+  attribute goes between the docstring and the `theorem` keyword.
+- Prose adaptation: the module docstrings of `Presheaf/Basic.lean`,
+  `IndRec/Basic.lean`, and `IndRec/Category.lean` describe the
+  suppression as
   "The `linter.checkUnivs false` option suppresses the ...". Because
   the option line is deleted and the attribute inserted, reword to
   "The `@[nolint checkUnivs]` attribute suppresses the ..." so the

--- a/geb-lean/scripts/geb-mathlib-backport.patch
+++ b/geb-lean/scripts/geb-mathlib-backport.patch
@@ -1,5 +1,5 @@
 diff --git a/vendor/geb-mathlib/Geb/Mathlib/Data/PFunctor/IndRec/Basic.lean b/vendor/geb-mathlib/Geb/Mathlib/Data/PFunctor/IndRec/Basic.lean
-index 12839ab..3995840 100644
+index 44ebba7..b6df37e 100644
 --- a/vendor/geb-mathlib/Geb/Mathlib/Data/PFunctor/IndRec/Basic.lean
 +++ b/vendor/geb-mathlib/Geb/Mathlib/Data/PFunctor/IndRec/Basic.lean
 @@ -3,6 +3,7 @@ Copyright (c) 2026 Terence Rokop. All rights reserved.
@@ -10,7 +10,7 @@ index 12839ab..3995840 100644
  module
  
  public import Geb.Mathlib.CategoryTheory.FreeCoprodCompDisc
-@@ -90,7 +91,7 @@ decodes to `o : O`); the input index type `I` parameterizes the
+@@ -109,7 +110,7 @@ decodes to `o : O`); the input index type `I` parameterizes the
  `delta` directions (a code `IR.delta I O B c` receives the decodings
  of its recursive arguments as assignments `B → I`).
  
@@ -19,7 +19,7 @@ index 12839ab..3995840 100644
  warning on the separated arity universes `uA`/`uB`: in the suppressed
  declarations' types they appear only together under `max`, so the
  linter flags them as a pair that could be unified; keeping them
-@@ -124,9 +125,9 @@ variable (I : Type uI) (O : Type uO)
+@@ -162,9 +163,9 @@ variable (I : Type uI) (O : Type uO)
  
  namespace IR
  
@@ -30,7 +30,7 @@ index 12839ab..3995840 100644
  def Shape : Type (max (uA + 1) (uB + 1) uO) :=
    O ⊕ Type uA ⊕ Type uB
  
-@@ -164,21 +165,21 @@ def directionElim.{v} (V : Type v) (σ : (A : Type uA) → A → V)
+@@ -202,21 +203,21 @@ def directionElim.{v} (V : Type v) (σ : (A : Type uA) → A → V)
    | Sum.inr (Sum.inl (A : Type uA)) => σ A (ULift.down ds)
    | Sum.inr (Sum.inr (B : Type uB)) => δ B (ULift.down ds)
  
@@ -55,7 +55,7 @@ index 12839ab..3995840 100644
  def ObjFst : Type (max (uA + 1) (uB + 1) uO) :=
    Shape.{uA, uB, uO} O
  
-@@ -219,9 +220,9 @@ theorem objIota_eq_mk.{v} (V : Type v) (o : O)
+@@ -257,9 +258,9 @@ theorem objIota_eq_mk.{v} (V : Type v) (o : O)
      objIota I O V o = (⟨Sum.inl o, ds⟩ : Obj.{uA, uB, uI, uO, v} I O V) :=
    congrArg (Sigma.mk (Sum.inl o)) (funext (fun x ↦ PEmpty.elim x))
  
@@ -66,7 +66,7 @@ index 12839ab..3995840 100644
  def Dest.{v, w} (V : Type v) (W : Type w) :
      Type (max (uA + 1) (uB + 1) uI uO v w) :=
    (O → W) × ((A : Type uA) → (A → V) → W) ×
-@@ -339,8 +340,8 @@ def depDestEquiv.{v, w} (V : Type v) (W : Obj I O V → Type w) :
+@@ -377,8 +378,8 @@ def depDestEquiv.{v, w} (V : Type v) (W : Obj I O V → Type w) :
    left_inv := DepDest.elimInv_elim I O V W
    right_inv := DepDest.elim_elimInv I O V W
  
@@ -76,7 +76,7 @@ index 12839ab..3995840 100644
  def Alg.{v} (V : Type v) : Type (max (uA + 1) (uB + 1) uI uO v) :=
    Dest.{uA, uB, uI, uO, v, v} I O V V
  
-@@ -351,9 +352,9 @@ def Alg.toHom.{v} (V : Type v) (alg : Alg.{uA, uB, uI, uO, v} I O V) : Obj I O V
+@@ -389,9 +390,9 @@ def Alg.toHom.{v} (V : Type v) (alg : Alg.{uA, uB, uI, uO, v} I O V) : Obj I O V
  
  end IR
  
@@ -87,7 +87,7 @@ index 12839ab..3995840 100644
  def IR : Type (max (uA + 1) (uB + 1) uI uO) :=
    PFunctor.W.{max (uA + 1) (uB + 1) uO, max uA uB uI}
      (IR.pFunctor.{uA, uB, uI, uO} I O)
-@@ -509,10 +510,10 @@ end IR
+@@ -619,10 +620,10 @@ end IR
  
  namespace IR
  
@@ -99,6 +99,50 @@ index 12839ab..3995840 100644
  def interpObjIota (o : O) : FreeCoprodCompDisc.Map.{max uA uB, uI, uO} I O :=
    fun _ ↦ ⟨ULift Unit, fun _ ↦ o⟩
  
+diff --git a/vendor/geb-mathlib/Geb/Mathlib/Data/PFunctor/IndRec/Category.lean b/vendor/geb-mathlib/Geb/Mathlib/Data/PFunctor/IndRec/Category.lean
+index a162a0c..92535e6 100644
+--- a/vendor/geb-mathlib/Geb/Mathlib/Data/PFunctor/IndRec/Category.lean
++++ b/vendor/geb-mathlib/Geb/Mathlib/Data/PFunctor/IndRec/Category.lean
+@@ -3,6 +3,7 @@ Copyright (c) 2026 Terence Rokop. All rights reserved.
+ Released under Apache 2.0 license as described in the file LICENSE.
+ Authors: Terence Rokop
+ -/
++-- Modified from geb-mathlib by scripts/geb-mathlib-backport.patch.
+ module
+ 
+ public import Geb.Mathlib.Data.PFunctor.IndRec.Naturality
+@@ -86,7 +87,7 @@ are carried as `FreeCoprodCompDisc.isoOfEq` transports and commuted
+ across the Lemma 4 isomorphism by elimination of the generalized
+ equality.
+ 
+-The `linter.checkUnivs false` option on `IR.comp_isoOfEq_hom` and
++The `@[nolint checkUnivs]` attribute on `IR.comp_isoOfEq_hom` and
+ `IR.isoOfEq_symm_hom_comp` suppresses the `checkUnivs` warning on
+ the separated arity universes `uA`/`uB`: in those two declarations'
+ types the pair appears only together under `max`, so the linter
+@@ -4125,10 +4126,10 @@ theorem interpHom_cast_cod (D : IR.{max uA uB, uB, uI, uO} I O)
+       (fun f ↦ (FreeCoprodCompDisc.Hom.comp_id O
+         ((interpHom I O D γ₀ f).1 X)).symm)
+       h
+-set_option linter.checkUnivs false in
+ /-- Postcomposition with an object-equality transport is the transport
+ of the morphism's codomain, by elimination of the generalized
+ equality. -/
++@[nolint checkUnivs]
+ theorem comp_isoOfEq_hom (Z W : FreeCoprodCompDisc.{max uA uB, uI} I) :
+     ∀ (V : FreeCoprodCompDisc.{max uA uB, uI} I) (q : W = V)
+       (f : FreeCoprodCompDisc.Hom I Z W),
+@@ -4143,9 +4144,9 @@ theorem comp_isoOfEq_hom (Z W : FreeCoprodCompDisc.{max uA uB, uI} I) :
+                 (FreeCoprodCompDisc.isoOfEq I q')) =
+             cast (congrArg (FreeCoprodCompDisc.Hom I Z) q') f)
+       (fun f ↦ FreeCoprodCompDisc.Hom.comp_id I f) q
+-set_option linter.checkUnivs false in
+ /-- An object-equality transport followed by its inverse is the
+ identity, by elimination of the generalized equality. -/
++@[nolint checkUnivs]
+ theorem isoOfEq_symm_hom_comp (Z : FreeCoprodCompDisc.{max uA uB, uO} O) :
+     ∀ (W : FreeCoprodCompDisc.{max uA uB, uO} O) (q : Z = W),
+       FreeCoprodCompDisc.Hom.comp O
 diff --git a/vendor/geb-mathlib/Geb/Mathlib/Data/PFunctor/Presheaf/Basic.lean b/vendor/geb-mathlib/Geb/Mathlib/Data/PFunctor/Presheaf/Basic.lean
 index 004265e..fc173cb 100644
 --- a/vendor/geb-mathlib/Geb/Mathlib/Data/PFunctor/Presheaf/Basic.lean

--- a/geb-lean/vendor/geb-mathlib/Geb/Mathlib/CategoryTheory.lean
+++ b/geb-lean/vendor/geb-mathlib/Geb/Mathlib/CategoryTheory.lean
@@ -6,6 +6,7 @@ Authors: Terence Rokop
 module
 
 public import Geb.Mathlib.CategoryTheory.FreeCoprodCompDisc
+public import Geb.Mathlib.CategoryTheory.FreeCoprodCompDisc.NatTrans
 public import Geb.Mathlib.CategoryTheory.Grothendieck
 
 /-!

--- a/geb-lean/vendor/geb-mathlib/Geb/Mathlib/CategoryTheory/FreeCoprodCompDisc.lean
+++ b/geb-lean/vendor/geb-mathlib/Geb/Mathlib/CategoryTheory/FreeCoprodCompDisc.lean
@@ -55,6 +55,17 @@ action, constructively.
   `refl`/`symm`/`trans` and the transport `isoOfEq`; `coprodIso` is
   the congruence of `coprod` along an index equivalence and a
   family of isomorphisms of the summands.
+* `FreeCoprodCompDisc.emptyObj`, `FreeCoprodCompDisc.emptyDesc` —
+  the initial object and its universal morphism.
+* `FreeCoprodCompDisc.coprodInj`, `FreeCoprodCompDisc.coprodDesc`,
+  `FreeCoprodCompDisc.coprodHomEquiv` — the injections, the
+  cotuple, and the universal property of the indexed coproduct.
+* `FreeCoprodCompDisc.coprodPairMor` — the functorial action of
+  `FreeCoprodCompDisc.coprodPair` on morphisms.
+* `FreeCoprodCompDisc.homSingletonEquiv` — morphisms out of a
+  singleton object as the fiber of the decoding over its value.
+* `FreeCoprodCompDisc.Iso.hom`, `FreeCoprodCompDisc.Iso.invHom` —
+  the underlying morphisms of an isomorphism.
 
 ## Main statements
 
@@ -63,6 +74,22 @@ action, constructively.
 * `FreeCoprodCompDisc.coprodMor_id`,
   `FreeCoprodCompDisc.coprodMor_comp` — the functoriality of
   `FreeCoprodCompDisc.coprodMor`.
+* `FreeCoprodCompDisc.emptyDesc_unique` — initiality.
+* `FreeCoprodCompDisc.coprodInj_desc`,
+  `FreeCoprodCompDisc.coprodDesc_eta` — the computation and
+  uniqueness laws of the cotuple, with the composition
+  compatibilities `FreeCoprodCompDisc.coprodMor_desc`,
+  `FreeCoprodCompDisc.coprodDesc_comp`,
+  `FreeCoprodCompDisc.coprodInj_mor`.
+* `FreeCoprodCompDisc.coprodPairMor_id`,
+  `FreeCoprodCompDisc.coprodPairMor_comp` — the functoriality of
+  `FreeCoprodCompDisc.coprodPairMor`, with the cotuple
+  compatibilities `FreeCoprodCompDisc.coprodPairMor_desc`,
+  `FreeCoprodCompDisc.coprodPairMor_id_desc`,
+  `FreeCoprodCompDisc.coprodPairMor_inr_desc_inl`.
+* `FreeCoprodCompDisc.Iso.hom_invHom`,
+  `FreeCoprodCompDisc.Iso.invHom_hom` — the inverse laws of the
+  underlying morphisms.
 
 ## Implementation notes
 
@@ -204,6 +231,103 @@ theorem coprodMor_comp.{w} (ι κ ρ : Type w) (r : ι → κ) (t : κ → ρ)
         (fun i ↦ Hom.comp D (hom₁ i) (hom₂ (r i))) :=
   Subtype.ext rfl
 
+/-- The initial object of the free coproduct completion: the empty
+family. -/
+def emptyObj : FreeCoprodCompDisc.{u, v} D :=
+  ⟨PEmpty, PEmpty.elim⟩
+
+/-- The unique morphism out of the initial object (the nullary
+cotuple). -/
+def emptyDesc (X : FreeCoprodCompDisc.{u, v} D) : Hom D (emptyObj D) X :=
+  ⟨PEmpty.elim, funext (fun a ↦ a.elim)⟩
+
+/-- Uniqueness of the morphism out of the initial object. -/
+theorem emptyDesc_unique (X : FreeCoprodCompDisc.{u, v} D)
+    (f : Hom D (emptyObj D) X) : f = emptyDesc D X :=
+  Subtype.ext (funext (fun a ↦ a.elim))
+
+section
+
+universe w
+
+/-- The injection into the `i`-th summand of an indexed coproduct. -/
+def coprodInj (ι : Type w) (fi : ι → FreeCoprodCompDisc.{u, v} D)
+    (i : ι) : Hom.{u, v, max u w} D (fi i) (coprod D ι fi) :=
+  ⟨fun a ↦ ⟨i, a⟩, rfl⟩
+
+/-- The cotuple: the universal morphism out of an indexed
+coproduct. -/
+def coprodDesc.{u'} (ι : Type w) (fi : ι → FreeCoprodCompDisc.{u, v} D)
+    (Z : FreeCoprodCompDisc.{u', v} D)
+    (m : (i : ι) → Hom D (fi i) Z) : Hom D (coprod D ι fi) Z :=
+  ⟨fun p ↦ (m p.1).1 p.2, funext (fun p ↦ congrFun (m p.1).2 p.2)⟩
+
+/-- The universal property of the indexed coproduct: morphisms out of
+`coprod ι fi` correspond to `ι`-indexed families of morphisms out of
+the summands (`copowerEquiv` is the constant-family case). -/
+def coprodHomEquiv.{u'} (ι : Type w)
+    (fi : ι → FreeCoprodCompDisc.{u, v} D)
+    (Z : FreeCoprodCompDisc.{u', v} D) :
+    Hom D (coprod D ι fi) Z ≃ ((i : ι) → Hom D (fi i) Z) :=
+  { toFun := fun h i ↦
+      ⟨fun a ↦ h.1 ⟨i, a⟩, funext (fun a ↦ congrFun h.2 ⟨i, a⟩)⟩,
+    invFun := coprodDesc D ι fi Z,
+    left_inv := fun _ ↦ Subtype.ext rfl,
+    right_inv := fun _ ↦ funext (fun _ ↦ Subtype.ext rfl) }
+
+end
+
+/-- Restricting a cotuple along an injection recovers the
+component (at one index universe). -/
+theorem coprodInj_desc (ι : Type u)
+    (fi : ι → FreeCoprodCompDisc.{u, v} D)
+    (Z : FreeCoprodCompDisc.{u, v} D) (m : (i : ι) → Hom D (fi i) Z)
+    (i : ι) :
+    Hom.comp D (coprodInj D ι fi i) (coprodDesc D ι fi Z m) = m i :=
+  Subtype.ext rfl
+
+/-- Every morphism out of an indexed coproduct is the cotuple of its
+restrictions (at one index universe). -/
+theorem coprodDesc_eta (ι : Type u)
+    (fi : ι → FreeCoprodCompDisc.{u, v} D)
+    (Z : FreeCoprodCompDisc.{u, v} D)
+    (h : Hom D (coprod D ι fi) Z) :
+    coprodDesc D ι fi Z
+        (fun i ↦ Hom.comp D (coprodInj D ι fi i) h) = h :=
+  Subtype.ext rfl
+
+/-- A reindexed coproduct morphism followed by a cotuple is the
+cotuple of the reindexed composites. -/
+theorem coprodMor_desc (ι κ : Type u) (r : ι → κ)
+    (fi : ι → FreeCoprodCompDisc.{u, v} D)
+    (gk : κ → FreeCoprodCompDisc.{u, v} D)
+    (hom : (i : ι) → Hom D (fi i) (gk (r i)))
+    (Z : FreeCoprodCompDisc.{u, v} D)
+    (m : (k : κ) → Hom D (gk k) Z) :
+    Hom.comp D (coprodMor D ι κ r fi gk hom) (coprodDesc D κ gk Z m) =
+      coprodDesc D ι fi Z (fun i ↦ Hom.comp D (hom i) (m (r i))) :=
+  Subtype.ext rfl
+
+/-- A cotuple followed by a morphism is the cotuple of the
+composites. -/
+theorem coprodDesc_comp (ι : Type u)
+    (fi : ι → FreeCoprodCompDisc.{u, v} D)
+    (Z W : FreeCoprodCompDisc.{u, v} D)
+    (m : (i : ι) → Hom D (fi i) Z) (g : Hom D Z W) :
+    Hom.comp D (coprodDesc D ι fi Z m) g =
+      coprodDesc D ι fi W (fun i ↦ Hom.comp D (m i) g) :=
+  Subtype.ext rfl
+
+/-- An injection followed by a reindexed coproduct morphism is the
+component followed by the reindexed injection. -/
+theorem coprodInj_mor (ι κ : Type u) (r : ι → κ)
+    (fi : ι → FreeCoprodCompDisc.{u, v} D)
+    (gk : κ → FreeCoprodCompDisc.{u, v} D)
+    (hom : (i : ι) → Hom D (fi i) (gk (r i))) (i : ι) :
+    Hom.comp D (coprodInj D ι fi i) (coprodMor D ι κ r fi gk hom) =
+      Hom.comp D (hom i) (coprodInj D κ gk (r i)) :=
+  Subtype.ext rfl
+
 /-- The binary coproduct of two objects of the free coproduct
 completion: the sum of the name types, the cotuple of the
 decodings — the cotuple object `[i, k]` of
@@ -223,15 +347,24 @@ def plus.{uJ, uK} (i : FreeCoprodCompDisc.{uJ, v} D)
     FreeCoprodCompDisc.{max uJ uK, v} D :=
   coprodPair.{v, uJ, uK} D i k
 
-/-- The left injection into a binary coproduct (at one index
-universe, where the coproduct is in-category). -/
-def coprodPairInl (X Y : FreeCoprodCompDisc.{u, v} D) :
-    Hom D X (coprodPair.{v, u, u} D X Y) :=
+/-- The left injection into a binary coproduct. The two summands
+may sit at different index universes, mirroring `coprodPair`; at
+`uX ≠ uY` the result is a heterogeneous `Hom` that cannot be fed to
+`Hom.comp`, which pins its source, target, and codomain to a single
+universe. -/
+def coprodPairInl.{uX, uY} (X : FreeCoprodCompDisc.{uX, v} D)
+    (Y : FreeCoprodCompDisc.{uY, v} D) :
+    Hom D X (coprodPair.{v, uX, uY} D X Y) :=
   ⟨Sum.inl, rfl⟩
 
-/-- The right injection into a binary coproduct. -/
-def coprodPairInr (X Y : FreeCoprodCompDisc.{u, v} D) :
-    Hom D Y (coprodPair.{v, u, u} D X Y) :=
+/-- The right injection into a binary coproduct. The two summands
+may sit at different index universes, mirroring `coprodPair`; at
+`uX ≠ uY` the result is a heterogeneous `Hom` that cannot be fed to
+`Hom.comp`, which pins its source, target, and codomain to a single
+universe. -/
+def coprodPairInr.{uX, uY} (X : FreeCoprodCompDisc.{uX, v} D)
+    (Y : FreeCoprodCompDisc.{uY, v} D) :
+    Hom D Y (coprodPair.{v, uX, uY} D X Y) :=
   ⟨Sum.inr, rfl⟩
 
 /-- The cotuple: the universal morphism out of a binary
@@ -266,6 +399,62 @@ theorem coprodPairDesc_eta (X Y Z : FreeCoprodCompDisc.{u, v} D)
       (Hom.comp D (coprodPairInr D X Y) h) = h :=
   Subtype.ext (funext (fun s ↦ Sum.casesOn s (fun _ ↦ rfl) (fun _ ↦ rfl)))
 
+/-- The functorial action of `coprodPair` on morphisms. The four
+objects may sit at four different index universes, mirroring
+`coprodPair`. -/
+def coprodPairMor.{uX, uY, uX', uY'} {X : FreeCoprodCompDisc.{uX, v} D}
+    {X' : FreeCoprodCompDisc.{uX', v} D}
+    {Y : FreeCoprodCompDisc.{uY, v} D}
+    {Y' : FreeCoprodCompDisc.{uY', v} D}
+    (f : Hom D X X') (g : Hom D Y Y') :
+    Hom D (coprodPair D X Y) (coprodPair D X' Y') :=
+  ⟨Sum.map f.1 g.1,
+    funext (fun s ↦
+      Sum.casesOn s (fun a ↦ congrFun f.2 a) (fun b ↦ congrFun g.2 b))⟩
+
+/-- `coprodPairMor` preserves identities (at one index universe per
+side). -/
+theorem coprodPairMor_id.{uX, uY} (X : FreeCoprodCompDisc.{uX, v} D)
+    (Y : FreeCoprodCompDisc.{uY, v} D) :
+    coprodPairMor D (Hom.id D X) (Hom.id D Y) =
+      Hom.id D (coprodPair D X Y) :=
+  Subtype.ext (funext (fun s ↦ Sum.casesOn s (fun _ ↦ rfl) (fun _ ↦ rfl)))
+
+/-- `coprodPairMor` preserves composition (at one index universe, where
+`Hom.comp` is available). -/
+theorem coprodPairMor_comp {X X' X'' Y Y' Y'' : FreeCoprodCompDisc.{u, v} D}
+    (f : Hom D X X') (f' : Hom D X' X'') (g : Hom D Y Y')
+    (g' : Hom D Y' Y'') :
+    coprodPairMor D (Hom.comp D f f') (Hom.comp D g g') =
+      Hom.comp D (coprodPairMor D f g) (coprodPairMor D f' g') :=
+  Subtype.ext (funext (fun s ↦ Sum.casesOn s (fun _ ↦ rfl) (fun _ ↦ rfl)))
+
+/-- `coprodPairMor` commutes with the cotuple: reindexing then
+descending is descending the composites (left component fixed). -/
+theorem coprodPairMor_desc {X Y Y' Z : FreeCoprodCompDisc.{u, v} D}
+    (g : Hom D Y Y') (l : Hom D X Z) (m : Hom D Y' Z) :
+    Hom.comp D (coprodPairMor D (Hom.id D X) g) (coprodPairDesc D l m) =
+      coprodPairDesc D l (Hom.comp D g m) :=
+  Subtype.ext (funext (fun s ↦ Sum.casesOn s (fun _ ↦ rfl) (fun _ ↦ rfl)))
+
+/-- Reindexing the right summand and then cotupling against the
+identity is cotupling against the identity and then composing. -/
+theorem coprodPairMor_id_desc {Z X Y : FreeCoprodCompDisc.{u, v} D}
+    (h : Hom D X Y) (e : Hom D Z X) :
+    Hom.comp D (coprodPairMor D (Hom.id D Z) h)
+        (coprodPairDesc D (Hom.comp D e h) (Hom.id D Y)) =
+      Hom.comp D (coprodPairDesc D e (Hom.id D X)) h :=
+  Subtype.ext (funext (fun s ↦ Sum.casesOn s (fun _ ↦ rfl) (fun _ ↦ rfl)))
+
+/-- Reindexing the right summand along the right injection and then
+cotupling the left injection against the identity is the identity. -/
+theorem coprodPairMor_inr_desc_inl {Z X : FreeCoprodCompDisc.{u, v} D} :
+    Hom.comp D (coprodPairMor D (Hom.id D Z) (coprodPairInr D Z X))
+        (coprodPairDesc D (coprodPairInl D Z X)
+          (Hom.id D (coprodPair.{v, u, u} D Z X))) =
+      Hom.id D (coprodPair.{v, u, u} D Z X) :=
+  Subtype.ext (funext (fun s ↦ Sum.casesOn s (fun _ ↦ rfl) (fun _ ↦ rfl)))
+
 /-- An isomorphism of two objects of the free coproduct completion of `D`
 treated as a discrete category: a name-type equivalence commuting with the
 decodings. -/
@@ -292,6 +481,30 @@ def Iso.trans.{u₁, u₂, u₃} {X : FreeCoprodCompDisc.{u₁, v} D}
 /-- Transport an isomorphism along an equality of objects. -/
 def isoOfEq {X Y : FreeCoprodCompDisc.{u, v} D} : X = Y → Iso D X Y
   | rfl => Iso.refl D X
+
+/-- The underlying morphism of an isomorphism. -/
+def Iso.hom {X Y : FreeCoprodCompDisc.{u, v} D} (e : Iso D X Y) :
+    Hom D X Y :=
+  ⟨fun a ↦ e.1 a, e.2⟩
+
+/-- The underlying morphism of the inverse of an isomorphism. -/
+def Iso.invHom {X Y : FreeCoprodCompDisc.{u, v} D} (e : Iso D X Y) :
+    Hom D Y X :=
+  ⟨fun b ↦ e.1.symm b, (Iso.symm D e).2⟩
+
+/-- The underlying morphisms of an isomorphism compose to the
+identity, forward-then-backward. -/
+theorem Iso.hom_invHom {X Y : FreeCoprodCompDisc.{u, v} D}
+    (e : Iso D X Y) :
+    Hom.comp D (Iso.hom D e) (Iso.invHom D e) = Hom.id D X :=
+  Subtype.ext (funext (fun a ↦ e.1.symm_apply_apply a))
+
+/-- The underlying morphisms of an isomorphism compose to the
+identity, backward-then-forward. -/
+theorem Iso.invHom_hom {X Y : FreeCoprodCompDisc.{u, v} D}
+    (e : Iso D X Y) :
+    Hom.comp D (Iso.invHom D e) (Iso.hom D e) = Hom.id D Y :=
+  Subtype.ext (funext (fun b ↦ e.1.apply_symm_apply b))
 
 /-- The congruence of `FreeCoprodCompDisc.coprod` along an index
 equivalence and a family of isomorphisms of the summands. -/
@@ -341,6 +554,17 @@ def homLiftEquiv.{w} (X : FreeCoprodCompDisc.{u, v} D)
       ⟨h.1 ∘ ULift.down, funext (fun a ↦ congrFun h.2 a.down)⟩,
     left_inv := fun _ ↦ Subtype.ext rfl,
     right_inv := fun _ ↦ Subtype.ext rfl }
+
+/-- Morphisms out of a singleton object are the fiber of the decoding
+over its value. -/
+def homSingletonEquiv (d : D) (Z : FreeCoprodCompDisc.{u, v} D) :
+    Hom D (⟨ULift Unit, fun _ ↦ d⟩ : FreeCoprodCompDisc.{u, v} D) Z ≃
+      {z : Z.1 // Z.2 z = d} :=
+  { toFun := fun f ↦ ⟨f.1 (ULift.up Unit.unit),
+      congrFun f.2 (ULift.up Unit.unit)⟩,
+    invFun := fun z ↦ ⟨fun _ ↦ z.1, funext (fun _ ↦ z.2)⟩,
+    left_inv := fun _ ↦ Subtype.ext rfl,
+    right_inv := fun _ ↦ rfl }
 
 end FreeCoprodCompDisc
 

--- a/geb-lean/vendor/geb-mathlib/Geb/Mathlib/CategoryTheory/FreeCoprodCompDisc/NatTrans.lean
+++ b/geb-lean/vendor/geb-mathlib/Geb/Mathlib/CategoryTheory/FreeCoprodCompDisc/NatTrans.lean
@@ -1,0 +1,600 @@
+/-
+Copyright (c) 2026 Terence Rokop. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Terence Rokop
+-/
+module
+
+public import Geb.Mathlib.CategoryTheory.FreeCoprodCompDisc
+
+/-!
+# Natural transformations between completion maps
+
+Natural transformations between morphism-mapped object maps of free
+coproduct completions (`FreeCoprodCompDisc.Map` paired with
+`FreeCoprodCompDisc.MapMor`): the naturality condition, the
+transformation space as a subtype, and the vertical structure
+(identity, composition, and the category laws). Functor-law
+predicates and composite maps support the horizontal structure.
+
+## Main definitions
+
+* `FreeCoprodCompDisc.IsNatTrans`, `FreeCoprodCompDisc.NatTrans` —
+  the naturality condition and the transformation space.
+* `FreeCoprodCompDisc.NatTrans.id`,
+  `FreeCoprodCompDisc.NatTrans.vcomp` — the vertical structure.
+* `FreeCoprodCompDisc.PreservesId`,
+  `FreeCoprodCompDisc.PreservesComp` — functor-law predicates on a
+  morphism map.
+* `FreeCoprodCompDisc.mapComp`, `FreeCoprodCompDisc.mapMorComp` —
+  the composite of two object maps and of their morphism maps.
+* `FreeCoprodCompDisc.NatTrans.whiskerRight`,
+  `FreeCoprodCompDisc.NatTrans.whiskerLeft`,
+  `FreeCoprodCompDisc.NatTrans.hcomp` — whiskering and horizontal
+  composition.
+* `FreeCoprodCompDisc.idMap`, `FreeCoprodCompDisc.idMapMor` — the
+  identity object map and its morphism-map component.
+* `FreeCoprodCompDisc.NatTrans.IsInverse`,
+  `FreeCoprodCompDisc.NatTrans.ofIsoFamily`,
+  `FreeCoprodCompDisc.NatTrans.invOfIsoFamily` — inverse pairs and
+  the conversion of a natural family of isomorphisms.
+* `FreeCoprodCompDisc.NatTrans.equivOfInverseTarget`,
+  `FreeCoprodCompDisc.NatTrans.equivOfInverseSource`,
+  `FreeCoprodCompDisc.NatTrans.congrSource` — transport
+  equivalences of transformation spaces.
+* `FreeCoprodCompDisc.natCoprodEquiv` — the coproduct
+  decomposition of transformation spaces.
+* `FreeCoprodCompDisc.copowerHomMap`,
+  `FreeCoprodCompDisc.plusMap` (with their morphism maps) and
+  `FreeCoprodCompDisc.natCopowerPlusEquiv` — the copower–Yoneda
+  adjunction: transformations out of the copowered map correspond
+  to transformations into the `plus`-precomposed map (components
+  `FreeCoprodCompDisc.natCopowerPlusToFun` and
+  `FreeCoprodCompDisc.natCopowerPlusInvFun`).
+
+## Main statements
+
+* `FreeCoprodCompDisc.NatTrans.id_vcomp`,
+  `FreeCoprodCompDisc.NatTrans.vcomp_id`,
+  `FreeCoprodCompDisc.NatTrans.vcomp_assoc` — the vertical
+  category laws.
+* `FreeCoprodCompDisc.NatTrans.hcomp_eq_vcomp_whisker`,
+  `FreeCoprodCompDisc.NatTrans.hcomp_id`,
+  `FreeCoprodCompDisc.NatTrans.hcomp_id_right`,
+  `FreeCoprodCompDisc.NatTrans.hcomp_id_left`,
+  `FreeCoprodCompDisc.NatTrans.hcomp_vcomp` — the coherence and
+  interchange laws of horizontal composition.
+* `FreeCoprodCompDisc.NatTrans.whiskerRight_idMap`,
+  `FreeCoprodCompDisc.NatTrans.whiskerLeft_idMap` — whiskering by
+  the identity object map is the identity operation (with the
+  functor-law witnesses `FreeCoprodCompDisc.idMapMor_preservesId`
+  and `FreeCoprodCompDisc.idMapMor_preservesComp`).
+* `FreeCoprodCompDisc.isNatTrans_invHom`,
+  `FreeCoprodCompDisc.NatTrans.ofIsoFamily_isInverse` — naturality
+  of the inverse family and the inverse laws of the packaged pair.
+* `FreeCoprodCompDisc.natCopowerPlus_invFun_toFun`,
+  `FreeCoprodCompDisc.natCopowerPlus_toFun_invFun` — the
+  round-trip laws of the adjunction.
+
+## Implementation notes
+
+A transformation is a subtype over a `Prop`-valued naturality
+condition, so equality of transformations is `Subtype.ext` plus
+`funext`, and the vertical laws are componentwise consequences of
+the `FreeCoprodCompDisc.Hom` category laws. Morphism maps carry no
+functor laws; the operations that need one take the corresponding
+`FreeCoprodCompDisc.PreservesId`/`FreeCoprodCompDisc.PreservesComp`
+law as an explicit hypothesis.
+
+## Tags
+
+free coproduct completion, natural transformation, functor category
+-/
+
+@[expose] public section
+
+universe u v w x
+
+namespace CategoryTheory
+
+namespace FreeCoprodCompDisc
+
+/-- The naturality condition on a family of componentwise morphisms
+between two morphism-mapped object maps. -/
+def IsNatTrans.{w'} (I : Type v) (O : Type w') (F G : Map.{u, v, w'} I O)
+    (mF : MapMor I O F) (mG : MapMor I O G)
+    (η : (X : FreeCoprodCompDisc.{u, v} I) → Hom.{u, w', u} O (F X) (G X)) :
+    Prop :=
+  ∀ (X Y : FreeCoprodCompDisc.{u, v} I) (h : Hom.{u, v, u} I X Y),
+    Hom.comp O (mF X Y h) (η Y) = Hom.comp O (η X) (mG X Y h)
+
+/-- A natural transformation between two morphism-mapped object maps:
+a componentwise family of morphisms satisfying the naturality
+condition. -/
+def NatTrans.{w'} (I : Type v) (O : Type w') (F G : Map.{u, v, w'} I O)
+    (mF : MapMor I O F) (mG : MapMor I O G) : Type (max (u + 1) v) :=
+  {η : (X : FreeCoprodCompDisc.{u, v} I) → Hom.{u, w', u} O (F X) (G X) //
+    IsNatTrans I O F G mF mG η}
+
+variable {I : Type v} {O : Type w} {P : Type x}
+
+/-- The identity natural transformation. -/
+def NatTrans.id (F : Map.{u, v, w} I O) (mF : MapMor I O F) :
+    NatTrans I O F F mF mF :=
+  ⟨fun X ↦ Hom.id O (F X),
+    fun X Y h ↦
+      (Hom.comp_id O (mF X Y h)).trans (Hom.id_comp O (mF X Y h)).symm⟩
+
+/-- Vertical composition of natural transformations. -/
+def NatTrans.vcomp {F G H : Map.{u, v, w} I O} {mF : MapMor I O F}
+    {mG : MapMor I O G} {mH : MapMor I O H}
+    (η : NatTrans I O F G mF mG) (θ : NatTrans I O G H mG mH) :
+    NatTrans I O F H mF mH :=
+  ⟨fun X ↦ Hom.comp O (η.1 X) (θ.1 X),
+    fun X Y h ↦
+      (Hom.comp_assoc O (mF X Y h) (η.1 Y) (θ.1 Y)).symm.trans
+        ((congrArg (fun t ↦ Hom.comp O t (θ.1 Y)) (η.2 X Y h)).trans
+          ((Hom.comp_assoc O (η.1 X) (mG X Y h) (θ.1 Y)).trans
+            ((congrArg (Hom.comp O (η.1 X)) (θ.2 X Y h)).trans
+              (Hom.comp_assoc O (η.1 X) (θ.1 X) (mH X Y h)).symm)))⟩
+
+/-- Vertical left identity. -/
+theorem NatTrans.id_vcomp {F G : Map.{u, v, w} I O} {mF : MapMor I O F}
+    {mG : MapMor I O G} (η : NatTrans I O F G mF mG) :
+    NatTrans.vcomp (NatTrans.id F mF) η = η :=
+  Subtype.ext (funext (fun X ↦ Hom.id_comp O (η.1 X)))
+
+/-- Vertical right identity. -/
+theorem NatTrans.vcomp_id {F G : Map.{u, v, w} I O} {mF : MapMor I O F}
+    {mG : MapMor I O G} (η : NatTrans I O F G mF mG) :
+    NatTrans.vcomp η (NatTrans.id G mG) = η :=
+  Subtype.ext (funext (fun X ↦ Hom.comp_id O (η.1 X)))
+
+/-- Vertical associativity. -/
+theorem NatTrans.vcomp_assoc {F G H K : Map.{u, v, w} I O}
+    {mF : MapMor I O F} {mG : MapMor I O G} {mH : MapMor I O H}
+    {mK : MapMor I O K} (η : NatTrans I O F G mF mG)
+    (θ : NatTrans I O G H mG mH) (ρ : NatTrans I O H K mH mK) :
+    NatTrans.vcomp (NatTrans.vcomp η θ) ρ =
+      NatTrans.vcomp η (NatTrans.vcomp θ ρ) :=
+  Subtype.ext (funext (fun X ↦ Hom.comp_assoc O (η.1 X) (θ.1 X) (ρ.1 X)))
+
+/-- Preservation of identities by a morphism map. -/
+def PreservesId (F : Map.{u, v, w} I O) (mF : MapMor I O F) : Prop :=
+  ∀ X : FreeCoprodCompDisc.{u, v} I,
+    mF X X (Hom.id I X) = Hom.id O (F X)
+
+/-- Preservation of composition by a morphism map. -/
+def PreservesComp (F : Map.{u, v, w} I O) (mF : MapMor I O F) : Prop :=
+  ∀ (X Y Z : FreeCoprodCompDisc.{u, v} I) (f : Hom I X Y) (g : Hom I Y Z),
+    mF X Z (Hom.comp I f g) = Hom.comp O (mF X Y f) (mF Y Z g)
+
+/-- The composite of two object maps. -/
+def mapComp (F : Map.{u, v, w} I O) (F' : Map.{u, w, x} O P) :
+    Map.{u, v, x} I P :=
+  fun X ↦ F' (F X)
+
+/-- The composite of two morphism maps, over the composite object
+map. -/
+def mapMorComp {F : Map.{u, v, w} I O} {F' : Map.{u, w, x} O P}
+    (mF : MapMor I O F) (mF' : MapMor O P F') :
+    MapMor I P (mapComp F F') :=
+  fun X Y h ↦ mF' (F X) (F Y) (mF X Y h)
+
+/-- Right whiskering: precomposition of a transformation with an
+object map (no functor-law hypotheses). -/
+def NatTrans.whiskerRight {F' G' : Map.{u, w, x} O P}
+    {mF' : MapMor O P F'} {mG' : MapMor O P G'} (F : Map.{u, v, w} I O)
+    (mF : MapMor I O F) (θ : NatTrans O P F' G' mF' mG') :
+    NatTrans I P (mapComp F F') (mapComp F G')
+      (mapMorComp mF mF') (mapMorComp mF mG') :=
+  ⟨fun X ↦ θ.1 (F X), fun X Y h ↦ θ.2 (F X) (F Y) (mF X Y h)⟩
+
+/-- Left whiskering: postcomposition of a transformation with an
+object map, whose naturality consumes the outer morphism map's
+composition-preservation law. -/
+def NatTrans.whiskerLeft {F G : Map.{u, v, w} I O} {mF : MapMor I O F}
+    {mG : MapMor I O G} (η : NatTrans I O F G mF mG)
+    (F' : Map.{u, w, x} O P) (mF' : MapMor O P F')
+    (hF' : PreservesComp F' mF') :
+    NatTrans I P (mapComp F F') (mapComp G F')
+      (mapMorComp mF mF') (mapMorComp mG mF') :=
+  ⟨fun X ↦ mF' (F X) (G X) (η.1 X),
+    fun X Y h ↦
+      (hF' (F X) (F Y) (G Y) (mF X Y h) (η.1 Y)).symm.trans
+        ((congrArg (mF' (F X) (G Y)) (η.2 X Y h)).trans
+          (hF' (F X) (G X) (G Y) (η.1 X) (mG X Y h)))⟩
+
+/-- Horizontal composition of natural transformations, in the
+`whiskerLeft`-then-`whiskerRight` orientation. -/
+def NatTrans.hcomp {F G : Map.{u, v, w} I O} {mF : MapMor I O F}
+    {mG : MapMor I O G} {F' G' : Map.{u, w, x} O P}
+    {mF' : MapMor O P F'} {mG' : MapMor O P G'}
+    (η : NatTrans I O F G mF mG) (θ : NatTrans O P F' G' mF' mG')
+    (hF' : PreservesComp F' mF') :
+    NatTrans I P (mapComp F F') (mapComp G G')
+      (mapMorComp mF mF') (mapMorComp mG mG') :=
+  NatTrans.vcomp (NatTrans.whiskerLeft η F' mF' hF')
+    (NatTrans.whiskerRight G mG θ)
+
+/-- The two orientations of the horizontal composite agree, by the
+second transformation's naturality. -/
+theorem NatTrans.hcomp_eq_vcomp_whisker {F G : Map.{u, v, w} I O}
+    {mF : MapMor I O F} {mG : MapMor I O G} {F' G' : Map.{u, w, x} O P}
+    {mF' : MapMor O P F'} {mG' : MapMor O P G'}
+    (η : NatTrans I O F G mF mG) (θ : NatTrans O P F' G' mF' mG')
+    (hF' : PreservesComp F' mF') (hG' : PreservesComp G' mG') :
+    NatTrans.hcomp η θ hF' =
+      NatTrans.vcomp (NatTrans.whiskerRight F mF θ)
+        (NatTrans.whiskerLeft η G' mG' hG') :=
+  Subtype.ext (funext (fun X ↦ θ.2 (F X) (G X) (η.1 X)))
+
+/-- The horizontal composite of identity transformations is the
+identity (consuming the outer morphism map's identity-preservation
+law). -/
+theorem NatTrans.hcomp_id {F : Map.{u, v, w} I O} {mF : MapMor I O F}
+    {F' : Map.{u, w, x} O P} {mF' : MapMor O P F'}
+    (hF'comp : PreservesComp F' mF') (hF'id : PreservesId F' mF') :
+    NatTrans.hcomp (NatTrans.id F mF) (NatTrans.id F' mF') hF'comp =
+      NatTrans.id (mapComp F F') (mapMorComp mF mF') :=
+  Subtype.ext (funext (fun X ↦
+    (congrArg (fun t ↦ Hom.comp P t (Hom.id P (F' (F X))))
+        (hF'id (F X))).trans
+      (Hom.comp_id P (Hom.id P (F' (F X))))))
+
+/-- Whiskering by an identity-transformation on the right is left
+whiskering. -/
+theorem NatTrans.hcomp_id_right {F G : Map.{u, v, w} I O}
+    {mF : MapMor I O F} {mG : MapMor I O G} {F' : Map.{u, w, x} O P}
+    {mF' : MapMor O P F'} (η : NatTrans I O F G mF mG)
+    (hF' : PreservesComp F' mF') :
+    NatTrans.hcomp η (NatTrans.id F' mF') hF' =
+      NatTrans.whiskerLeft η F' mF' hF' :=
+  Subtype.ext (funext (fun X ↦ Hom.comp_id P (mF' (F X) (G X) (η.1 X))))
+
+/-- Whiskering by an identity-transformation on the left is right
+whiskering. -/
+theorem NatTrans.hcomp_id_left {F : Map.{u, v, w} I O}
+    {mF : MapMor I O F} {F' G' : Map.{u, w, x} O P}
+    {mF' : MapMor O P F'} {mG' : MapMor O P G'}
+    (θ : NatTrans O P F' G' mF' mG') (hF'comp : PreservesComp F' mF')
+    (hF'id : PreservesId F' mF') :
+    NatTrans.hcomp (NatTrans.id F mF) θ hF'comp =
+      NatTrans.whiskerRight F mF θ :=
+  Subtype.ext (funext (fun X ↦
+    (congrArg (fun t ↦ Hom.comp P t (θ.1 (F X))) (hF'id (F X))).trans
+      (Hom.id_comp P (θ.1 (F X)))))
+
+/-- The identity object map. -/
+def idMap : Map.{u, v, v} I I :=
+  fun X ↦ X
+
+/-- The morphism-map component of the identity object map. -/
+def idMapMor : MapMor I I (idMap : Map.{u, v, v} I I) :=
+  fun _ _ h ↦ h
+
+/-- The identity object map preserves identities. -/
+theorem idMapMor_preservesId :
+    PreservesId (idMap : Map.{u, v, v} I I) idMapMor :=
+  fun _ ↦ rfl
+
+/-- The identity object map preserves composition. -/
+theorem idMapMor_preservesComp :
+    PreservesComp (idMap : Map.{u, v, v} I I) idMapMor :=
+  fun _ _ _ _ _ ↦ rfl
+
+/-- Whiskering a transformation with the identity object map on the
+precomposition side is the identity operation. -/
+theorem NatTrans.whiskerRight_idMap {F' G' : Map.{u, v, w} I O}
+    {mF' : MapMor I O F'} {mG' : MapMor I O G'}
+    (θ : NatTrans I O F' G' mF' mG') :
+    NatTrans.whiskerRight (idMap : Map.{u, v, v} I I) idMapMor θ = θ :=
+  Subtype.ext rfl
+
+/-- Whiskering a transformation with the identity object map on the
+postcomposition side is the identity operation. -/
+theorem NatTrans.whiskerLeft_idMap {F G : Map.{u, v, w} I O}
+    {mF : MapMor I O F} {mG : MapMor I O G}
+    (η : NatTrans I O F G mF mG) :
+    NatTrans.whiskerLeft η (idMap : Map.{u, w, w} O O) idMapMor
+      idMapMor_preservesComp = η :=
+  Subtype.ext rfl
+
+/-- The interchange law between horizontal and vertical composition. -/
+theorem NatTrans.hcomp_vcomp {F G H : Map.{u, v, w} I O}
+    {mF : MapMor I O F} {mG : MapMor I O G} {mH : MapMor I O H}
+    {F' G' H' : Map.{u, w, x} O P} {mF' : MapMor O P F'}
+    {mG' : MapMor O P G'} {mH' : MapMor O P H'}
+    (η : NatTrans I O F G mF mG) (η' : NatTrans I O G H mG mH)
+    (θ : NatTrans O P F' G' mF' mG') (θ' : NatTrans O P G' H' mG' mH')
+    (hF' : PreservesComp F' mF') (hG' : PreservesComp G' mG') :
+    NatTrans.hcomp (NatTrans.vcomp η η') (NatTrans.vcomp θ θ') hF' =
+      NatTrans.vcomp (NatTrans.hcomp η θ hF')
+        (NatTrans.hcomp η' θ' hG') :=
+  Subtype.ext (funext (fun X ↦
+    (congrArg (fun t ↦ Hom.comp P t
+        (Hom.comp P (θ.1 (H X)) (θ'.1 (H X))))
+      (hF' (F X) (G X) (H X) (η.1 X) (η'.1 X))).trans
+    (congrArg (fun t ↦
+        Hom.comp P (Hom.comp P (mF' (F X) (G X) (η.1 X)) t)
+          (θ'.1 (H X)))
+      (θ.2 (G X) (H X) (η'.1 X)))))
+
+/-- Two natural transformations are inverse when their vertical
+composites in both orders are identities. -/
+def NatTrans.IsInverse {F G : Map.{u, v, w} I O} {mF : MapMor I O F}
+    {mG : MapMor I O G} (α : NatTrans I O F G mF mG)
+    (β : NatTrans I O G F mG mF) : Prop :=
+  NatTrans.vcomp α β = NatTrans.id F mF ∧
+    NatTrans.vcomp β α = NatTrans.id G mG
+
+/-- The componentwise inverses of a natural family of isomorphisms
+form a natural family. -/
+theorem isNatTrans_invHom {F G : Map.{u, v, w} I O}
+    {mF : MapMor I O F} {mG : MapMor I O G}
+    (iso : (X : FreeCoprodCompDisc.{u, v} I) → Iso O (F X) (G X))
+    (hnat : IsNatTrans I O F G mF mG (fun X ↦ Iso.hom O (iso X))) :
+    IsNatTrans I O G F mG mF (fun X ↦ Iso.invHom O (iso X)) :=
+  fun X Y h ↦
+    Subtype.ext (funext (fun b ↦
+      (congrArg (fun t ↦ (iso Y).1.symm ((mG X Y h).1 t))
+          ((iso X).1.apply_symm_apply b).symm).trans
+        ((congrArg (fun t ↦ (iso Y).1.symm t)
+            (congrFun (congrArg Subtype.val (hnat X Y h))
+              ((iso X).1.symm b)).symm).trans
+          ((iso Y).1.symm_apply_apply
+            ((mF X Y h).1 ((iso X).1.symm b))))))
+
+/-- Package a natural family of isomorphisms as a natural
+transformation. -/
+def NatTrans.ofIsoFamily {F G : Map.{u, v, w} I O}
+    {mF : MapMor I O F} {mG : MapMor I O G}
+    (iso : (X : FreeCoprodCompDisc.{u, v} I) → Iso O (F X) (G X))
+    (hnat : IsNatTrans I O F G mF mG (fun X ↦ Iso.hom O (iso X))) :
+    NatTrans I O F G mF mG :=
+  ⟨fun X ↦ Iso.hom O (iso X), hnat⟩
+
+/-- Package the inverses of a natural family of isomorphisms as a
+natural transformation. -/
+def NatTrans.invOfIsoFamily {F G : Map.{u, v, w} I O}
+    {mF : MapMor I O F} {mG : MapMor I O G}
+    (iso : (X : FreeCoprodCompDisc.{u, v} I) → Iso O (F X) (G X))
+    (hnat : IsNatTrans I O F G mF mG (fun X ↦ Iso.hom O (iso X))) :
+    NatTrans I O G F mG mF :=
+  ⟨fun X ↦ Iso.invHom O (iso X), isNatTrans_invHom iso hnat⟩
+
+/-- The two transformations packaged from a natural family of
+isomorphisms are inverse. -/
+theorem NatTrans.ofIsoFamily_isInverse {F G : Map.{u, v, w} I O}
+    {mF : MapMor I O F} {mG : MapMor I O G}
+    (iso : (X : FreeCoprodCompDisc.{u, v} I) → Iso O (F X) (G X))
+    (hnat : IsNatTrans I O F G mF mG (fun X ↦ Iso.hom O (iso X))) :
+    NatTrans.IsInverse (NatTrans.ofIsoFamily iso hnat)
+      (NatTrans.invOfIsoFamily iso hnat) :=
+  ⟨Subtype.ext (funext (fun X ↦ Iso.hom_invHom O (iso X))),
+    Subtype.ext (funext (fun X ↦ Iso.invHom_hom O (iso X)))⟩
+
+/-- Postcomposition with one half of an inverse pair is an
+equivalence on transformation spaces (target side). -/
+def NatTrans.equivOfInverseTarget {F G G' : Map.{u, v, w} I O}
+    {mF : MapMor I O F} {mG : MapMor I O G} {mG' : MapMor I O G'}
+    (α : NatTrans I O G G' mG mG') (β : NatTrans I O G' G mG' mG)
+    (h : NatTrans.IsInverse α β) :
+    NatTrans I O F G mF mG ≃ NatTrans I O F G' mF mG' :=
+  { toFun := fun η ↦ NatTrans.vcomp η α,
+    invFun := fun θ ↦ NatTrans.vcomp θ β,
+    left_inv := fun η ↦
+      (NatTrans.vcomp_assoc η α β).trans
+        ((congrArg (fun t ↦ NatTrans.vcomp η t) h.1).trans
+          (NatTrans.vcomp_id η)),
+    right_inv := fun θ ↦
+      (NatTrans.vcomp_assoc θ β α).trans
+        ((congrArg (fun t ↦ NatTrans.vcomp θ t) h.2).trans
+          (NatTrans.vcomp_id θ)) }
+
+/-- Precomposition with one half of an inverse pair is an
+equivalence on transformation spaces (source side). -/
+def NatTrans.equivOfInverseSource {F F' G : Map.{u, v, w} I O}
+    {mF : MapMor I O F} {mF' : MapMor I O F'} {mG : MapMor I O G}
+    (α : NatTrans I O F' F mF' mF) (β : NatTrans I O F F' mF mF')
+    (h : NatTrans.IsInverse α β) :
+    NatTrans I O F G mF mG ≃ NatTrans I O F' G mF' mG :=
+  { toFun := fun η ↦ NatTrans.vcomp α η,
+    invFun := fun θ ↦ NatTrans.vcomp β θ,
+    left_inv := fun η ↦
+      (NatTrans.vcomp_assoc β α η).symm.trans
+        ((congrArg (fun t ↦ NatTrans.vcomp t η) h.2).trans
+          (NatTrans.id_vcomp η)),
+    right_inv := fun θ ↦
+      (NatTrans.vcomp_assoc α β θ).symm.trans
+        ((congrArg (fun t ↦ NatTrans.vcomp t θ) h.1).trans
+          (NatTrans.id_vcomp θ)) }
+
+/-- Rewrite the source morphism map of a transformation space along an
+equality of morphism maps. -/
+def NatTrans.congrSource {F G : Map.{u, v, w} I O} {mF mF' : MapMor I O F}
+    (e : mF = mF') (mG : MapMor I O G) :
+    NatTrans I O F G mF mG ≃ NatTrans I O F G mF' mG :=
+  Eq.rec (motive := fun mF'' _ ↦
+      NatTrans I O F G mF mG ≃ NatTrans I O F G mF'' mG)
+    (Equiv.refl (NatTrans I O F G mF mG)) e
+
+/-- The generic coproduct decomposition of transformation spaces:
+transformations out of a pointwise indexed coproduct of object maps
+correspond to families of transformations out of the summands. -/
+def natCoprodEquiv (A : Type u) (Fa : A → Map.{u, v, w} I O)
+    (mFa : (a : A) → MapMor I O (Fa a)) (G : Map.{u, v, w} I O)
+    (mG : MapMor I O G) :
+    NatTrans I O (fun X ↦ coprod O A (fun a ↦ Fa a X)) G
+        (fun X Y h ↦ coprodMor O A A _root_.id (fun a ↦ Fa a X)
+          (fun a ↦ Fa a Y) (fun a ↦ mFa a X Y h)) mG ≃
+      ((a : A) → NatTrans I O (Fa a) G (mFa a) mG) :=
+  { toFun := fun η a ↦
+      ⟨fun X ↦ Hom.comp O (coprodInj O A (fun a' ↦ Fa a' X) a) (η.1 X),
+        fun X Y h ↦
+          congrArg (Hom.comp O (coprodInj O A (fun a' ↦ Fa a' X) a))
+            (η.2 X Y h)⟩,
+    invFun := fun θ ↦
+      ⟨fun X ↦ coprodDesc O A (fun a ↦ Fa a X) (G X) (fun a ↦ (θ a).1 X),
+        fun X Y h ↦
+          congrArg (coprodDesc O A (fun a ↦ Fa a X) (G Y))
+            (funext (fun a ↦ (θ a).2 X Y h))⟩,
+    left_inv := fun _ ↦ Subtype.ext (funext (fun _ ↦ Subtype.ext rfl)),
+    right_inv := fun _ ↦
+      funext (fun _ ↦ Subtype.ext (funext (fun _ ↦ Subtype.ext rfl))) }
+
+/-- The object map `X ↦ Hom(c, X) ⊗ F X`: the copower of the value of
+`F` by the hom-set out of `c`. -/
+def copowerHomMap (c : FreeCoprodCompDisc.{u, v} I)
+    (F : Map.{u, v, w} I O) : Map.{u, v, w} I O :=
+  fun X ↦ copower.{u, w, u} O (Hom.{u, v, u} I c X) (F X)
+
+/-- The morphism-map component of `copowerHomMap`. -/
+def copowerHomMapMor (c : FreeCoprodCompDisc.{u, v} I)
+    {F : Map.{u, v, w} I O} (mF : MapMor I O F) :
+    MapMor I O (copowerHomMap c F) :=
+  fun X Y h ↦
+    coprodMor O (Hom I c X) (Hom I c Y) (fun e ↦ Hom.comp I e h)
+      (fun _ ↦ F X) (fun _ ↦ F Y) (fun _ ↦ mF X Y h)
+
+/-- The object map `(c +)`: the binary coproduct with fixed left
+object `c`. -/
+def plusMap (c : FreeCoprodCompDisc.{u, v} I) : Map.{u, v, v} I I :=
+  fun X ↦ plus.{v, u, u} I c X
+
+/-- The morphism-map component of `plusMap`. -/
+def plusMapMor (c : FreeCoprodCompDisc.{u, v} I) :
+    MapMor I I (plusMap c) :=
+  fun _ _ h ↦ coprodPairMor I (Hom.id I c) h
+
+/-- The forward direction of the copower–plus correspondence: from a
+transformation out of the copowered map to one into the
+`plus`-precomposed map. -/
+def natCopowerPlusToFun (c : FreeCoprodCompDisc.{u, v} I)
+    {F G : Map.{u, v, w} I O} {mF : MapMor I O F} {mG : MapMor I O G}
+    (hFcomp : PreservesComp F mF)
+    (η : NatTrans I O (copowerHomMap c F) G (copowerHomMapMor c mF) mG) :
+    NatTrans I O F (mapComp (plusMap c) G) mF
+      (mapMorComp (plusMapMor c) mG) :=
+  ⟨fun X ↦
+    Hom.comp O (mF X (plus I c X) (coprodPairInr I c X))
+      (Hom.comp O
+        (coprodInj O (Hom I c (plus I c X)) (fun _ ↦ F (plus I c X))
+          (coprodPairInl I c X))
+        (η.1 (plus I c X))),
+    fun X Y h ↦
+      Subtype.ext (funext (fun a ↦
+        (congrArg
+            (fun t ↦ (η.1 (plus I c Y)).1 ⟨coprodPairInl I c Y, t⟩)
+            ((congrFun (congrArg Subtype.val
+                  (hFcomp X Y (plus I c Y) h (coprodPairInr I c Y)))
+                a).symm.trans
+              (congrFun (congrArg Subtype.val
+                  (hFcomp X (plus I c X) (plus I c Y)
+                    (coprodPairInr I c X)
+                    (coprodPairMor I (Hom.id I c) h)))
+                a))).trans
+          (congrFun (congrArg Subtype.val
+              (η.2 (plus I c X) (plus I c Y)
+                (coprodPairMor I (Hom.id I c) h)))
+            ⟨coprodPairInl I c X,
+              (mF X (plus I c X) (coprodPairInr I c X)).1 a⟩)))⟩
+
+/-- The backward direction of the copower–plus correspondence: from a
+transformation into the `plus`-precomposed map to one out of the
+copowered map. -/
+def natCopowerPlusInvFun (c : FreeCoprodCompDisc.{u, v} I)
+    {F G : Map.{u, v, w} I O} {mF : MapMor I O F} {mG : MapMor I O G}
+    (hGcomp : PreservesComp G mG)
+    (θ : NatTrans I O F (mapComp (plusMap c) G) mF
+      (mapMorComp (plusMapMor c) mG)) :
+    NatTrans I O (copowerHomMap c F) G (copowerHomMapMor c mF) mG :=
+  ⟨fun X ↦
+    coprodDesc O (Hom I c X) (fun _ ↦ F X) (G X)
+      (fun e ↦
+        Hom.comp O (θ.1 X)
+          (mG (plus I c X) X (coprodPairDesc I e (Hom.id I X)))),
+    fun X Y h ↦
+      Subtype.ext (funext (fun p ↦
+        (congrArg
+            (fun t ↦ (mG (plus I c Y) Y
+                (coprodPairDesc I (Hom.comp I p.1 h) (Hom.id I Y))).1 t)
+            (congrFun (congrArg Subtype.val (θ.2 X Y h)) p.2)).trans
+          ((congrFun (congrArg Subtype.val
+                (hGcomp (plus I c X) (plus I c Y) Y
+                  (coprodPairMor I (Hom.id I c) h)
+                  (coprodPairDesc I (Hom.comp I p.1 h) (Hom.id I Y))))
+              ((θ.1 X).1 p.2)).symm.trans
+            ((congrArg
+                (fun k ↦ (mG (plus I c X) Y k).1 ((θ.1 X).1 p.2))
+                (coprodPairMor_id_desc I h p.1)).trans
+              (congrFun (congrArg Subtype.val
+                  (hGcomp (plus I c X) X Y
+                    (coprodPairDesc I p.1 (Hom.id I X)) h))
+                ((θ.1 X).1 p.2))))))⟩
+
+/-- The backward direction inverts the forward direction of the
+copower–plus correspondence. -/
+theorem natCopowerPlus_invFun_toFun (c : FreeCoprodCompDisc.{u, v} I)
+    {F G : Map.{u, v, w} I O} {mF : MapMor I O F} {mG : MapMor I O G}
+    (hFid : PreservesId F mF) (hFcomp : PreservesComp F mF)
+    (hGcomp : PreservesComp G mG)
+    (η : NatTrans I O (copowerHomMap c F) G (copowerHomMapMor c mF) mG) :
+    natCopowerPlusInvFun c hGcomp (natCopowerPlusToFun c hFcomp η) = η :=
+  Subtype.ext (funext (fun X ↦ Subtype.ext (funext (fun p ↦
+    (congrFun (congrArg Subtype.val
+          (η.2 (plus I c X) X (coprodPairDesc I p.1 (Hom.id I X))))
+        ⟨coprodPairInl I c X,
+          (mF X (plus I c X) (coprodPairInr I c X)).1 p.2⟩).symm.trans
+      (congrArg (fun t ↦ (η.1 X).1 ⟨p.1, t⟩)
+        ((congrFun (congrArg Subtype.val
+              (hFcomp X (plus I c X) X (coprodPairInr I c X)
+                (coprodPairDesc I p.1 (Hom.id I X)))) p.2).symm.trans
+          (congrFun (congrArg Subtype.val (hFid X)) p.2)))))))
+
+/-- The forward direction inverts the backward direction of the
+copower–plus correspondence. -/
+theorem natCopowerPlus_toFun_invFun (c : FreeCoprodCompDisc.{u, v} I)
+    {F G : Map.{u, v, w} I O} {mF : MapMor I O F} {mG : MapMor I O G}
+    (hGid : PreservesId G mG) (hGcomp : PreservesComp G mG)
+    (hFcomp : PreservesComp F mF)
+    (θ : NatTrans I O F (mapComp (plusMap c) G) mF
+      (mapMorComp (plusMapMor c) mG)) :
+    natCopowerPlusToFun c hFcomp (natCopowerPlusInvFun c hGcomp θ) = θ :=
+  Subtype.ext (funext (fun X ↦ Subtype.ext (funext (fun a ↦
+    (congrArg
+        (fun t ↦ (mG (plus I c (plus I c X)) (plus I c X)
+            (coprodPairDesc I (coprodPairInl I c X)
+              (Hom.id I (plus I c X)))).1 t)
+        (congrFun (congrArg Subtype.val
+            (θ.2 X (plus I c X) (coprodPairInr I c X))) a)).trans
+      ((congrFun (congrArg Subtype.val
+            (hGcomp (plus I c X) (plus I c (plus I c X)) (plus I c X)
+              (coprodPairMor I (Hom.id I c) (coprodPairInr I c X))
+              (coprodPairDesc I (coprodPairInl I c X)
+                (Hom.id I (plus I c X)))))
+          ((θ.1 X).1 a)).symm.trans
+        ((congrArg
+            (fun k ↦ (mG (plus I c X) (plus I c X) k).1 ((θ.1 X).1 a))
+            (coprodPairMor_inr_desc_inl I (Z := c) (X := X))).trans
+          (congrFun (congrArg Subtype.val (hGid (plus I c X)))
+            ((θ.1 X).1 a))))))))
+
+/-- The copower–Yoneda adjunction: transformations out of the
+copowered map correspond to transformations into the
+`plus`-precomposed map. -/
+def natCopowerPlusEquiv (c : FreeCoprodCompDisc.{u, v} I)
+    {F G : Map.{u, v, w} I O} (mF : MapMor I O F) (mG : MapMor I O G)
+    (hFid : PreservesId F mF) (hFcomp : PreservesComp F mF)
+    (hGid : PreservesId G mG) (hGcomp : PreservesComp G mG) :
+    NatTrans I O (copowerHomMap c F) G (copowerHomMapMor c mF) mG ≃
+      NatTrans I O F (mapComp (plusMap c) G) mF
+        (mapMorComp (plusMapMor c) mG) :=
+  { toFun := natCopowerPlusToFun c hFcomp,
+    invFun := natCopowerPlusInvFun c hGcomp,
+    left_inv := natCopowerPlus_invFun_toFun c hFid hFcomp hGcomp,
+    right_inv := natCopowerPlus_toFun_invFun c hGid hGcomp hFcomp }
+
+end FreeCoprodCompDisc
+
+end CategoryTheory

--- a/geb-lean/vendor/geb-mathlib/Geb/Mathlib/Data/PFunctor/IndRec.lean
+++ b/geb-lean/vendor/geb-mathlib/Geb/Mathlib/Data/PFunctor/IndRec.lean
@@ -8,6 +8,8 @@ module
 public import Geb.Mathlib.Data.PFunctor.IndRec.Basic
 public import Geb.Mathlib.Data.PFunctor.IndRec.Hom
 public import Geb.Mathlib.Data.PFunctor.IndRec.Functor
+public import Geb.Mathlib.Data.PFunctor.IndRec.Naturality
+public import Geb.Mathlib.Data.PFunctor.IndRec.Category
 public import Geb.Mathlib.Data.PFunctor.IndRec.Universes
 public import Geb.Mathlib.Data.PFunctor.IndRec.Container
 

--- a/geb-lean/vendor/geb-mathlib/Geb/Mathlib/Data/PFunctor/IndRec/Basic.lean
+++ b/geb-lean/vendor/geb-mathlib/Geb/Mathlib/Data/PFunctor/IndRec/Basic.lean
@@ -129,9 +129,10 @@ affected declarations: Lemma 4 states an equality between the
 precomposed and direct interpretations, but `IR.interpPrecompIso`
 supplies only the pointwise isomorphism `IR.PrecompIsoMotive`, since
 equality is not the natural comparison between general objects here;
-Lemma 3 states a natural isomorphism, but `IR.interpDeltaIso` states
-it pointwise at a fixed object, since natural transformations between
-interpretations are not yet defined. The `delta` case of both
+the naturality upgrade is `IR.interpPrecompIso_natural`. Lemma 3
+states a natural isomorphism, but `IR.interpDeltaIso` states it
+pointwise at a fixed object; the naturality upgrade is
+`IR.natDeltaEquiv`. The `delta` case of both
 `IR.precomp` and `IR.interpPrecompIso` inserts `ULift`s to align the
 classifier sigma's index universe with the code's ambient arity
 universes, and `IR.interpDeltaIso` inserts `FreeCoprodCompDisc.lift`
@@ -1030,8 +1031,8 @@ interpreting the dependent product (`delta`) code at `k` is isomorphic
 to the indexed coproduct, over the direction assignments `i : B → I`,
 of the copower of the interpretation of the subcode `c i` by the
 morphisms `Hom I (lift ⟨B, i⟩) k`. The paper states a natural
-isomorphism; the recorded deviation states it pointwise at `k`, because
-natural transformations between interpretations are not yet defined.
+isomorphism; the recorded deviation states it pointwise at `k`; the
+naturality upgrade is `IR.natDeltaEquiv`.
 The isomorphism composes `interpDeltaIsoGroup` and `interpDeltaIsoHom`;
 its decodings agree definitionally. -/
 def interpDeltaIso (B : Type uB)

--- a/geb-lean/vendor/geb-mathlib/Geb/Mathlib/Data/PFunctor/IndRec/Category.lean
+++ b/geb-lean/vendor/geb-mathlib/Geb/Mathlib/Data/PFunctor/IndRec/Category.lean
@@ -1,0 +1,5264 @@
+/-
+Copyright (c) 2026 Terence Rokop. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Terence Rokop
+-/
+-- Modified from geb-mathlib by scripts/geb-mathlib-backport.patch.
+module
+
+public import Geb.Mathlib.Data.PFunctor.IndRec.Naturality
+
+/-!
+# The category of IR codes
+
+Corollary 2 of [HancockMcBrideGhaniMalatestaAltenkirch2013]: `IR`
+codes and the homsets of Definition 8 form a category. Composition
+is transferred through the full-and-faithful interpretation of
+Theorem 3 — the code morphism carried by the vertical composite of
+the interpreted transformations — and the category laws follow from
+the vertical laws together with the round-trip laws of the Theorem 3
+equivalence. The identity laws additionally consume the
+identity-image equation `IR.interpHom_id`, proved by induction on
+the domain code over the stack of `IR.preUnitStack`, against the
+semantic counterpart of that stack: an iterated coproduct tower with
+its iterated Lemma 4 isomorphism.
+
+## Main definitions
+
+* `IR.mplus`, `IR.mplusInj`, `IR.mplusMorMap` — the iterated
+  coproduct object of a stack of superscripts, its iterated
+  injection, and its action on morphisms.
+* `IR.mprecompIso` — the iterated Lemma 4 isomorphism between the
+  interpretation of an iterated precomposition and the
+  interpretation at `IR.mplus`.
+* `IR.preUnitComponent` — the semantic pre-unit component: the
+  interpretation image of `IR.mplusInj`, composed with the inverse
+  of `IR.mprecompIso`.
+* `IR.interpHomDeltaSummand` — the per-summand transport of the
+  `δ`-domain case of `IR.interpHomEquiv`.
+* `IR.interpHomIotaComposite`, `IR.interpHomIotaCast` — the
+  `ι`-branch equivalence of the Theorem 3 step and its transport
+  along a code equality.
+* `IR.deltaEmptyWeight`, `IR.deltaEmptyInj` — the canonical weight
+  out of the lift of an empty-witnessed family, and the semantic
+  inclusion of the empty-witnessed summand into the `δ`
+  interpretation.
+* `IR.deltaEmptySummandHom` — the transported summand isomorphism
+  of the Lemma 4 `δ`-square at that inclusion.
+* `IR.navWeight`, `IR.navReindex` — the tower navigation weight,
+  and the reindexing of a lifted direction family along the
+  inclusion of the all-unresolved classifier's subtype.
+* `IR.navInj` — the tower-conjugated navigation inclusion.
+* `IR.navBridgeMor` — the tower morphism induced by a weight at a
+  right-appended superscript.
+* `IR.comp` — composition of code morphisms: the code morphism
+  carried by the vertical composite of the interpreted
+  transformations.
+
+## Main statements
+
+* `IR.mprecompIso_natural` — naturality of the tower isomorphism in
+  the interpreted object.
+* `IR.interpHom_sigmaPush` — `IR.interpHom` sends `IR.sigmaPush` to
+  composition with the semantic `σ`-injection.
+* `IR.interpHom_deltaEmptyPush` — `IR.interpHom` sends
+  `IR.deltaEmptyPush` to composition with the semantic
+  empty-summand inclusion.
+* `IR.interpHom_msigmaPush`, `IR.interpHom_deltaNav` —
+  `IR.interpHom` sends the stack `σ`-push and the tower navigation
+  to composition with the corresponding semantic inclusion.
+* `IR.interpHom_preUnitStack` — `IR.interpHom` sends
+  `IR.preUnitStack` to the semantic pre-unit component, by
+  `IR.induction` on the domain code.
+* `IR.interpHom_comp`, `IR.interpHom_id` — `IR.interpHom` sends
+  `IR.comp` to the vertical composite and `IR.id` to the identity
+  transformation: the interpretation is functorial on morphisms.
+* `IR.id_comp`, `IR.comp_id`, `IR.comp_assoc` — the category laws
+  of Corollary 2 of [HancockMcBrideGhaniMalatestaAltenkirch2013].
+
+## Implementation notes
+
+The tower constructions recurse on the stack through `List.rec`, not
+on codes; the snoc lemmas are the corresponding `List.rec`
+inductions, with the motive quantified over the code where the
+recursion changes it (`IR.mprecompIso` and its snoc lemmas). Object
+equalities entering the tower (`IR.mplus_snoc`, `IR.mprecomp_snoc`)
+are carried as `FreeCoprodCompDisc.isoOfEq` transports and commuted
+across the Lemma 4 isomorphism by elimination of the generalized
+equality.
+
+The `@[nolint checkUnivs]` attribute on `IR.comp_isoOfEq_hom` and
+`IR.isoOfEq_symm_hom_comp` suppresses the `checkUnivs` warning on
+the separated arity universes `uA`/`uB`: in those two declarations'
+types the pair appears only together under `max`, so the linter
+reports it as unifiable; keeping the two distinct is the point of
+the separation. `IndRec.Basic` carries the same suppression, for
+the same reason.
+
+## References
+
+* [HancockMcBrideGhaniMalatestaAltenkirch2013]
+
+## Tags
+
+inductive-recursive, morphism, category
+-/
+
+@[expose] public section
+
+universe uA uB uI uO
+
+namespace IndRec
+
+open CategoryTheory
+
+variable (I : Type uI) (O : Type uO)
+
+namespace IR
+
+/-! ### The semantic tower -/
+
+/-- The iterated coproduct object: fold `plus` over the stack. -/
+def mplus (L : List (SupObj.{uB, uI} I)) (X : FreeCoprodCompDisc.{max uA uB, uI} I) :
+    FreeCoprodCompDisc.{max uA uB, uI} I :=
+  L.rec X (fun b _L ih ↦ FreeCoprodCompDisc.plus.{uI, uB, max uA uB} I b ih)
+
+/-- `mplus` at a right-appended superscript feeds the coproduct at the
+inner position. -/
+theorem mplus_snoc (L : List (SupObj.{uB, uI} I)) (b : SupObj.{uB, uI} I)
+    (X : FreeCoprodCompDisc.{max uA uB, uI} I) :
+    mplus.{uA, uB, uI} I (L ++ [b]) X =
+      mplus.{uA, uB, uI} I L (FreeCoprodCompDisc.plus.{uI, uB, max uA uB} I b X) :=
+  L.rec (motive := fun L ↦ mplus.{uA, uB, uI} I (L ++ [b]) X =
+      mplus.{uA, uB, uI} I L (FreeCoprodCompDisc.plus.{uI, uB, max uA uB} I b X))
+    rfl
+    (fun a _L ih ↦ congrArg (FreeCoprodCompDisc.plus.{uI, uB, max uA uB} I a) ih)
+
+/-- The iterated right injection into `mplus`. -/
+def mplusInj (L : List (SupObj.{uB, uI} I)) (X : FreeCoprodCompDisc.{max uA uB, uI} I) :
+    FreeCoprodCompDisc.Hom I X (mplus.{uA, uB, uI} I L X) :=
+  L.rec (motive := fun L ↦ FreeCoprodCompDisc.Hom I X (mplus.{uA, uB, uI} I L X))
+    (FreeCoprodCompDisc.Hom.id I X)
+    (fun b _L ih ↦ FreeCoprodCompDisc.Hom.comp I ih
+      (FreeCoprodCompDisc.coprodPairInr I b (mplus.{uA, uB, uI} I _L X)))
+
+/-- The iterated Lemma 4 isomorphism between the interpretation of an
+iterated precomposition and the interpretation at `mplus`. -/
+def mprecompIso (L : List (SupObj.{uB, uI} I)) :
+    ∀ (γ : IR.{max uA uB, uB, uI, uO} I O) (X : FreeCoprodCompDisc.{max uA uB, uI} I),
+      FreeCoprodCompDisc.Iso O (interpObj I O (mprecomp I O L γ) X)
+        (interpObj I O γ (mplus.{uA, uB, uI} I L X)) :=
+  L.rec (motive := fun L ↦ ∀ γ X,
+      FreeCoprodCompDisc.Iso O (interpObj I O (mprecomp I O L γ) X)
+        (interpObj I O γ (mplus.{uA, uB, uI} I L X)))
+    (fun γ X ↦ FreeCoprodCompDisc.Iso.refl O (interpObj I O γ X))
+    (fun b _L ih γ X ↦
+      FreeCoprodCompDisc.Iso.trans O (ih (precomp I O b.1 b.2 γ) X)
+        (interpPrecompIso I O γ b.1 b.2 (mplus.{uA, uB, uI} I _L X)))
+
+/-- The semantic pre-unit component: the interpretation image of the
+iterated injection, composed with the inverse of the iterated Lemma 4
+isomorphism. -/
+def preUnitComponent (γ : IR.{max uA uB, uB, uI, uO} I O)
+    (L : List (SupObj.{uB, uI} I)) (X : FreeCoprodCompDisc.{max uA uB, uI} I) :
+    FreeCoprodCompDisc.Hom O (interpObj I O γ X)
+      (interpObj I O (mprecomp I O L γ) X) :=
+  FreeCoprodCompDisc.Hom.comp O
+    (interpMor I O γ X (mplus.{uA, uB, uI} I L X) (mplusInj.{uA, uB, uI} I L X))
+    (FreeCoprodCompDisc.Iso.invHom O (mprecompIso.{uA, uB, uI, uO} I O L γ X))
+
+/-- At the empty stack the semantic pre-unit component is the
+identity. -/
+theorem preUnitComponent_nil (γ : IR.{max uA uB, uB, uI, uO} I O)
+    (X : FreeCoprodCompDisc.{max uA uB, uI} I) :
+    preUnitComponent I O γ [] X = FreeCoprodCompDisc.Hom.id O (interpObj I O γ X) :=
+  (congrArg (fun t ↦ FreeCoprodCompDisc.Hom.comp O t
+      (FreeCoprodCompDisc.Iso.invHom O (mprecompIso.{uA, uB, uI, uO} I O [] γ X)))
+    (interpMor_id I O γ X)).trans
+    (FreeCoprodCompDisc.Hom.id_comp O
+      (FreeCoprodCompDisc.Iso.invHom O (mprecompIso.{uA, uB, uI, uO} I O [] γ X)))
+
+/-- Transport of a composite with a fresh right injection along an
+equality of the inner object, by elimination of the generalized
+equality: the cast passes to the left factor. -/
+theorem comp_coprodPairInr_cast (a : SupObj.{uB, uI} I)
+    (X : FreeCoprodCompDisc.{max uA uB, uI} I) :
+    ∀ (W W' : FreeCoprodCompDisc.{max uA uB, uI} I) (e : W = W')
+      (u : FreeCoprodCompDisc.Hom I X W),
+      cast (congrArg (FreeCoprodCompDisc.Hom I X)
+          (congrArg (FreeCoprodCompDisc.plus.{uI, uB, max uA uB} I a) e))
+        (FreeCoprodCompDisc.Hom.comp I u
+          (FreeCoprodCompDisc.coprodPairInr.{uI, uB, max uA uB} I a W)) =
+      FreeCoprodCompDisc.Hom.comp I
+        (cast (congrArg (FreeCoprodCompDisc.Hom I X) e) u)
+        (FreeCoprodCompDisc.coprodPairInr.{uI, uB, max uA uB} I a W') :=
+  fun W _W' e ↦
+    Eq.rec (motive := fun W'' e' ↦ ∀ u : FreeCoprodCompDisc.Hom I X W,
+        cast (congrArg (FreeCoprodCompDisc.Hom I X)
+            (congrArg (FreeCoprodCompDisc.plus.{uI, uB, max uA uB} I a) e'))
+          (FreeCoprodCompDisc.Hom.comp I u
+            (FreeCoprodCompDisc.coprodPairInr.{uI, uB, max uA uB} I a W)) =
+        FreeCoprodCompDisc.Hom.comp I
+          (cast (congrArg (FreeCoprodCompDisc.Hom I X) e') u)
+          (FreeCoprodCompDisc.coprodPairInr.{uI, uB, max uA uB} I a W''))
+      (fun _ ↦ rfl) e
+
+/-- `IR.mplusInj` at a right-appended superscript, transported along
+`IR.mplus_snoc`: the fresh inner injection followed by the tower
+injection at the enlarged base. -/
+theorem mplusInj_snoc (L : List (SupObj.{uB, uI} I)) (b : SupObj.{uB, uI} I)
+    (X : FreeCoprodCompDisc.{max uA uB, uI} I) :
+    cast (congrArg (FreeCoprodCompDisc.Hom I X) (mplus_snoc.{uA, uB, uI} I L b X))
+        (mplusInj.{uA, uB, uI} I (L ++ [b]) X) =
+      FreeCoprodCompDisc.Hom.comp I
+        (FreeCoprodCompDisc.coprodPairInr.{uI, uB, max uA uB} I b X)
+        (mplusInj.{uA, uB, uI} I L (FreeCoprodCompDisc.plus.{uI, uB, max uA uB} I b X)) :=
+  L.rec (motive := fun L' ↦
+      cast (congrArg (FreeCoprodCompDisc.Hom I X) (mplus_snoc.{uA, uB, uI} I L' b X))
+          (mplusInj.{uA, uB, uI} I (L' ++ [b]) X) =
+        FreeCoprodCompDisc.Hom.comp I
+          (FreeCoprodCompDisc.coprodPairInr.{uI, uB, max uA uB} I b X)
+          (mplusInj.{uA, uB, uI} I L'
+            (FreeCoprodCompDisc.plus.{uI, uB, max uA uB} I b X)))
+    ((FreeCoprodCompDisc.Hom.id_comp I
+        (FreeCoprodCompDisc.coprodPairInr.{uI, uB, max uA uB} I b X)).trans
+      (FreeCoprodCompDisc.Hom.comp_id I
+        (FreeCoprodCompDisc.coprodPairInr.{uI, uB, max uA uB} I b X)).symm)
+    (fun a _L ih ↦
+      (comp_coprodPairInr_cast I a X (mplus.{uA, uB, uI} I (_L ++ [b]) X)
+          (mplus.{uA, uB, uI} I _L (FreeCoprodCompDisc.plus.{uI, uB, max uA uB} I b X))
+          (mplus_snoc.{uA, uB, uI} I _L b X)
+          (mplusInj.{uA, uB, uI} I (_L ++ [b]) X)).trans
+        ((congrArg
+            (fun t ↦ FreeCoprodCompDisc.Hom.comp I t
+              (FreeCoprodCompDisc.coprodPairInr.{uI, uB, max uA uB} I a
+                (mplus.{uA, uB, uI} I _L
+                  (FreeCoprodCompDisc.plus.{uI, uB, max uA uB} I b X))))
+            ih).trans
+          (FreeCoprodCompDisc.Hom.comp_assoc I
+            (FreeCoprodCompDisc.coprodPairInr.{uI, uB, max uA uB} I b X)
+            (mplusInj.{uA, uB, uI} I _L
+              (FreeCoprodCompDisc.plus.{uI, uB, max uA uB} I b X))
+            (FreeCoprodCompDisc.coprodPairInr.{uI, uB, max uA uB} I a
+              (mplus.{uA, uB, uI} I _L
+                (FreeCoprodCompDisc.plus.{uI, uB, max uA uB} I b X))))))
+
+/-- The Lemma 4 isomorphism commutes object-equality transports across
+its two sides (forward direction), by elimination of the generalized
+equality. -/
+theorem interpPrecompIso_hom_isoOfEq (γ : IR.{max uA uB, uB, uI, uO} I O)
+    (Q : Type uB) (q : Q → I) :
+    ∀ (W W' : FreeCoprodCompDisc.{max uA uB, uI} I) (e : W = W'),
+      FreeCoprodCompDisc.Hom.comp O
+          (FreeCoprodCompDisc.Iso.hom O (FreeCoprodCompDisc.isoOfEq O
+            (congrArg (interpObj I O (precomp I O Q q γ)) e)))
+          (FreeCoprodCompDisc.Iso.hom O (interpPrecompIso I O γ Q q W')) =
+        FreeCoprodCompDisc.Hom.comp O
+          (FreeCoprodCompDisc.Iso.hom O (interpPrecompIso I O γ Q q W))
+          (FreeCoprodCompDisc.Iso.hom O (FreeCoprodCompDisc.isoOfEq O
+            (congrArg
+              (fun w ↦ interpObj I O γ
+                (FreeCoprodCompDisc.plus.{uI, uB, max uA uB} I ⟨Q, q⟩ w))
+              e))) :=
+  fun W _W' e ↦
+    Eq.rec (motive := fun W'' e' ↦
+        FreeCoprodCompDisc.Hom.comp O
+            (FreeCoprodCompDisc.Iso.hom O (FreeCoprodCompDisc.isoOfEq O
+              (congrArg (interpObj I O (precomp I O Q q γ)) e')))
+            (FreeCoprodCompDisc.Iso.hom O (interpPrecompIso I O γ Q q W'')) =
+          FreeCoprodCompDisc.Hom.comp O
+            (FreeCoprodCompDisc.Iso.hom O (interpPrecompIso I O γ Q q W))
+            (FreeCoprodCompDisc.Iso.hom O (FreeCoprodCompDisc.isoOfEq O
+              (congrArg
+                (fun w ↦ interpObj I O γ
+                  (FreeCoprodCompDisc.plus.{uI, uB, max uA uB} I ⟨Q, q⟩ w))
+                e'))))
+      rfl e
+
+/-- The Lemma 4 isomorphism commutes object-equality transports across
+its two sides (inverse direction), by elimination of the generalized
+equality. -/
+theorem interpPrecompIso_invHom_isoOfEq (γ : IR.{max uA uB, uB, uI, uO} I O)
+    (Q : Type uB) (q : Q → I) :
+    ∀ (W W' : FreeCoprodCompDisc.{max uA uB, uI} I) (e : W = W'),
+      FreeCoprodCompDisc.Hom.comp O
+          (FreeCoprodCompDisc.Iso.hom O (FreeCoprodCompDisc.isoOfEq O
+            (congrArg
+              (fun w ↦ interpObj I O γ
+                (FreeCoprodCompDisc.plus.{uI, uB, max uA uB} I ⟨Q, q⟩ w))
+              e)))
+          (FreeCoprodCompDisc.Iso.invHom O (interpPrecompIso I O γ Q q W')) =
+        FreeCoprodCompDisc.Hom.comp O
+          (FreeCoprodCompDisc.Iso.invHom O (interpPrecompIso I O γ Q q W))
+          (FreeCoprodCompDisc.Iso.hom O (FreeCoprodCompDisc.isoOfEq O
+            (congrArg (interpObj I O (precomp I O Q q γ)) e))) :=
+  fun W _W' e ↦
+    Eq.rec (motive := fun W'' e' ↦
+        FreeCoprodCompDisc.Hom.comp O
+            (FreeCoprodCompDisc.Iso.hom O (FreeCoprodCompDisc.isoOfEq O
+              (congrArg
+                (fun w ↦ interpObj I O γ
+                  (FreeCoprodCompDisc.plus.{uI, uB, max uA uB} I ⟨Q, q⟩ w))
+                e')))
+            (FreeCoprodCompDisc.Iso.invHom O (interpPrecompIso I O γ Q q W'')) =
+          FreeCoprodCompDisc.Hom.comp O
+            (FreeCoprodCompDisc.Iso.invHom O (interpPrecompIso I O γ Q q W))
+            (FreeCoprodCompDisc.Iso.hom O (FreeCoprodCompDisc.isoOfEq O
+              (congrArg (interpObj I O (precomp I O Q q γ)) e'))))
+      rfl e
+
+/-- The forward component of `IR.mprecompIso` at a right-appended
+superscript: one Lemma 4 layer at the base of the tower, conjugated by
+the `IR.mprecomp_snoc` and `IR.mplus_snoc` transports. -/
+theorem mprecompIso_snoc_hom (L : List (SupObj.{uB, uI} I)) (b : SupObj.{uB, uI} I)
+    (γ : IR.{max uA uB, uB, uI, uO} I O) (X : FreeCoprodCompDisc.{max uA uB, uI} I) :
+    FreeCoprodCompDisc.Iso.hom O (mprecompIso.{uA, uB, uI, uO} I O (L ++ [b]) γ X) =
+      FreeCoprodCompDisc.Hom.comp O
+        (FreeCoprodCompDisc.Hom.comp O
+          (FreeCoprodCompDisc.Iso.hom O (FreeCoprodCompDisc.isoOfEq O
+            (congrArg (fun c ↦ interpObj I O c X) (mprecomp_snoc I O L b γ))))
+          (FreeCoprodCompDisc.Iso.hom O
+            (interpPrecompIso I O (mprecomp I O L γ) b.1 b.2 X)))
+        (FreeCoprodCompDisc.Hom.comp O
+          (FreeCoprodCompDisc.Iso.hom O (mprecompIso.{uA, uB, uI, uO} I O L γ
+            (FreeCoprodCompDisc.plus.{uI, uB, max uA uB} I b X)))
+          (FreeCoprodCompDisc.Iso.hom O (FreeCoprodCompDisc.isoOfEq O
+            (congrArg (interpObj I O γ) (mplus_snoc.{uA, uB, uI} I L b X).symm)))) :=
+  L.rec (motive := fun L' ↦ ∀ γ' : IR.{max uA uB, uB, uI, uO} I O,
+      FreeCoprodCompDisc.Iso.hom O
+          (mprecompIso.{uA, uB, uI, uO} I O (L' ++ [b]) γ' X) =
+        FreeCoprodCompDisc.Hom.comp O
+          (FreeCoprodCompDisc.Hom.comp O
+            (FreeCoprodCompDisc.Iso.hom O (FreeCoprodCompDisc.isoOfEq O
+              (congrArg (fun c ↦ interpObj I O c X) (mprecomp_snoc I O L' b γ'))))
+            (FreeCoprodCompDisc.Iso.hom O
+              (interpPrecompIso I O (mprecomp I O L' γ') b.1 b.2 X)))
+          (FreeCoprodCompDisc.Hom.comp O
+            (FreeCoprodCompDisc.Iso.hom O (mprecompIso.{uA, uB, uI, uO} I O L' γ'
+              (FreeCoprodCompDisc.plus.{uI, uB, max uA uB} I b X)))
+            (FreeCoprodCompDisc.Iso.hom O (FreeCoprodCompDisc.isoOfEq O
+              (congrArg (interpObj I O γ')
+                (mplus_snoc.{uA, uB, uI} I L' b X).symm)))))
+    (fun _ ↦ rfl)
+    (fun a _L ih γ' ↦
+      (congrArg
+          (fun t ↦ FreeCoprodCompDisc.Hom.comp O t
+            (FreeCoprodCompDisc.Iso.hom O
+              (interpPrecompIso I O γ' a.1 a.2
+                (mplus.{uA, uB, uI} I (_L ++ [b]) X))))
+          (ih (precomp I O a.1 a.2 γ'))).trans
+        ((FreeCoprodCompDisc.Hom.comp_assoc O
+            (FreeCoprodCompDisc.Hom.comp O
+              (FreeCoprodCompDisc.Iso.hom O (FreeCoprodCompDisc.isoOfEq O
+                (congrArg (fun c ↦ interpObj I O c X)
+                  (mprecomp_snoc I O _L b (precomp I O a.1 a.2 γ')))))
+              (FreeCoprodCompDisc.Iso.hom O
+                (interpPrecompIso I O (mprecomp I O _L (precomp I O a.1 a.2 γ'))
+                  b.1 b.2 X)))
+            (FreeCoprodCompDisc.Hom.comp O
+              (FreeCoprodCompDisc.Iso.hom O
+                (mprecompIso.{uA, uB, uI, uO} I O _L (precomp I O a.1 a.2 γ')
+                  (FreeCoprodCompDisc.plus.{uI, uB, max uA uB} I b X)))
+              (FreeCoprodCompDisc.Iso.hom O (FreeCoprodCompDisc.isoOfEq O
+                (congrArg (interpObj I O (precomp I O a.1 a.2 γ'))
+                  (mplus_snoc.{uA, uB, uI} I _L b X).symm))))
+            (FreeCoprodCompDisc.Iso.hom O
+              (interpPrecompIso I O γ' a.1 a.2
+                (mplus.{uA, uB, uI} I (_L ++ [b]) X)))).trans
+          (congrArg
+            (FreeCoprodCompDisc.Hom.comp O
+              (FreeCoprodCompDisc.Hom.comp O
+                (FreeCoprodCompDisc.Iso.hom O (FreeCoprodCompDisc.isoOfEq O
+                  (congrArg (fun c ↦ interpObj I O c X)
+                    (mprecomp_snoc I O _L b (precomp I O a.1 a.2 γ')))))
+                (FreeCoprodCompDisc.Iso.hom O
+                  (interpPrecompIso I O
+                    (mprecomp I O _L (precomp I O a.1 a.2 γ')) b.1 b.2 X))))
+            ((FreeCoprodCompDisc.Hom.comp_assoc O
+                (FreeCoprodCompDisc.Iso.hom O
+                  (mprecompIso.{uA, uB, uI, uO} I O _L (precomp I O a.1 a.2 γ')
+                    (FreeCoprodCompDisc.plus.{uI, uB, max uA uB} I b X)))
+                (FreeCoprodCompDisc.Iso.hom O (FreeCoprodCompDisc.isoOfEq O
+                  (congrArg (interpObj I O (precomp I O a.1 a.2 γ'))
+                    (mplus_snoc.{uA, uB, uI} I _L b X).symm)))
+                (FreeCoprodCompDisc.Iso.hom O
+                  (interpPrecompIso I O γ' a.1 a.2
+                    (mplus.{uA, uB, uI} I (_L ++ [b]) X)))).trans
+              ((congrArg
+                  (FreeCoprodCompDisc.Hom.comp O
+                    (FreeCoprodCompDisc.Iso.hom O
+                      (mprecompIso.{uA, uB, uI, uO} I O _L
+                        (precomp I O a.1 a.2 γ')
+                        (FreeCoprodCompDisc.plus.{uI, uB, max uA uB} I b X))))
+                  (interpPrecompIso_hom_isoOfEq I O γ' a.1 a.2
+                    (mplus.{uA, uB, uI} I _L
+                      (FreeCoprodCompDisc.plus.{uI, uB, max uA uB} I b X))
+                    (mplus.{uA, uB, uI} I (_L ++ [b]) X)
+                    (mplus_snoc.{uA, uB, uI} I _L b X).symm)).trans
+                (FreeCoprodCompDisc.Hom.comp_assoc O
+                  (FreeCoprodCompDisc.Iso.hom O
+                    (mprecompIso.{uA, uB, uI, uO} I O _L (precomp I O a.1 a.2 γ')
+                      (FreeCoprodCompDisc.plus.{uI, uB, max uA uB} I b X)))
+                  (FreeCoprodCompDisc.Iso.hom O
+                    (interpPrecompIso I O γ' a.1 a.2
+                      (mplus.{uA, uB, uI} I _L
+                        (FreeCoprodCompDisc.plus.{uI, uB, max uA uB} I b X))))
+                  (FreeCoprodCompDisc.Iso.hom O (FreeCoprodCompDisc.isoOfEq O
+                    (congrArg
+                      (fun w ↦ interpObj I O γ'
+                        (FreeCoprodCompDisc.plus.{uI, uB, max uA uB} I a w))
+                      (mplus_snoc.{uA, uB, uI} I _L b X).symm)))).symm)))))
+    γ
+
+/-- The inverse component of `IR.mprecompIso` at a right-appended
+superscript: the inverse of one Lemma 4 layer at the base of the
+tower, conjugated by the `IR.mplus_snoc` and `IR.mprecomp_snoc`
+transports. -/
+theorem mprecompIso_snoc_invHom (L : List (SupObj.{uB, uI} I)) (b : SupObj.{uB, uI} I)
+    (γ : IR.{max uA uB, uB, uI, uO} I O) (X : FreeCoprodCompDisc.{max uA uB, uI} I) :
+    FreeCoprodCompDisc.Iso.invHom O
+        (mprecompIso.{uA, uB, uI, uO} I O (L ++ [b]) γ X) =
+      FreeCoprodCompDisc.Hom.comp O
+        (FreeCoprodCompDisc.Hom.comp O
+          (FreeCoprodCompDisc.Iso.hom O (FreeCoprodCompDisc.isoOfEq O
+            (congrArg (interpObj I O γ) (mplus_snoc.{uA, uB, uI} I L b X))))
+          (FreeCoprodCompDisc.Iso.invHom O (mprecompIso.{uA, uB, uI, uO} I O L γ
+            (FreeCoprodCompDisc.plus.{uI, uB, max uA uB} I b X))))
+        (FreeCoprodCompDisc.Hom.comp O
+          (FreeCoprodCompDisc.Iso.invHom O
+            (interpPrecompIso I O (mprecomp I O L γ) b.1 b.2 X))
+          (FreeCoprodCompDisc.Iso.hom O (FreeCoprodCompDisc.isoOfEq O
+            (congrArg (fun c ↦ interpObj I O c X)
+              (mprecomp_snoc I O L b γ).symm)))) :=
+  L.rec (motive := fun L' ↦ ∀ γ' : IR.{max uA uB, uB, uI, uO} I O,
+      FreeCoprodCompDisc.Iso.invHom O
+          (mprecompIso.{uA, uB, uI, uO} I O (L' ++ [b]) γ' X) =
+        FreeCoprodCompDisc.Hom.comp O
+          (FreeCoprodCompDisc.Hom.comp O
+            (FreeCoprodCompDisc.Iso.hom O (FreeCoprodCompDisc.isoOfEq O
+              (congrArg (interpObj I O γ') (mplus_snoc.{uA, uB, uI} I L' b X))))
+            (FreeCoprodCompDisc.Iso.invHom O
+              (mprecompIso.{uA, uB, uI, uO} I O L' γ'
+                (FreeCoprodCompDisc.plus.{uI, uB, max uA uB} I b X))))
+          (FreeCoprodCompDisc.Hom.comp O
+            (FreeCoprodCompDisc.Iso.invHom O
+              (interpPrecompIso I O (mprecomp I O L' γ') b.1 b.2 X))
+            (FreeCoprodCompDisc.Iso.hom O (FreeCoprodCompDisc.isoOfEq O
+              (congrArg (fun c ↦ interpObj I O c X)
+                (mprecomp_snoc I O L' b γ').symm)))))
+    (fun _ ↦ rfl)
+    (fun a _L ih γ' ↦
+      (congrArg
+          (FreeCoprodCompDisc.Hom.comp O
+            (FreeCoprodCompDisc.Iso.invHom O
+              (interpPrecompIso I O γ' a.1 a.2
+                (mplus.{uA, uB, uI} I (_L ++ [b]) X))))
+          (ih (precomp I O a.1 a.2 γ'))).trans
+        ((congrArg
+            (FreeCoprodCompDisc.Hom.comp O
+              (FreeCoprodCompDisc.Iso.invHom O
+                (interpPrecompIso I O γ' a.1 a.2
+                  (mplus.{uA, uB, uI} I (_L ++ [b]) X))))
+            (FreeCoprodCompDisc.Hom.comp_assoc O
+              (FreeCoprodCompDisc.Iso.hom O (FreeCoprodCompDisc.isoOfEq O
+                (congrArg (interpObj I O (precomp I O a.1 a.2 γ'))
+                  (mplus_snoc.{uA, uB, uI} I _L b X))))
+              (FreeCoprodCompDisc.Iso.invHom O
+                (mprecompIso.{uA, uB, uI, uO} I O _L (precomp I O a.1 a.2 γ')
+                  (FreeCoprodCompDisc.plus.{uI, uB, max uA uB} I b X)))
+              (FreeCoprodCompDisc.Hom.comp O
+                (FreeCoprodCompDisc.Iso.invHom O
+                  (interpPrecompIso I O
+                    (mprecomp I O _L (precomp I O a.1 a.2 γ')) b.1 b.2 X))
+                (FreeCoprodCompDisc.Iso.hom O (FreeCoprodCompDisc.isoOfEq O
+                  (congrArg (fun c ↦ interpObj I O c X)
+                    (mprecomp_snoc I O _L b (precomp I O a.1 a.2 γ')).symm)))))).trans
+          ((FreeCoprodCompDisc.Hom.comp_assoc O
+              (FreeCoprodCompDisc.Iso.invHom O
+                (interpPrecompIso I O γ' a.1 a.2
+                  (mplus.{uA, uB, uI} I (_L ++ [b]) X)))
+              (FreeCoprodCompDisc.Iso.hom O (FreeCoprodCompDisc.isoOfEq O
+                (congrArg (interpObj I O (precomp I O a.1 a.2 γ'))
+                  (mplus_snoc.{uA, uB, uI} I _L b X))))
+              (FreeCoprodCompDisc.Hom.comp O
+                (FreeCoprodCompDisc.Iso.invHom O
+                  (mprecompIso.{uA, uB, uI, uO} I O _L (precomp I O a.1 a.2 γ')
+                    (FreeCoprodCompDisc.plus.{uI, uB, max uA uB} I b X)))
+                (FreeCoprodCompDisc.Hom.comp O
+                  (FreeCoprodCompDisc.Iso.invHom O
+                    (interpPrecompIso I O
+                      (mprecomp I O _L (precomp I O a.1 a.2 γ')) b.1 b.2 X))
+                  (FreeCoprodCompDisc.Iso.hom O (FreeCoprodCompDisc.isoOfEq O
+                    (congrArg (fun c ↦ interpObj I O c X)
+                      (mprecomp_snoc I O _L b
+                        (precomp I O a.1 a.2 γ')).symm)))))).symm.trans
+            ((congrArg
+                (fun t ↦ FreeCoprodCompDisc.Hom.comp O t
+                  (FreeCoprodCompDisc.Hom.comp O
+                    (FreeCoprodCompDisc.Iso.invHom O
+                      (mprecompIso.{uA, uB, uI, uO} I O _L
+                        (precomp I O a.1 a.2 γ')
+                        (FreeCoprodCompDisc.plus.{uI, uB, max uA uB} I b X)))
+                    (FreeCoprodCompDisc.Hom.comp O
+                      (FreeCoprodCompDisc.Iso.invHom O
+                        (interpPrecompIso I O
+                          (mprecomp I O _L (precomp I O a.1 a.2 γ'))
+                          b.1 b.2 X))
+                      (FreeCoprodCompDisc.Iso.hom O
+                        (FreeCoprodCompDisc.isoOfEq O
+                          (congrArg (fun c ↦ interpObj I O c X)
+                            (mprecomp_snoc I O _L b
+                              (precomp I O a.1 a.2 γ')).symm))))))
+                (interpPrecompIso_invHom_isoOfEq I O γ' a.1 a.2
+                  (mplus.{uA, uB, uI} I (_L ++ [b]) X)
+                  (mplus.{uA, uB, uI} I _L
+                    (FreeCoprodCompDisc.plus.{uI, uB, max uA uB} I b X))
+                  (mplus_snoc.{uA, uB, uI} I _L b X)).symm).trans
+              ((FreeCoprodCompDisc.Hom.comp_assoc O
+                  (FreeCoprodCompDisc.Hom.comp O
+                    (FreeCoprodCompDisc.Iso.hom O (FreeCoprodCompDisc.isoOfEq O
+                      (congrArg
+                        (fun w ↦ interpObj I O γ'
+                          (FreeCoprodCompDisc.plus.{uI, uB, max uA uB} I a w))
+                        (mplus_snoc.{uA, uB, uI} I _L b X))))
+                    (FreeCoprodCompDisc.Iso.invHom O
+                      (interpPrecompIso I O γ' a.1 a.2
+                        (mplus.{uA, uB, uI} I _L
+                          (FreeCoprodCompDisc.plus.{uI, uB, max uA uB} I b X)))))
+                  (FreeCoprodCompDisc.Iso.invHom O
+                    (mprecompIso.{uA, uB, uI, uO} I O _L
+                      (precomp I O a.1 a.2 γ')
+                      (FreeCoprodCompDisc.plus.{uI, uB, max uA uB} I b X)))
+                  (FreeCoprodCompDisc.Hom.comp O
+                    (FreeCoprodCompDisc.Iso.invHom O
+                      (interpPrecompIso I O
+                        (mprecomp I O _L (precomp I O a.1 a.2 γ'))
+                        b.1 b.2 X))
+                    (FreeCoprodCompDisc.Iso.hom O (FreeCoprodCompDisc.isoOfEq O
+                      (congrArg (fun c ↦ interpObj I O c X)
+                        (mprecomp_snoc I O _L b
+                          (precomp I O a.1 a.2 γ')).symm))))).trans
+                ((congrArg
+                    (FreeCoprodCompDisc.Hom.comp O
+                      (FreeCoprodCompDisc.Iso.hom O
+                        (FreeCoprodCompDisc.isoOfEq O
+                          (congrArg
+                            (fun w ↦ interpObj I O γ'
+                              (FreeCoprodCompDisc.plus.{uI, uB, max uA uB}
+                                I a w))
+                            (mplus_snoc.{uA, uB, uI} I _L b X)))))
+                    (FreeCoprodCompDisc.Hom.comp_assoc O
+                      (FreeCoprodCompDisc.Iso.invHom O
+                        (interpPrecompIso I O γ' a.1 a.2
+                          (mplus.{uA, uB, uI} I _L
+                            (FreeCoprodCompDisc.plus.{uI, uB, max uA uB}
+                              I b X))))
+                      (FreeCoprodCompDisc.Iso.invHom O
+                        (mprecompIso.{uA, uB, uI, uO} I O _L
+                          (precomp I O a.1 a.2 γ')
+                          (FreeCoprodCompDisc.plus.{uI, uB, max uA uB} I b X)))
+                      (FreeCoprodCompDisc.Hom.comp O
+                        (FreeCoprodCompDisc.Iso.invHom O
+                          (interpPrecompIso I O
+                            (mprecomp I O _L (precomp I O a.1 a.2 γ'))
+                            b.1 b.2 X))
+                        (FreeCoprodCompDisc.Iso.hom O
+                          (FreeCoprodCompDisc.isoOfEq O
+                            (congrArg (fun c ↦ interpObj I O c X)
+                              (mprecomp_snoc I O _L b
+                                (precomp I O a.1 a.2 γ')).symm)))))).symm.trans
+                  (FreeCoprodCompDisc.Hom.comp_assoc O
+                    (FreeCoprodCompDisc.Hom.comp O
+                      (FreeCoprodCompDisc.Iso.hom O
+                        (FreeCoprodCompDisc.isoOfEq O
+                          (congrArg
+                            (fun w ↦ interpObj I O γ'
+                              (FreeCoprodCompDisc.plus.{uI, uB, max uA uB}
+                                I a w))
+                            (mplus_snoc.{uA, uB, uI} I _L b X))))
+                      (FreeCoprodCompDisc.Hom.comp O
+                        (FreeCoprodCompDisc.Iso.invHom O
+                          (interpPrecompIso I O γ' a.1 a.2
+                            (mplus.{uA, uB, uI} I _L
+                              (FreeCoprodCompDisc.plus.{uI, uB, max uA uB}
+                                I b X))))
+                        (FreeCoprodCompDisc.Iso.invHom O
+                          (mprecompIso.{uA, uB, uI, uO} I O _L
+                            (precomp I O a.1 a.2 γ')
+                            (FreeCoprodCompDisc.plus.{uI, uB, max uA uB}
+                              I b X)))))
+                    (FreeCoprodCompDisc.Iso.invHom O
+                      (interpPrecompIso I O
+                        (mprecomp I O _L (precomp I O a.1 a.2 γ'))
+                        b.1 b.2 X))
+                    (FreeCoprodCompDisc.Iso.hom O
+                      (FreeCoprodCompDisc.isoOfEq O
+                        (congrArg (fun c ↦ interpObj I O c X)
+                          (mprecomp_snoc I O _L b
+                            (precomp I O a.1 a.2 γ')).symm))))))))))
+    γ
+
+/-- The tower action on morphisms: the identity on every stacked
+superscript, the given morphism at the base. -/
+def mplusMorMap (L : List (SupObj.{uB, uI} I))
+    (X Y : FreeCoprodCompDisc.{max uA uB, uI} I) (h : FreeCoprodCompDisc.Hom I X Y) :
+    FreeCoprodCompDisc.Hom I (mplus.{uA, uB, uI} I L X) (mplus.{uA, uB, uI} I L Y) :=
+  L.rec (motive := fun L' ↦
+      FreeCoprodCompDisc.Hom I (mplus.{uA, uB, uI} I L' X) (mplus.{uA, uB, uI} I L' Y))
+    h
+    (fun b _L ih ↦
+      FreeCoprodCompDisc.coprodPairMor I (FreeCoprodCompDisc.Hom.id I b) ih)
+
+/-- The iterated Lemma 4 naturality: `IR.mprecompIso` is natural in the
+interpreted object, between the tower interpretation's morphism map and
+the direct interpretation's at the `IR.mplusMorMap` image. -/
+theorem mprecompIso_natural (L : List (SupObj.{uB, uI} I))
+    (γ : IR.{max uA uB, uB, uI, uO} I O)
+    (X Y : FreeCoprodCompDisc.{max uA uB, uI} I) (h : FreeCoprodCompDisc.Hom I X Y) :
+    FreeCoprodCompDisc.Hom.comp O
+        (interpMor I O (mprecomp I O L γ) X Y h)
+        (FreeCoprodCompDisc.Iso.hom O (mprecompIso.{uA, uB, uI, uO} I O L γ Y)) =
+      FreeCoprodCompDisc.Hom.comp O
+        (FreeCoprodCompDisc.Iso.hom O (mprecompIso.{uA, uB, uI, uO} I O L γ X))
+        (interpMor I O γ (mplus.{uA, uB, uI} I L X) (mplus.{uA, uB, uI} I L Y)
+          (mplusMorMap.{uA, uB, uI} I L X Y h)) :=
+  L.rec (motive := fun L' ↦ ∀ γ' : IR.{max uA uB, uB, uI, uO} I O,
+      FreeCoprodCompDisc.Hom.comp O
+          (interpMor I O (mprecomp I O L' γ') X Y h)
+          (FreeCoprodCompDisc.Iso.hom O
+            (mprecompIso.{uA, uB, uI, uO} I O L' γ' Y)) =
+        FreeCoprodCompDisc.Hom.comp O
+          (FreeCoprodCompDisc.Iso.hom O
+            (mprecompIso.{uA, uB, uI, uO} I O L' γ' X))
+          (interpMor I O γ' (mplus.{uA, uB, uI} I L' X)
+            (mplus.{uA, uB, uI} I L' Y) (mplusMorMap.{uA, uB, uI} I L' X Y h)))
+    (fun γ' ↦
+      (FreeCoprodCompDisc.Hom.comp_id O (interpMor I O γ' X Y h)).trans
+        (FreeCoprodCompDisc.Hom.id_comp O (interpMor I O γ' X Y h)).symm)
+    (fun a _L ih γ' ↦
+      (FreeCoprodCompDisc.Hom.comp_assoc O
+          (interpMor I O (mprecomp I O _L (precomp I O a.1 a.2 γ')) X Y h)
+          (FreeCoprodCompDisc.Iso.hom O
+            (mprecompIso.{uA, uB, uI, uO} I O _L (precomp I O a.1 a.2 γ') Y))
+          (FreeCoprodCompDisc.Iso.hom O
+            (interpPrecompIso I O γ' a.1 a.2
+              (mplus.{uA, uB, uI} I _L Y)))).symm.trans
+        ((congrArg
+            (fun t ↦ FreeCoprodCompDisc.Hom.comp O t
+              (FreeCoprodCompDisc.Iso.hom O
+                (interpPrecompIso I O γ' a.1 a.2 (mplus.{uA, uB, uI} I _L Y))))
+            (ih (precomp I O a.1 a.2 γ'))).trans
+          ((FreeCoprodCompDisc.Hom.comp_assoc O
+              (FreeCoprodCompDisc.Iso.hom O
+                (mprecompIso.{uA, uB, uI, uO} I O _L (precomp I O a.1 a.2 γ') X))
+              (interpMor I O (precomp I O a.1 a.2 γ') (mplus.{uA, uB, uI} I _L X)
+                (mplus.{uA, uB, uI} I _L Y) (mplusMorMap.{uA, uB, uI} I _L X Y h))
+              (FreeCoprodCompDisc.Iso.hom O
+                (interpPrecompIso I O γ' a.1 a.2
+                  (mplus.{uA, uB, uI} I _L Y)))).trans
+            ((congrArg
+                (FreeCoprodCompDisc.Hom.comp O
+                  (FreeCoprodCompDisc.Iso.hom O
+                    (mprecompIso.{uA, uB, uI, uO} I O _L
+                      (precomp I O a.1 a.2 γ') X)))
+                (interpPrecompIso_natural I O γ' a.1 a.2
+                  (mplus.{uA, uB, uI} I _L X) (mplus.{uA, uB, uI} I _L Y)
+                  (mplusMorMap.{uA, uB, uI} I _L X Y h))).trans
+              (FreeCoprodCompDisc.Hom.comp_assoc O
+                (FreeCoprodCompDisc.Iso.hom O
+                  (mprecompIso.{uA, uB, uI, uO} I O _L
+                    (precomp I O a.1 a.2 γ') X))
+                (FreeCoprodCompDisc.Iso.hom O
+                  (interpPrecompIso I O γ' a.1 a.2 (mplus.{uA, uB, uI} I _L X)))
+                (interpMor I O γ'
+                  (FreeCoprodCompDisc.plus.{uI, uB, max uA uB} I a
+                    (mplus.{uA, uB, uI} I _L X))
+                  (FreeCoprodCompDisc.plus.{uI, uB, max uA uB} I a
+                    (mplus.{uA, uB, uI} I _L Y))
+                  (FreeCoprodCompDisc.coprodPairMor I
+                    (FreeCoprodCompDisc.Hom.id I a)
+                    (mplusMorMap.{uA, uB, uI} I _L X Y h)))).symm))))
+    γ
+
+/-! ### The `interpHom` characterizing equations -/
+
+/-- Components pass through `NatTrans.congrSource` unchanged. -/
+theorem congrSource_symm_fst {F G : FreeCoprodCompDisc.Map.{uA, uI, uO} I O}
+    {mF mF' : FreeCoprodCompDisc.MapMor I O F} (e : mF = mF')
+    (mG : FreeCoprodCompDisc.MapMor I O G)
+    (η : FreeCoprodCompDisc.NatTrans I O F G mF' mG) :
+    ((FreeCoprodCompDisc.NatTrans.congrSource e mG).symm η).1 = η.1 :=
+  Eq.rec (motive := fun mF'' e' ↦
+      ∀ η' : FreeCoprodCompDisc.NatTrans I O F G mF'' mG,
+        ((FreeCoprodCompDisc.NatTrans.congrSource e' mG).symm η').1 = η'.1)
+    (fun _ ↦ rfl) e η
+
+/-- The characterizing equation of `IR.interpHomEquiv` at `IR.mk`. -/
+theorem interpHomEquiv_mk (s : Shape.{max uA uB, uB, uO} O)
+    (d : Direction I O s → IR.{max uA uB, uB, uI, uO} I O)
+    (γ' : IR.{max uA uB, uB, uI, uO} I O) :
+    interpHomEquiv I O (mk I O s d) γ' =
+      interpHomEquivStep I O s d (fun x ↦ interpHomEquiv I O (d x)) γ' :=
+  congrFun (rec_mk I O (interpHomEquivStep I O) s d) γ'
+
+/-- The component of `IR.interpHom` at an `ι`-domain: the singleton
+morphism carried by the inner hom, composed with the codomain's image
+of the unique morphism out of the initial object. -/
+theorem interpHom_iota (o : O) (γ' : IR.{max uA uB, uB, uI, uO} I O)
+    (f : InnerHom.{uA, uB, uI, uO} I O o γ')
+    (X : FreeCoprodCompDisc.{max uA uB, uI} I) :
+    (interpHom I O (iota.{max uA uB, uB, uI, uO} I O o) γ' f).1 X =
+      FreeCoprodCompDisc.Hom.comp O
+        ((FreeCoprodCompDisc.homSingletonEquiv O o
+            (interpObj I O γ' (FreeCoprodCompDisc.emptyObj I))).symm
+          (innerHomEquiv I O o γ' f))
+        (interpMor I O γ' (FreeCoprodCompDisc.emptyObj I) X
+          (FreeCoprodCompDisc.emptyDesc I X)) :=
+  congrArg (fun e ↦ (e f).1 X)
+    (interpHomEquiv_mk I O (Sum.inl o) PEmpty.elim γ')
+
+/-- The component of `IR.interpHom` at a `σ`-domain: the cotuple of the
+subcode components. -/
+theorem interpHom_sigma (A : Type (max uA uB))
+    (K : A → IR.{max uA uB, uB, uI, uO} I O)
+    (γ' : IR.{max uA uB, uB, uI, uO} I O)
+    (f : Hom.{uA, uB, uI, uO} I O (sigma I O A K) γ')
+    (X : FreeCoprodCompDisc.{max uA uB, uI} I) :
+    (interpHom I O (sigma I O A K) γ' f).1 X =
+      FreeCoprodCompDisc.coprodDesc O A (fun a ↦ interpObj I O (K a) X)
+        (interpObj I O γ' X)
+        (fun a ↦ (interpHom I O (K a) γ' (f a)).1 X) :=
+  (congrArg (fun e ↦ (e f).1 X)
+      (interpHomEquiv_mk I O (Sum.inr (Sum.inl A)) (K ∘ ULift.down) γ')).trans
+    (congrFun
+      (congrSource_symm_fst.{max uA uB, uI, uO} I O
+        (interpMor_sigma.{max uA uB, uB, uI, uO} I O A K) _
+        (FreeCoprodCompDisc.natCoprodEquiv.{max uA uB, uI, uO} A
+            (fun a ↦ interpObj I O (K a))
+            (fun a ↦ interpMor I O (K a)) (interpObj I O γ')
+            (interpMor I O γ')
+          |>.symm (fun a ↦ interpHomEquiv I O (K a) γ' (f a))))
+      X)
+
+/-- The per-summand transport of the `δ`-domain case of
+`IR.interpHomEquiv`: the interpretation of a clause 3 component,
+transported to a transformation out of the copower summand by the
+Lemma 4 pair, the bridge pair, and the copower adjunction. -/
+def interpHomDeltaSummand (B : Type uB)
+    (c : (B → I) → IR.{max uA uB, uB, uI, uO} I O)
+    (γ' : IR.{max uA uB, uB, uI, uO} I O) (i : B → I)
+    (g : Hom.{uA, uB, uI, uO} I O (c i) (precomp I O B i γ')) :
+    FreeCoprodCompDisc.NatTrans I O
+      (FreeCoprodCompDisc.copowerHomMap
+        (FreeCoprodCompDisc.lift.{uB, uI, max uA uB} I ⟨B, i⟩)
+        (interpObj I O (c i)))
+      (interpObj I O γ')
+      (FreeCoprodCompDisc.copowerHomMapMor
+        (FreeCoprodCompDisc.lift.{uB, uI, max uA uB} I ⟨B, i⟩)
+        (interpMor I O (c i)))
+      (interpMor I O γ') :=
+  (FreeCoprodCompDisc.natCopowerPlusEquiv
+      (FreeCoprodCompDisc.lift.{uB, uI, max uA uB} I ⟨B, i⟩)
+      (interpMor I O (c i)) (interpMor I O γ')
+      (interpMor_id I O (c i)) (interpMor_comp I O (c i))
+      (interpMor_id I O γ') (interpMor_comp I O γ')).symm
+    (FreeCoprodCompDisc.NatTrans.vcomp
+      (FreeCoprodCompDisc.NatTrans.vcomp
+        (interpHom I O (c i) (precomp I O B i γ') g)
+        (FreeCoprodCompDisc.NatTrans.ofIsoFamily
+          (fun k ↦ interpPrecompIso I O γ' B i k)
+          (interpPrecompIso_natural I O γ' B i)))
+      (plusLiftBridgeNatInv I O B i γ'))
+
+/-- The component of `IR.interpHom` at a `δ`-domain: the cotuple of the
+transported subcode components. -/
+theorem interpHom_delta (B : Type uB)
+    (c : (B → I) → IR.{max uA uB, uB, uI, uO} I O)
+    (γ' : IR.{max uA uB, uB, uI, uO} I O)
+    (f : Hom.{uA, uB, uI, uO} I O (delta I O B c) γ')
+    (X : FreeCoprodCompDisc.{max uA uB, uI} I) :
+    (interpHom I O (delta I O B c) γ' f).1 X =
+      deltaDesc I O B c X (interpObj I O γ' X)
+        (fun i ↦ (interpHomDeltaSummand I O B c γ' i (f i)).1 X) :=
+  congrArg (fun e ↦ (e f).1 X)
+    (interpHomEquiv_mk I O (Sum.inr (Sum.inr B)) (c ∘ ULift.down) γ')
+
+/-- `IR.deltaDesc` composes on the right componentwise. -/
+theorem deltaDesc_comp (B : Type uB)
+    (c : (B → I) → IR.{max uA uB, uB, uI, uO} I O)
+    (X : FreeCoprodCompDisc.{max uA uB, uI} I)
+    (Z W : FreeCoprodCompDisc.{max uA uB, uO} O)
+    (m : (i : B → I) → FreeCoprodCompDisc.Hom O
+      (FreeCoprodCompDisc.copowerHomMap
+        (FreeCoprodCompDisc.lift.{uB, uI, max uA uB} I ⟨B, i⟩)
+        (interpObj I O (c i)) X) Z)
+    (g : FreeCoprodCompDisc.Hom O Z W) :
+    FreeCoprodCompDisc.Hom.comp O (deltaDesc I O B c X Z m) g =
+      deltaDesc I O B c X W (fun i ↦ FreeCoprodCompDisc.Hom.comp O (m i) g) :=
+  deltaHom_ext I O B c X W _ _ (fun i ↦
+    ((FreeCoprodCompDisc.Hom.comp_assoc O (deltaInto I O B c i X)
+        (deltaDesc I O B c X Z m) g).symm.trans
+      (congrArg (fun t ↦ FreeCoprodCompDisc.Hom.comp O t g)
+        (deltaInto_desc I O B c i X Z m))).trans
+    (deltaInto_desc I O B c i X W
+      (fun i' ↦ FreeCoprodCompDisc.Hom.comp O (m i') g)).symm)
+
+/-- The `σ`-injection square: a semantic `σ`-injection commutes the
+morphism map of a `σ`-interpretation with the summand's. -/
+theorem interpMor_sigma_inj (A' : Type (max uA uB))
+    (K' : A' → IR.{max uA uB, uB, uI, uO} I O) (a' : A')
+    (Z W : FreeCoprodCompDisc.{max uA uB, uI} I)
+    (h : FreeCoprodCompDisc.Hom I Z W) :
+    FreeCoprodCompDisc.Hom.comp O
+        (FreeCoprodCompDisc.coprodInj O A' (fun a ↦ interpObj I O (K' a) Z) a')
+        (interpMor I O (sigma I O A' K') Z W h) =
+      FreeCoprodCompDisc.Hom.comp O (interpMor I O (K' a') Z W h)
+        (FreeCoprodCompDisc.coprodInj O A' (fun a ↦ interpObj I O (K' a) W) a') :=
+  (congrArg
+      (fun (t : MorMapSig I O (sigma I O A' K')) ↦
+        FreeCoprodCompDisc.Hom.comp O
+          (FreeCoprodCompDisc.coprodInj O A' (fun a ↦ interpObj I O (K' a) Z) a')
+          (t Z W h))
+      (interpMor_sigma.{max uA uB, uB, uI, uO} I O A' K')).trans
+    (FreeCoprodCompDisc.coprodInj_mor O A' A' _root_.id
+        (fun a ↦ interpObj I O (K' a) Z) (fun a ↦ interpObj I O (K' a) W)
+        (fun a ↦ interpMor I O (K' a) Z W h) a').symm
+
+/-- The characterizing equation of `IR.innerHomEquiv` at `IR.mk`. -/
+theorem innerHomEquiv_mk (o : O) (s : Shape.{max uA uB, uB, uO} O)
+    (d : Direction I O s → IR.{max uA uB, uB, uI, uO} I O) :
+    innerHomEquiv I O o (mk I O s d) =
+      innerHomEquivStep I O o s d (fun x ↦ innerHomEquiv I O o (d x)) :=
+  rec_mk I O (innerHomEquivStep I O o) s d
+
+/-! ### The `σ`-push characterization -/
+
+/-- The statement of the `IR.sigmaPush` characterization at one code:
+`IR.interpHom` sends a pushed morphism to the composite with the
+semantic `σ`-injection. -/
+def InterpHomSigmaPushMotive (γ : IR.{max uA uB, uB, uI, uO} I O) : Prop :=
+  ∀ (A' : Type (max uA uB)) (K' : A' → IR.{max uA uB, uB, uI, uO} I O)
+    (a' : A') (f : Hom.{uA, uB, uI, uO} I O γ (K' a'))
+    (X : FreeCoprodCompDisc.{max uA uB, uI} I),
+    (interpHom I O γ (sigma I O A' K') (sigmaPush I O γ A' K' a' f)).1 X =
+      FreeCoprodCompDisc.Hom.comp O ((interpHom I O γ (K' a') f).1 X)
+        (FreeCoprodCompDisc.coprodInj O A' (fun a ↦ interpObj I O (K' a) X) a')
+
+/-- The `ι`-composite of the Theorem 3 step at codomain `γ'`
+(definitionally the equivalence the step transports). -/
+def interpHomIotaComposite (o : O) (γ' : IR.{max uA uB, uB, uI, uO} I O) :
+    InnerHom.{uA, uB, uI, uO} I O o γ' ≃
+      FreeCoprodCompDisc.NatTrans I O
+        (interpObj I O (iota.{max uA uB, uB, uI, uO} I O o)) (interpObj I O γ')
+        (interpMor I O (iota.{max uA uB, uB, uI, uO} I O o)) (interpMor I O γ') :=
+  (innerHomEquiv I O o γ').trans
+    ((FreeCoprodCompDisc.homSingletonEquiv O o
+        (interpObj I O γ' (FreeCoprodCompDisc.emptyObj I))).symm.trans
+      (natIotaEquiv I O o γ').symm)
+
+/-- The transport of `IR.interpHomIotaComposite` along a code equality
+(definitionally the `ι`-branch of `IR.interpHomEquivStep`). -/
+def interpHomIotaCast (o : O) (γ' : IR.{max uA uB, uB, uI, uO} I O)
+    (ir : IR.{max uA uB, uB, uI, uO} I O)
+    (e : iota.{max uA uB, uB, uI, uO} I O o = ir) :
+    InnerHom.{uA, uB, uI, uO} I O o γ' ≃
+      FreeCoprodCompDisc.NatTrans I O (interpObj I O ir) (interpObj I O γ')
+        (interpMor I O ir) (interpMor I O γ') :=
+  Eq.rec (motive := fun ir' _ ↦
+      InnerHom.{uA, uB, uI, uO} I O o γ' ≃
+        FreeCoprodCompDisc.NatTrans I O (interpObj I O ir') (interpObj I O γ')
+          (interpMor I O ir') (interpMor I O γ'))
+    (interpHomIotaComposite I O o γ') e
+
+/-- The singleton morphism at a `σ`-summand name factors through the
+semantic `σ`-injection. -/
+theorem homSingletonEquiv_symm_inj (o : O) (A' : Type (max uA uB))
+    (K' : A' → IR.{max uA uB, uB, uI, uO} I O) (a' : A')
+    (z : {z : (interpObj I O (K' a') (FreeCoprodCompDisc.emptyObj I)).1 //
+      (interpObj I O (K' a') (FreeCoprodCompDisc.emptyObj I)).2 z = o}) :
+    (FreeCoprodCompDisc.homSingletonEquiv O o
+        (interpObj I O (sigma I O A' K') (FreeCoprodCompDisc.emptyObj I))).symm
+        ⟨⟨a', z.1⟩, z.2⟩ =
+      FreeCoprodCompDisc.Hom.comp O
+        ((FreeCoprodCompDisc.homSingletonEquiv O o
+            (interpObj I O (K' a') (FreeCoprodCompDisc.emptyObj I))).symm z)
+        (FreeCoprodCompDisc.coprodInj O A'
+          (fun a ↦ interpObj I O (K' a) (FreeCoprodCompDisc.emptyObj I)) a') :=
+  Subtype.ext (funext (fun _ ↦ rfl))
+
+/-- The `σ`-push equation for the transported `ι`-composite, by
+elimination of the code equality: at the reflexive instance both sides
+compute to singleton morphisms into the initial-object fiber, related
+by `IR.homSingletonEquiv_symm_inj` and the `σ`-injection square. -/
+theorem interpHomIotaCast_sigmaPush (o : O) (A' : Type (max uA uB))
+    (K' : A' → IR.{max uA uB, uB, uI, uO} I O) (a' : A')
+    (f : InnerHom.{uA, uB, uI, uO} I O o (K' a'))
+    (X : FreeCoprodCompDisc.{max uA uB, uI} I)
+    (ir : IR.{max uA uB, uB, uI, uO} I O)
+    (e : iota.{max uA uB, uB, uI, uO} I O o = ir) :
+    ((interpHomIotaCast I O o (sigma I O A' K') ir e) ⟨a', f⟩).1 X =
+      FreeCoprodCompDisc.Hom.comp O
+        (((interpHomIotaCast I O o (K' a') ir e) f).1 X)
+        (FreeCoprodCompDisc.coprodInj O A' (fun a ↦ interpObj I O (K' a) X) a') :=
+  Eq.rec (motive := fun ir' e' ↦
+      ((interpHomIotaCast I O o (sigma I O A' K') ir' e') ⟨a', f⟩).1 X =
+        FreeCoprodCompDisc.Hom.comp O
+          (((interpHomIotaCast I O o (K' a') ir' e') f).1 X)
+          (FreeCoprodCompDisc.coprodInj O A'
+            (fun a ↦ interpObj I O (K' a) X) a'))
+    ((congrArg
+        (fun t ↦ FreeCoprodCompDisc.Hom.comp O
+          ((FreeCoprodCompDisc.homSingletonEquiv O o
+              (interpObj I O (sigma I O A' K')
+                (FreeCoprodCompDisc.emptyObj I))).symm (t ⟨a', f⟩))
+          (interpMor I O (sigma I O A' K') (FreeCoprodCompDisc.emptyObj I) X
+            (FreeCoprodCompDisc.emptyDesc I X)))
+        (innerHomEquiv_mk I O o (Sum.inr (Sum.inl A')) (K' ∘ ULift.down))).trans
+      ((congrArg
+          (fun t ↦ FreeCoprodCompDisc.Hom.comp O t
+            (interpMor I O (sigma I O A' K') (FreeCoprodCompDisc.emptyObj I) X
+              (FreeCoprodCompDisc.emptyDesc I X)))
+          (homSingletonEquiv_symm_inj I O o A' K' a'
+            (innerHomEquiv I O o (K' a') f))).trans
+        ((FreeCoprodCompDisc.Hom.comp_assoc O
+            ((FreeCoprodCompDisc.homSingletonEquiv O o
+                (interpObj I O (K' a') (FreeCoprodCompDisc.emptyObj I))).symm
+              (innerHomEquiv I O o (K' a') f))
+            (FreeCoprodCompDisc.coprodInj O A'
+              (fun a ↦ interpObj I O (K' a) (FreeCoprodCompDisc.emptyObj I)) a')
+            (interpMor I O (sigma I O A' K') (FreeCoprodCompDisc.emptyObj I) X
+              (FreeCoprodCompDisc.emptyDesc I X))).trans
+          ((congrArg
+              (FreeCoprodCompDisc.Hom.comp O
+                ((FreeCoprodCompDisc.homSingletonEquiv O o
+                    (interpObj I O (K' a')
+                      (FreeCoprodCompDisc.emptyObj I))).symm
+                  (innerHomEquiv I O o (K' a') f)))
+              (interpMor_sigma_inj I O A' K' a'
+                (FreeCoprodCompDisc.emptyObj I) X
+                (FreeCoprodCompDisc.emptyDesc I X))).trans
+            (FreeCoprodCompDisc.Hom.comp_assoc O
+              ((FreeCoprodCompDisc.homSingletonEquiv O o
+                  (interpObj I O (K' a')
+                    (FreeCoprodCompDisc.emptyObj I))).symm
+                (innerHomEquiv I O o (K' a') f))
+              (interpMor I O (K' a') (FreeCoprodCompDisc.emptyObj I) X
+                (FreeCoprodCompDisc.emptyDesc I X))
+              (FreeCoprodCompDisc.coprodInj O A'
+                (fun a ↦ interpObj I O (K' a) X) a')).symm))))
+    e
+
+/-- The `ι`-case of the `IR.sigmaPush` characterization. -/
+theorem interpHom_sigmaPush_mk_iota (o : O)
+    (d : Direction I O (Sum.inl o : Shape.{max uA uB, uB, uO} O) →
+      IR.{max uA uB, uB, uI, uO} I O) :
+    InterpHomSigmaPushMotive I O (mk I O (Sum.inl o) d) :=
+  fun A' K' a' f X ↦
+    (congrArg
+        (fun t ↦ (interpHom I O (mk I O (Sum.inl o) d)
+          (sigma I O A' K') t).1 X)
+        (sigmaPush_mk_iota I O o d A' K' a' f)).trans
+      ((congrArg (fun e ↦ (e (⟨a', f⟩ :
+            InnerHom.{uA, uB, uI, uO} I O o (sigma I O A' K'))).1 X)
+          (interpHomEquiv_mk I O (Sum.inl o) d (sigma I O A' K'))).trans
+        ((interpHomIotaCast_sigmaPush I O o A' K' a' f X
+            (mk I O (Sum.inl o) d)
+            (mk_congr I O (Sum.inl o)
+              (funext (fun x ↦ nomatch x)) :
+                mk I O (Sum.inl o) PEmpty.elim = mk I O (Sum.inl o) d)).trans
+          (congrArg
+            (fun t ↦ FreeCoprodCompDisc.Hom.comp O t
+              (FreeCoprodCompDisc.coprodInj O A'
+                (fun a ↦ interpObj I O (K' a) X) a'))
+            (congrArg (fun e ↦ (e f).1 X)
+              (interpHomEquiv_mk I O (Sum.inl o) d (K' a'))).symm)))
+
+/-- The `σ`-domain case of the `IR.sigmaPush` characterization:
+componentwise by the inductive hypotheses, then the cotuple
+compatibility. -/
+theorem interpHom_sigmaPush_mk_sigma (A : Type (max uA uB))
+    (d : Direction I O (Sum.inr (Sum.inl A) : Shape.{max uA uB, uB, uO} O) →
+      IR.{max uA uB, uB, uI, uO} I O)
+    (ih : (x : Direction I O (Sum.inr (Sum.inl A) : Shape.{max uA uB, uB, uO} O)) →
+      InterpHomSigmaPushMotive I O (d x)) :
+    InterpHomSigmaPushMotive I O (mk I O (Sum.inr (Sum.inl A)) d) :=
+  fun A' K' a' f X ↦
+    (congrArg
+        (fun t ↦ (interpHom I O (mk I O (Sum.inr (Sum.inl A)) d)
+          (sigma I O A' K') t).1 X)
+        (sigmaPush_mk_sigma I O A d A' K' a' f)).trans
+      ((interpHom_sigma I O A (fun a ↦ d (ULift.up a)) (sigma I O A' K')
+          (fun b ↦ sigmaPush I O (d (ULift.up b)) A' K' a' (f b)) X).trans
+        ((congrArg
+            (FreeCoprodCompDisc.coprodDesc O A
+              (fun a ↦ interpObj I O (d (ULift.up a)) X)
+              (interpObj I O (sigma I O A' K') X))
+            (funext (fun b ↦ ih (ULift.up b) A' K' a' (f b) X))).trans
+          ((FreeCoprodCompDisc.coprodDesc_comp O A
+              (fun a ↦ interpObj I O (d (ULift.up a)) X)
+              (interpObj I O (K' a') X) (interpObj I O (sigma I O A' K') X)
+              (fun b ↦ (interpHom I O (d (ULift.up b)) (K' a') (f b)).1 X)
+              (FreeCoprodCompDisc.coprodInj O A'
+                (fun a ↦ interpObj I O (K' a) X) a')).symm.trans
+            (congrArg
+              (fun t ↦ FreeCoprodCompDisc.Hom.comp O t
+                (FreeCoprodCompDisc.coprodInj O A'
+                  (fun a ↦ interpObj I O (K' a) X) a'))
+              (interpHom_sigma I O A (fun a ↦ d (ULift.up a))
+                (K' a') f X).symm))))
+
+/-- The Lemma 4 `σ`-square: the isomorphism of `IR.interpPrecompIso`
+at a `σ`-code commutes the lifted-summand injection with the direct
+summand injection. -/
+theorem interpPrecompIso_sigma_inj (A' : Type (max uA uB))
+    (K' : A' → IR.{max uA uB, uB, uI, uO} I O) (a' : A')
+    (Q : Type uB) (q : Q → I) (k : FreeCoprodCompDisc.{max uA uB, uI} I) :
+    FreeCoprodCompDisc.Hom.comp O
+        (FreeCoprodCompDisc.coprodInj O (ULift.{uB} A')
+          (fun x ↦ interpObj I O (precomp I O Q q (K' x.down)) k)
+          (ULift.up a'))
+        (FreeCoprodCompDisc.Iso.hom O
+          (interpPrecompIso I O (sigma I O A' K') Q q k)) =
+      FreeCoprodCompDisc.Hom.comp O
+        (FreeCoprodCompDisc.Iso.hom O (interpPrecompIso I O (K' a') Q q k))
+        (FreeCoprodCompDisc.coprodInj O A'
+          (fun a ↦ interpObj I O (K' a)
+            (FreeCoprodCompDisc.plus.{uI, uB, max uA uB} I ⟨Q, q⟩ k)) a') :=
+  (congrArg
+      (fun t ↦ FreeCoprodCompDisc.Hom.comp O
+        (FreeCoprodCompDisc.coprodInj O (ULift.{uB} A')
+          (fun x ↦ interpObj I O (precomp I O Q q (K' x.down)) k)
+          (ULift.up a'))
+        (FreeCoprodCompDisc.Iso.hom O (t Q q k)))
+      (interpPrecompIso_mk I O (Sum.inr (Sum.inl A')) (K' ∘ ULift.down))).trans
+    (Subtype.ext (funext (fun _ ↦ rfl)))
+
+/-- The transported-composite equation behind the `δ`-domain case: a
+`σ`-injection pushed through the Lemma 4 isomorphism and the bridge
+factors out of the transported composite. -/
+theorem interpHomDeltaSummand_theta (B : Type uB)
+    (c : (B → I) → IR.{max uA uB, uB, uI, uO} I O)
+    (A' : Type (max uA uB)) (K' : A' → IR.{max uA uB, uB, uI, uO} I O)
+    (a' : A') (i : B → I)
+    (u : Hom.{uA, uB, uI, uO} I O (c i) (precomp I O B i (sigma I O A' K')))
+    (v : Hom.{uA, uB, uI, uO} I O (c i) (precomp I O B i (K' a')))
+    (X : FreeCoprodCompDisc.{max uA uB, uI} I)
+    (hu : (interpHom I O (c i) (precomp I O B i (sigma I O A' K')) u).1 X =
+      FreeCoprodCompDisc.Hom.comp O
+        ((interpHom I O (c i) (precomp I O B i (K' a')) v).1 X)
+        (FreeCoprodCompDisc.coprodInj O (ULift.{uB} A')
+          (fun x ↦ interpObj I O (precomp I O B i (K' x.down)) X)
+          (ULift.up a'))) :
+    FreeCoprodCompDisc.Hom.comp O
+        (FreeCoprodCompDisc.Hom.comp O
+          ((interpHom I O (c i) (precomp I O B i (sigma I O A' K')) u).1 X)
+          (FreeCoprodCompDisc.Iso.hom O
+            (interpPrecompIso I O (sigma I O A' K') B i X)))
+        ((plusLiftBridgeNatInv I O B i (sigma I O A' K')).1 X) =
+      FreeCoprodCompDisc.Hom.comp O
+        (FreeCoprodCompDisc.Hom.comp O
+          (FreeCoprodCompDisc.Hom.comp O
+            ((interpHom I O (c i) (precomp I O B i (K' a')) v).1 X)
+            (FreeCoprodCompDisc.Iso.hom O
+              (interpPrecompIso I O (K' a') B i X)))
+          ((plusLiftBridgeNatInv I O B i (K' a')).1 X))
+        (FreeCoprodCompDisc.coprodInj O A'
+          (fun a ↦ interpObj I O (K' a)
+            (FreeCoprodCompDisc.plus I
+              (FreeCoprodCompDisc.lift.{uB, uI, max uA uB} I ⟨B, i⟩) X))
+          a') :=
+  (congrArg
+      (fun t ↦ FreeCoprodCompDisc.Hom.comp O
+        (FreeCoprodCompDisc.Hom.comp O t
+          (FreeCoprodCompDisc.Iso.hom O
+            (interpPrecompIso I O (sigma I O A' K') B i X)))
+        ((plusLiftBridgeNatInv I O B i (sigma I O A' K')).1 X))
+      hu).trans
+    ((congrArg
+        (fun t ↦ FreeCoprodCompDisc.Hom.comp O t
+          ((plusLiftBridgeNatInv I O B i (sigma I O A' K')).1 X))
+        ((FreeCoprodCompDisc.Hom.comp_assoc O
+            ((interpHom I O (c i) (precomp I O B i (K' a')) v).1 X)
+            (FreeCoprodCompDisc.coprodInj O (ULift.{uB} A')
+              (fun x ↦ interpObj I O (precomp I O B i (K' x.down)) X)
+              (ULift.up a'))
+            (FreeCoprodCompDisc.Iso.hom O
+              (interpPrecompIso I O (sigma I O A' K') B i X))).trans
+          ((congrArg
+              (FreeCoprodCompDisc.Hom.comp O
+                ((interpHom I O (c i) (precomp I O B i (K' a')) v).1 X))
+              (interpPrecompIso_sigma_inj I O A' K' a' B i X)).trans
+            (FreeCoprodCompDisc.Hom.comp_assoc O
+              ((interpHom I O (c i) (precomp I O B i (K' a')) v).1 X)
+              (FreeCoprodCompDisc.Iso.hom O
+                (interpPrecompIso I O (K' a') B i X))
+              (FreeCoprodCompDisc.coprodInj O A'
+                (fun a ↦ interpObj I O (K' a)
+                  (FreeCoprodCompDisc.plus.{uI, uB, max uA uB} I ⟨B, i⟩ X))
+                a')).symm))).trans
+      ((FreeCoprodCompDisc.Hom.comp_assoc O
+          (FreeCoprodCompDisc.Hom.comp O
+            ((interpHom I O (c i) (precomp I O B i (K' a')) v).1 X)
+            (FreeCoprodCompDisc.Iso.hom O
+              (interpPrecompIso I O (K' a') B i X)))
+          (FreeCoprodCompDisc.coprodInj O A'
+            (fun a ↦ interpObj I O (K' a)
+              (FreeCoprodCompDisc.plus.{uI, uB, max uA uB} I ⟨B, i⟩ X)) a')
+          ((plusLiftBridgeNatInv I O B i (sigma I O A' K')).1 X)).trans
+        ((congrArg
+            (FreeCoprodCompDisc.Hom.comp O
+              (FreeCoprodCompDisc.Hom.comp O
+                ((interpHom I O (c i) (precomp I O B i (K' a')) v).1 X)
+                (FreeCoprodCompDisc.Iso.hom O
+                  (interpPrecompIso I O (K' a') B i X))))
+            (interpMor_sigma_inj I O A' K' a'
+              (FreeCoprodCompDisc.plus I ⟨B, i⟩ X)
+              (FreeCoprodCompDisc.plus I
+                (FreeCoprodCompDisc.lift.{uB, uI, max uA uB} I ⟨B, i⟩) X)
+              (plusLiftBridgeInvHom I B i X))).trans
+          (FreeCoprodCompDisc.Hom.comp_assoc O
+            (FreeCoprodCompDisc.Hom.comp O
+              ((interpHom I O (c i) (precomp I O B i (K' a')) v).1 X)
+              (FreeCoprodCompDisc.Iso.hom O
+                (interpPrecompIso I O (K' a') B i X)))
+            ((plusLiftBridgeNatInv I O B i (K' a')).1 X)
+            (FreeCoprodCompDisc.coprodInj O A'
+              (fun a ↦ interpObj I O (K' a)
+                (FreeCoprodCompDisc.plus I
+                  (FreeCoprodCompDisc.lift.{uB, uI, max uA uB} I ⟨B, i⟩) X))
+              a')).symm)))
+
+/-- The per-summand transport of a `σ`-injection through the `δ`-case
+target transports, given the summand's own push equation. -/
+theorem interpHomDeltaSummand_inj (B : Type uB)
+    (c : (B → I) → IR.{max uA uB, uB, uI, uO} I O)
+    (A' : Type (max uA uB)) (K' : A' → IR.{max uA uB, uB, uI, uO} I O)
+    (a' : A') (i : B → I)
+    (u : Hom.{uA, uB, uI, uO} I O (c i) (precomp I O B i (sigma I O A' K')))
+    (v : Hom.{uA, uB, uI, uO} I O (c i) (precomp I O B i (K' a')))
+    (X : FreeCoprodCompDisc.{max uA uB, uI} I)
+    (hu : (interpHom I O (c i) (precomp I O B i (sigma I O A' K')) u).1 X =
+      FreeCoprodCompDisc.Hom.comp O
+        ((interpHom I O (c i) (precomp I O B i (K' a')) v).1 X)
+        (FreeCoprodCompDisc.coprodInj O (ULift.{uB} A')
+          (fun x ↦ interpObj I O (precomp I O B i (K' x.down)) X)
+          (ULift.up a'))) :
+    (interpHomDeltaSummand I O B c (sigma I O A' K') i u).1 X =
+      FreeCoprodCompDisc.Hom.comp O
+        ((interpHomDeltaSummand I O B c (K' a') i v).1 X)
+        (FreeCoprodCompDisc.coprodInj O A'
+          (fun a ↦ interpObj I O (K' a) X) a') :=
+  (congrArg
+      (FreeCoprodCompDisc.coprodDesc O
+        (FreeCoprodCompDisc.Hom I
+          (FreeCoprodCompDisc.lift.{uB, uI, max uA uB} I ⟨B, i⟩) X)
+        (fun _ ↦ interpObj I O (c i) X)
+        (interpObj I O (sigma I O A' K') X))
+      (funext (fun e ↦
+        (congrArg
+            (fun t ↦ FreeCoprodCompDisc.Hom.comp O t
+              (interpMor I O (sigma I O A' K')
+                (FreeCoprodCompDisc.plus I
+                  (FreeCoprodCompDisc.lift.{uB, uI, max uA uB} I ⟨B, i⟩) X)
+                X
+                (FreeCoprodCompDisc.coprodPairDesc I e
+                  (FreeCoprodCompDisc.Hom.id I X))))
+            (interpHomDeltaSummand_theta I O B c A' K' a' i u v X hu)).trans
+          ((FreeCoprodCompDisc.Hom.comp_assoc O
+              (FreeCoprodCompDisc.Hom.comp O
+                (FreeCoprodCompDisc.Hom.comp O
+                  ((interpHom I O (c i) (precomp I O B i (K' a')) v).1 X)
+                  (FreeCoprodCompDisc.Iso.hom O
+                    (interpPrecompIso I O (K' a') B i X)))
+                ((plusLiftBridgeNatInv I O B i (K' a')).1 X))
+              (FreeCoprodCompDisc.coprodInj O A'
+                (fun a ↦ interpObj I O (K' a)
+                  (FreeCoprodCompDisc.plus I
+                    (FreeCoprodCompDisc.lift.{uB, uI, max uA uB} I ⟨B, i⟩) X))
+                a')
+              (interpMor I O (sigma I O A' K')
+                (FreeCoprodCompDisc.plus I
+                  (FreeCoprodCompDisc.lift.{uB, uI, max uA uB} I ⟨B, i⟩) X)
+                X
+                (FreeCoprodCompDisc.coprodPairDesc I e
+                  (FreeCoprodCompDisc.Hom.id I X)))).trans
+            ((congrArg
+                (FreeCoprodCompDisc.Hom.comp O
+                  (FreeCoprodCompDisc.Hom.comp O
+                    (FreeCoprodCompDisc.Hom.comp O
+                      ((interpHom I O (c i) (precomp I O B i (K' a')) v).1 X)
+                      (FreeCoprodCompDisc.Iso.hom O
+                        (interpPrecompIso I O (K' a') B i X)))
+                    ((plusLiftBridgeNatInv I O B i (K' a')).1 X)))
+                (interpMor_sigma_inj I O A' K' a'
+                  (FreeCoprodCompDisc.plus I
+                    (FreeCoprodCompDisc.lift.{uB, uI, max uA uB} I ⟨B, i⟩) X)
+                  X
+                  (FreeCoprodCompDisc.coprodPairDesc I e
+                    (FreeCoprodCompDisc.Hom.id I X)))).trans
+              (FreeCoprodCompDisc.Hom.comp_assoc O
+                (FreeCoprodCompDisc.Hom.comp O
+                  (FreeCoprodCompDisc.Hom.comp O
+                    ((interpHom I O (c i) (precomp I O B i (K' a')) v).1 X)
+                    (FreeCoprodCompDisc.Iso.hom O
+                      (interpPrecompIso I O (K' a') B i X)))
+                  ((plusLiftBridgeNatInv I O B i (K' a')).1 X))
+                (interpMor I O (K' a')
+                  (FreeCoprodCompDisc.plus I
+                    (FreeCoprodCompDisc.lift.{uB, uI, max uA uB} I ⟨B, i⟩) X)
+                  X
+                  (FreeCoprodCompDisc.coprodPairDesc I e
+                    (FreeCoprodCompDisc.Hom.id I X)))
+                (FreeCoprodCompDisc.coprodInj O A'
+                  (fun a ↦ interpObj I O (K' a) X) a')).symm))))).trans
+    (FreeCoprodCompDisc.coprodDesc_comp O
+        (FreeCoprodCompDisc.Hom I
+          (FreeCoprodCompDisc.lift.{uB, uI, max uA uB} I ⟨B, i⟩) X)
+        (fun _ ↦ interpObj I O (c i) X) (interpObj I O (K' a') X)
+        (interpObj I O (sigma I O A' K') X)
+        (fun e ↦ FreeCoprodCompDisc.Hom.comp O
+          (FreeCoprodCompDisc.Hom.comp O
+            (FreeCoprodCompDisc.Hom.comp O
+              ((interpHom I O (c i) (precomp I O B i (K' a')) v).1 X)
+              (FreeCoprodCompDisc.Iso.hom O
+                (interpPrecompIso I O (K' a') B i X)))
+            ((plusLiftBridgeNatInv I O B i (K' a')).1 X))
+          (interpMor I O (K' a')
+            (FreeCoprodCompDisc.plus I
+              (FreeCoprodCompDisc.lift.{uB, uI, max uA uB} I ⟨B, i⟩) X) X
+            (FreeCoprodCompDisc.coprodPairDesc I e
+              (FreeCoprodCompDisc.Hom.id I X))))
+        (FreeCoprodCompDisc.coprodInj O A'
+          (fun a ↦ interpObj I O (K' a) X) a')).symm
+
+/-- The `δ`-domain case of the `IR.sigmaPush` characterization. -/
+theorem interpHom_sigmaPush_mk_delta (B : Type uB)
+    (d : Direction I O (Sum.inr (Sum.inr B) : Shape.{max uA uB, uB, uO} O) →
+      IR.{max uA uB, uB, uI, uO} I O)
+    (ih : (x : Direction I O (Sum.inr (Sum.inr B) : Shape.{max uA uB, uB, uO} O)) →
+      InterpHomSigmaPushMotive I O (d x)) :
+    InterpHomSigmaPushMotive I O (mk I O (Sum.inr (Sum.inr B)) d) :=
+  fun A' K' a' f X ↦
+    (congrArg
+        (fun t ↦ (interpHom I O (mk I O (Sum.inr (Sum.inr B)) d)
+          (sigma I O A' K') t).1 X)
+        (sigmaPush_mk_delta I O B d A' K' a' f)).trans
+      ((interpHom_delta I O B (fun j ↦ d (ULift.up j)) (sigma I O A' K')
+          (fun i ↦ sigmaPush I O (d (ULift.up i)) (ULift.{uB} A')
+            (fun x ↦ precomp I O B i (K' x.down)) (ULift.up a') (f i)) X).trans
+        ((congrArg
+            (deltaDesc I O B (fun j ↦ d (ULift.up j)) X
+              (interpObj I O (sigma I O A' K') X))
+            (funext (fun i ↦
+              interpHomDeltaSummand_inj I O B (fun j ↦ d (ULift.up j))
+                A' K' a' i
+                (sigmaPush I O (d (ULift.up i)) (ULift.{uB} A')
+                  (fun x ↦ precomp I O B i (K' x.down)) (ULift.up a') (f i))
+                (f i) X
+                (ih (ULift.up i) (ULift.{uB} A')
+                  (fun x ↦ precomp I O B i (K' x.down)) (ULift.up a')
+                  (f i) X)))).trans
+          ((deltaDesc_comp I O B (fun j ↦ d (ULift.up j)) X
+              (interpObj I O (K' a') X) (interpObj I O (sigma I O A' K') X)
+              (fun i ↦ (interpHomDeltaSummand I O B (fun j ↦ d (ULift.up j))
+                (K' a') i (f i)).1 X)
+              (FreeCoprodCompDisc.coprodInj O A'
+                (fun a ↦ interpObj I O (K' a) X) a')).symm.trans
+            (congrArg
+              (fun t ↦ FreeCoprodCompDisc.Hom.comp O t
+                (FreeCoprodCompDisc.coprodInj O A'
+                  (fun a ↦ interpObj I O (K' a) X) a'))
+              (interpHom_delta I O B (fun j ↦ d (ULift.up j))
+                (K' a') f X).symm))))
+
+/-- `IR.interpHom` sends `IR.sigmaPush` to composition with the
+semantic `σ`-injection, by `IR.induction`. -/
+theorem interpHom_sigmaPush (γ : IR.{max uA uB, uB, uI, uO} I O) :
+    InterpHomSigmaPushMotive I O γ :=
+  induction I O (InterpHomSigmaPushMotive I O)
+    (fun s ↦ match s with
+      | Sum.inl o => fun d _ ↦ interpHom_sigmaPush_mk_iota I O o d
+      | Sum.inr (Sum.inl A) => fun d ih ↦ interpHom_sigmaPush_mk_sigma I O A d ih
+      | Sum.inr (Sum.inr B) => fun d ih ↦ interpHom_sigmaPush_mk_delta I O B d ih)
+    γ
+
+/-! ### The empty-`δ`-push characterization -/
+
+/-- Hom-extensionality at an empty-name domain: any two morphisms out
+of the lift of an empty-witnessed family are equal. -/
+theorem emptyHom_ext (E : Type uB) (e : E → PEmpty.{1})
+    (X : FreeCoprodCompDisc.{max uA uB, uI} I)
+    (f g : FreeCoprodCompDisc.Hom I
+      (FreeCoprodCompDisc.lift.{uB, uI, max uA uB} I ⟨E, fun x ↦ (e x).elim⟩) X) :
+    f = g :=
+  Subtype.ext (funext (fun z ↦ (e z.down).elim))
+
+/-- The canonical weight: the morphism out of the lift of an
+empty-witnessed family given by elimination at every name. -/
+def deltaEmptyWeight (E : Type uB) (e : E → PEmpty.{1})
+    (X : FreeCoprodCompDisc.{max uA uB, uI} I) :
+    FreeCoprodCompDisc.Hom I
+      (FreeCoprodCompDisc.lift.{uB, uI, max uA uB} I ⟨E, fun x ↦ (e x).elim⟩) X :=
+  ⟨fun z ↦ (e z.down).elim, funext (fun z ↦ (e z.down).elim)⟩
+
+/-- The semantic inclusion of the empty-witnessed summand into the
+`delta` interpretation: the copower injection at the canonical weight
+followed by the summand inclusion `IR.deltaInto`. -/
+def deltaEmptyInj (E : Type uB) (e : E → PEmpty.{1})
+    (M : (E → I) → IR.{max uA uB, uB, uI, uO} I O)
+    (X : FreeCoprodCompDisc.{max uA uB, uI} I) :
+    FreeCoprodCompDisc.Hom O (interpObj I O (M (fun x ↦ (e x).elim)) X)
+      (interpObj I O (delta I O E M) X) :=
+  FreeCoprodCompDisc.Hom.comp O
+    (FreeCoprodCompDisc.coprodInj O
+      (FreeCoprodCompDisc.Hom I
+        (FreeCoprodCompDisc.lift.{uB, uI, max uA uB} I ⟨E, fun x ↦ (e x).elim⟩) X)
+      (fun _ ↦ interpObj I O (M (fun x ↦ (e x).elim)) X)
+      (deltaEmptyWeight I E e X))
+    (deltaInto I O E M (fun x ↦ (e x).elim) X)
+
+/-- The generic injection square: the semantic empty-summand inclusion
+commutes the morphism map of the `delta` interpretation with the
+summand's. -/
+theorem interpMor_deltaEmpty_inj (E : Type uB) (e : E → PEmpty.{1})
+    (M : (E → I) → IR.{max uA uB, uB, uI, uO} I O)
+    (Z W : FreeCoprodCompDisc.{max uA uB, uI} I)
+    (h : FreeCoprodCompDisc.Hom I Z W) :
+    FreeCoprodCompDisc.Hom.comp O (deltaEmptyInj I O E e M Z)
+        (interpMor I O (delta I O E M) Z W h) =
+      FreeCoprodCompDisc.Hom.comp O
+        (interpMor I O (M (fun x ↦ (e x).elim)) Z W h)
+        (deltaEmptyInj I O E e M W) :=
+  (FreeCoprodCompDisc.Hom.comp_assoc O
+      (FreeCoprodCompDisc.coprodInj O
+        (FreeCoprodCompDisc.Hom I
+          (FreeCoprodCompDisc.lift.{uB, uI, max uA uB} I ⟨E, fun x ↦ (e x).elim⟩) Z)
+        (fun _ ↦ interpObj I O (M (fun x ↦ (e x).elim)) Z)
+        (deltaEmptyWeight I E e Z))
+      (deltaInto I O E M (fun x ↦ (e x).elim) Z)
+      (interpMor I O (delta I O E M) Z W h)).trans
+    ((congrArg
+        (FreeCoprodCompDisc.Hom.comp O
+          (FreeCoprodCompDisc.coprodInj O
+            (FreeCoprodCompDisc.Hom I
+              (FreeCoprodCompDisc.lift.{uB, uI, max uA uB} I
+                ⟨E, fun x ↦ (e x).elim⟩) Z)
+            (fun _ ↦ interpObj I O (M (fun x ↦ (e x).elim)) Z)
+            (deltaEmptyWeight I E e Z)))
+        (deltaInto_natural I O E M (fun x ↦ (e x).elim) Z W h).symm).trans
+      ((FreeCoprodCompDisc.Hom.comp_assoc O
+          (FreeCoprodCompDisc.coprodInj O
+            (FreeCoprodCompDisc.Hom I
+              (FreeCoprodCompDisc.lift.{uB, uI, max uA uB} I
+                ⟨E, fun x ↦ (e x).elim⟩) Z)
+            (fun _ ↦ interpObj I O (M (fun x ↦ (e x).elim)) Z)
+            (deltaEmptyWeight I E e Z))
+          (FreeCoprodCompDisc.copowerHomMapMor
+            (FreeCoprodCompDisc.lift.{uB, uI, max uA uB} I ⟨E, fun x ↦ (e x).elim⟩)
+            (interpMor I O (M (fun x ↦ (e x).elim))) Z W h)
+          (deltaInto I O E M (fun x ↦ (e x).elim) W)).symm.trans
+        ((congrArg
+            (fun t ↦ FreeCoprodCompDisc.Hom.comp O t
+              (deltaInto I O E M (fun x ↦ (e x).elim) W))
+            (FreeCoprodCompDisc.coprodInj_mor O
+              (FreeCoprodCompDisc.Hom I
+                (FreeCoprodCompDisc.lift.{uB, uI, max uA uB} I
+                  ⟨E, fun x ↦ (e x).elim⟩) Z)
+              (FreeCoprodCompDisc.Hom I
+                (FreeCoprodCompDisc.lift.{uB, uI, max uA uB} I
+                  ⟨E, fun x ↦ (e x).elim⟩) W)
+              (fun e' ↦ FreeCoprodCompDisc.Hom.comp I e' h)
+              (fun _ ↦ interpObj I O (M (fun x ↦ (e x).elim)) Z)
+              (fun _ ↦ interpObj I O (M (fun x ↦ (e x).elim)) W)
+              (fun _ ↦ interpMor I O (M (fun x ↦ (e x).elim)) Z W h)
+              (deltaEmptyWeight I E e Z))).trans
+          ((congrArg
+              (fun t ↦ FreeCoprodCompDisc.Hom.comp O
+                (FreeCoprodCompDisc.Hom.comp O
+                  (interpMor I O (M (fun x ↦ (e x).elim)) Z W h)
+                  (FreeCoprodCompDisc.coprodInj O
+                    (FreeCoprodCompDisc.Hom I
+                      (FreeCoprodCompDisc.lift.{uB, uI, max uA uB} I
+                        ⟨E, fun x ↦ (e x).elim⟩) W)
+                    (fun _ ↦ interpObj I O (M (fun x ↦ (e x).elim)) W) t))
+                (deltaInto I O E M (fun x ↦ (e x).elim) W))
+              (emptyHom_ext I E e W
+                (FreeCoprodCompDisc.Hom.comp I (deltaEmptyWeight I E e Z) h)
+                (deltaEmptyWeight I E e W))).trans
+            (FreeCoprodCompDisc.Hom.comp_assoc O
+              (interpMor I O (M (fun x ↦ (e x).elim)) Z W h)
+              (FreeCoprodCompDisc.coprodInj O
+                (FreeCoprodCompDisc.Hom I
+                  (FreeCoprodCompDisc.lift.{uB, uI, max uA uB} I
+                    ⟨E, fun x ↦ (e x).elim⟩) W)
+                (fun _ ↦ interpObj I O (M (fun x ↦ (e x).elim)) W)
+                (deltaEmptyWeight I E e W))
+              (deltaInto I O E M (fun x ↦ (e x).elim) W))))))
+
+/-- Transport of a summand interpretation along an equality of
+assignments: the object-level `isoOfEq` agrees with the name-level
+cast, for any proofs of the assignment equality. -/
+theorem interpObj_isoOfEq_cast (E : Type uB)
+    (M : (E → I) → IR.{max uA uB, uB, uI, uO} I O)
+    (X : FreeCoprodCompDisc.{max uA uB, uI} I) (a : E → I) :
+    ∀ (c : E → I) (s : a = c) (s' : a = c)
+      (y : (interpObj I O (M a) X).1),
+      (FreeCoprodCompDisc.isoOfEq O
+          (congrArg (fun m ↦ interpObj I O (M m) X) s)).1 y =
+        cast (congrArg (fun m ↦ (interpObj I O (M m) X).1) s') y :=
+  fun _ s ↦
+    Eq.rec (motive := fun c' s'' ↦ ∀ (s' : a = c')
+        (y : (interpObj I O (M a) X).1),
+        (FreeCoprodCompDisc.isoOfEq O
+            (congrArg (fun m ↦ interpObj I O (M m) X) s'')).1 y =
+          cast (congrArg (fun m ↦ (interpObj I O (M m) X).1) s') y)
+      (fun _ _ ↦ rfl) s
+
+/-- The transported summand isomorphism of the Lemma 4 `δ`-square at
+the empty inclusion: the summand's Lemma 4 isomorphism followed by the
+transport along the collapse of the merged assignment. -/
+def deltaEmptySummandHom (E : Type uB) (e : E → PEmpty.{1})
+    (M : (E → I) → IR.{max uA uB, uB, uI, uO} I O)
+    (Q : Type uB) (q : Q → I) (k : FreeCoprodCompDisc.{max uA uB, uI} I) :
+    FreeCoprodCompDisc.Hom O
+      (interpObj I O
+        (precomp I O Q q (M (precompMerge I Q q (fun x ↦ (e x).elim)
+          (fun z : {z : E // (fun x ↦ (e x).elim : E → Q ⊕ PUnit.{uB + 1}) z =
+              Sum.inr PUnit.unit} ↦
+            (((e z.1).elim : PEmpty.{1}).elim : I))))) k)
+      (interpObj I O (M (fun x ↦ (e x).elim))
+        (FreeCoprodCompDisc.plus.{uI, uB, max uA uB} I ⟨Q, q⟩ k)) :=
+  FreeCoprodCompDisc.Hom.comp O
+    (FreeCoprodCompDisc.Iso.hom O
+      (interpPrecompIso I O
+        (M (precompMerge I Q q (fun x ↦ (e x).elim)
+          (fun z ↦ (((e z.1).elim : PEmpty.{1}).elim : I)))) Q q k))
+    (FreeCoprodCompDisc.Iso.hom O
+      (FreeCoprodCompDisc.isoOfEq O
+        (congrArg
+          (fun a ↦ interpObj I O (M a)
+            (FreeCoprodCompDisc.plus.{uI, uB, max uA uB} I ⟨Q, q⟩ k))
+          (funext (fun x ↦ (e x).elim) :
+            (fun x ↦ ((e x).elim : I)) =
+              precompMerge I Q q (fun x ↦ (e x).elim)
+                (fun z ↦ (((e z.1).elim : PEmpty.{1}).elim : I))).symm)))
+
+/-- The name-level computation of the Lemma 4 `δ`-square at the empty
+inclusion, with every empty-derived assignment equality generalized:
+both routes transport the summand's Lemma 4 image along propositionally
+equal paths, identified by proof irrelevance at the base. -/
+theorem deltaEmpty_strip (E : Type uB) (e : E → PEmpty.{1})
+    (M : (E → I) → IR.{max uA uB, uB, uI, uO} I O)
+    (Q : Type uB) (q : Q → I) (k : FreeCoprodCompDisc.{max uA uB, uI} I) :
+    ∀ (j' : {z : E // (fun x ↦ (e x).elim : E → Q ⊕ PUnit.{uB + 1}) z =
+        Sum.inr PUnit.unit} → I)
+      (hj : (fun z : {z : E // (fun x ↦ (e x).elim : E → Q ⊕ PUnit.{uB + 1}) z =
+          Sum.inr PUnit.unit} ↦ (((e z.1).elim : PEmpty.{1}).elim : I)) = j')
+      (w₁ : E → Q ⊕ k.1)
+      (s₁ : precompMerge I Q q (fun x ↦ (e x).elim) j' = Sum.elim q k.2 ∘ w₁)
+      (w₂ : E → Q ⊕ k.1) (_hw : w₁ = w₂)
+      (b₂ : E → I)
+      (r₂ : precompMerge I Q q (fun x ↦ (e x).elim)
+          (fun z ↦ (((e z.1).elim : PEmpty.{1}).elim : I)) = b₂)
+      (s₂ : b₂ = Sum.elim q k.2 ∘ w₂)
+      (n : (interpObj I O (precomp I O Q q (M (precompMerge I Q q
+        (fun x ↦ (e x).elim)
+        (fun z ↦ (((e z.1).elim : PEmpty.{1}).elim : I))))) k).1),
+      (⟨w₁, (FreeCoprodCompDisc.isoOfEq O
+          (congrArg (fun m ↦ interpObj I O (M m)
+            (FreeCoprodCompDisc.plus.{uI, uB, max uA uB} I ⟨Q, q⟩ k)) s₁)).1
+          ((FreeCoprodCompDisc.Iso.hom O
+            (interpPrecompIso I O
+              (M (precompMerge I Q q (fun x ↦ (e x).elim) j')) Q q k)).1
+            (cast (congrArg (fun t ↦ (interpObj I O (precomp I O Q q
+              (M (precompMerge I Q q (fun x ↦ (e x).elim) t))) k).1) hj) n))⟩ :
+        (interpObj I O (delta I O E M)
+          (FreeCoprodCompDisc.plus.{uI, uB, max uA uB} I ⟨Q, q⟩ k)).1) =
+      ⟨w₂, cast (congrArg (fun m ↦ (interpObj I O (M m)
+          (FreeCoprodCompDisc.plus.{uI, uB, max uA uB} I ⟨Q, q⟩ k)).1) s₂)
+        ((FreeCoprodCompDisc.isoOfEq O
+          (congrArg (fun m ↦ interpObj I O (M m)
+            (FreeCoprodCompDisc.plus.{uI, uB, max uA uB} I ⟨Q, q⟩ k)) r₂)).1
+          ((FreeCoprodCompDisc.Iso.hom O
+            (interpPrecompIso I O (M (precompMerge I Q q (fun x ↦ (e x).elim)
+              (fun z ↦ (((e z.1).elim : PEmpty.{1}).elim : I)))) Q q k)).1 n))⟩ :=
+  fun _ hj ↦
+    Eq.rec (motive := fun j'' hj' ↦ ∀ (w₁ : E → Q ⊕ k.1)
+        (s₁ : precompMerge I Q q (fun x ↦ (e x).elim) j'' = Sum.elim q k.2 ∘ w₁)
+        (w₂ : E → Q ⊕ k.1) (_hw : w₁ = w₂) (b₂ : E → I)
+        (r₂ : precompMerge I Q q (fun x ↦ (e x).elim)
+            (fun z ↦ (((e z.1).elim : PEmpty.{1}).elim : I)) = b₂)
+        (s₂ : b₂ = Sum.elim q k.2 ∘ w₂)
+        (n : (interpObj I O (precomp I O Q q (M (precompMerge I Q q
+          (fun x ↦ (e x).elim)
+          (fun z ↦ (((e z.1).elim : PEmpty.{1}).elim : I))))) k).1),
+        (⟨w₁, (FreeCoprodCompDisc.isoOfEq O
+            (congrArg (fun m ↦ interpObj I O (M m)
+              (FreeCoprodCompDisc.plus.{uI, uB, max uA uB} I ⟨Q, q⟩ k)) s₁)).1
+            ((FreeCoprodCompDisc.Iso.hom O
+              (interpPrecompIso I O
+                (M (precompMerge I Q q (fun x ↦ (e x).elim) j'')) Q q k)).1
+              (cast (congrArg (fun t ↦ (interpObj I O (precomp I O Q q
+                (M (precompMerge I Q q (fun x ↦ (e x).elim) t))) k).1) hj') n))⟩ :
+          (interpObj I O (delta I O E M)
+            (FreeCoprodCompDisc.plus.{uI, uB, max uA uB} I ⟨Q, q⟩ k)).1) =
+        ⟨w₂, cast (congrArg (fun m ↦ (interpObj I O (M m)
+            (FreeCoprodCompDisc.plus.{uI, uB, max uA uB} I ⟨Q, q⟩ k)).1) s₂)
+          ((FreeCoprodCompDisc.isoOfEq O
+            (congrArg (fun m ↦ interpObj I O (M m)
+              (FreeCoprodCompDisc.plus.{uI, uB, max uA uB} I ⟨Q, q⟩ k)) r₂)).1
+            ((FreeCoprodCompDisc.Iso.hom O
+              (interpPrecompIso I O (M (precompMerge I Q q (fun x ↦ (e x).elim)
+                (fun z ↦ (((e z.1).elim : PEmpty.{1}).elim : I)))) Q q k)).1
+              n))⟩)
+      (fun w₁ s₁ _ hw ↦
+        Eq.rec (motive := fun w₂' _ ↦ ∀ (b₂ : E → I)
+            (r₂ : precompMerge I Q q (fun x ↦ (e x).elim)
+                (fun z ↦ (((e z.1).elim : PEmpty.{1}).elim : I)) = b₂)
+            (s₂ : b₂ = Sum.elim q k.2 ∘ w₂')
+            (n : (interpObj I O (precomp I O Q q (M (precompMerge I Q q
+              (fun x ↦ (e x).elim)
+              (fun z ↦ (((e z.1).elim : PEmpty.{1}).elim : I))))) k).1),
+            (⟨w₁, (FreeCoprodCompDisc.isoOfEq O
+                (congrArg (fun m ↦ interpObj I O (M m)
+                  (FreeCoprodCompDisc.plus.{uI, uB, max uA uB} I ⟨Q, q⟩ k)) s₁)).1
+                ((FreeCoprodCompDisc.Iso.hom O
+                  (interpPrecompIso I O (M (precompMerge I Q q
+                    (fun x ↦ (e x).elim)
+                    (fun z ↦ (((e z.1).elim : PEmpty.{1}).elim : I)))) Q q k)).1
+                  n)⟩ :
+              (interpObj I O (delta I O E M)
+                (FreeCoprodCompDisc.plus.{uI, uB, max uA uB} I ⟨Q, q⟩ k)).1) =
+            ⟨w₂', cast (congrArg (fun m ↦ (interpObj I O (M m)
+                (FreeCoprodCompDisc.plus.{uI, uB, max uA uB} I ⟨Q, q⟩ k)).1) s₂)
+              ((FreeCoprodCompDisc.isoOfEq O
+                (congrArg (fun m ↦ interpObj I O (M m)
+                  (FreeCoprodCompDisc.plus.{uI, uB, max uA uB} I ⟨Q, q⟩ k)) r₂)).1
+                ((FreeCoprodCompDisc.Iso.hom O
+                  (interpPrecompIso I O (M (precompMerge I Q q
+                    (fun x ↦ (e x).elim)
+                    (fun z ↦ (((e z.1).elim : PEmpty.{1}).elim : I)))) Q q k)).1
+                  n))⟩)
+          (fun _ r₂ ↦
+            Eq.rec (motive := fun b₂' r₂' ↦ ∀ (s₂ : b₂' = Sum.elim q k.2 ∘ w₁)
+                (n : (interpObj I O (precomp I O Q q (M (precompMerge I Q q
+                  (fun x ↦ (e x).elim)
+                  (fun z ↦ (((e z.1).elim : PEmpty.{1}).elim : I))))) k).1),
+                (⟨w₁, (FreeCoprodCompDisc.isoOfEq O
+                    (congrArg (fun m ↦ interpObj I O (M m)
+                      (FreeCoprodCompDisc.plus.{uI, uB, max uA uB} I ⟨Q, q⟩ k))
+                      s₁)).1
+                    ((FreeCoprodCompDisc.Iso.hom O
+                      (interpPrecompIso I O (M (precompMerge I Q q
+                        (fun x ↦ (e x).elim)
+                        (fun z ↦ (((e z.1).elim : PEmpty.{1}).elim : I))))
+                        Q q k)).1 n)⟩ :
+                  (interpObj I O (delta I O E M)
+                    (FreeCoprodCompDisc.plus.{uI, uB, max uA uB} I ⟨Q, q⟩ k)).1) =
+                ⟨w₁, cast (congrArg (fun m ↦ (interpObj I O (M m)
+                    (FreeCoprodCompDisc.plus.{uI, uB, max uA uB} I ⟨Q, q⟩ k)).1)
+                    s₂)
+                  ((FreeCoprodCompDisc.isoOfEq O
+                    (congrArg (fun m ↦ interpObj I O (M m)
+                      (FreeCoprodCompDisc.plus.{uI, uB, max uA uB} I ⟨Q, q⟩ k))
+                      r₂')).1
+                    ((FreeCoprodCompDisc.Iso.hom O
+                      (interpPrecompIso I O (M (precompMerge I Q q
+                        (fun x ↦ (e x).elim)
+                        (fun z ↦ (((e z.1).elim : PEmpty.{1}).elim : I))))
+                        Q q k)).1 n))⟩)
+              (fun s₂ n ↦
+                congrArg
+                  (fun t ↦ (⟨w₁, t⟩ :
+                    (interpObj I O (delta I O E M)
+                      (FreeCoprodCompDisc.plus.{uI, uB, max uA uB} I
+                        ⟨Q, q⟩ k)).1))
+                  (interpObj_isoOfEq_cast I O E M
+                    (FreeCoprodCompDisc.plus.{uI, uB, max uA uB} I ⟨Q, q⟩ k)
+                    (precompMerge I Q q (fun x ↦ (e x).elim)
+                      (fun z ↦ (((e z.1).elim : PEmpty.{1}).elim : I)))
+                    (Sum.elim q k.2 ∘ w₁) s₁ s₂
+                    ((FreeCoprodCompDisc.Iso.hom O
+                      (interpPrecompIso I O (M (precompMerge I Q q
+                        (fun x ↦ (e x).elim)
+                        (fun z ↦ (((e z.1).elim : PEmpty.{1}).elim : I))))
+                        Q q k)).1 n)))
+              r₂)
+          hw)
+      hj
+
+/-- The Lemma 4 `δ`-square at the empty inclusion: the syntactic
+injection at the precomposed level, pushed through the Lemma 4
+isomorphism, is the transported summand isomorphism followed by the
+semantic empty-summand inclusion at the coproduct object. -/
+theorem interpPrecompIso_deltaEmpty_inj (E : Type uB) (e : E → PEmpty.{1})
+    (M : (E → I) → IR.{max uA uB, uB, uI, uO} I O)
+    (Q : Type uB) (q : Q → I) (k : FreeCoprodCompDisc.{max uA uB, uI} I) :
+    FreeCoprodCompDisc.Hom.comp O
+        (FreeCoprodCompDisc.Hom.comp O
+          (deltaEmptyInj I O
+            {z : E // (fun x ↦ (e x).elim : E → Q ⊕ PUnit.{uB + 1}) z =
+              Sum.inr PUnit.unit}
+            (fun z ↦ (e z.1).elim)
+            (fun j ↦ precomp I O Q q
+              (M (precompMerge I Q q (fun x ↦ (e x).elim) j)))
+            k)
+          (FreeCoprodCompDisc.coprodInj O
+            (ULift.{max uA uB} (E → Q ⊕ PUnit.{uB + 1}))
+            (fun cl ↦ interpObj I O
+              (delta I O {z : E // cl.down z = Sum.inr PUnit.unit}
+                (fun j ↦ precomp I O Q q
+                  (M (precompMerge I Q q cl.down j)))) k)
+            (ULift.up (fun x ↦ (e x).elim))))
+        (FreeCoprodCompDisc.Iso.hom O
+          (interpPrecompIso I O (delta I O E M) Q q k)) =
+      FreeCoprodCompDisc.Hom.comp O (deltaEmptySummandHom I O E e M Q q k)
+        (deltaEmptyInj I O E e M
+          (FreeCoprodCompDisc.plus.{uI, uB, max uA uB} I ⟨Q, q⟩ k)) :=
+  (congrArg
+      (fun t ↦ FreeCoprodCompDisc.Hom.comp O
+        (FreeCoprodCompDisc.Hom.comp O
+          (deltaEmptyInj I O
+            {z : E // (fun x ↦ (e x).elim : E → Q ⊕ PUnit.{uB + 1}) z =
+              Sum.inr PUnit.unit}
+            (fun z ↦ (e z.1).elim)
+            (fun j ↦ precomp I O Q q
+              (M (precompMerge I Q q (fun x ↦ (e x).elim) j)))
+            k)
+          (FreeCoprodCompDisc.coprodInj O
+            (ULift.{max uA uB} (E → Q ⊕ PUnit.{uB + 1}))
+            (fun cl ↦ interpObj I O
+              (delta I O {z : E // cl.down z = Sum.inr PUnit.unit}
+                (fun j ↦ precomp I O Q q
+                  (M (precompMerge I Q q cl.down j)))) k)
+            (ULift.up (fun x ↦ (e x).elim))))
+        (FreeCoprodCompDisc.Iso.hom O (t Q q k)))
+      (interpPrecompIso_mk I O (Sum.inr (Sum.inr E)) (M ∘ ULift.down))).trans
+    (Subtype.ext (funext (fun n ↦
+      deltaEmpty_strip I O E e M Q q k
+        (fun z ↦ k.2 (((e z.1).elim : PEmpty.{1}).elim))
+        (funext (fun z ↦ (e z.1).elim))
+        (arrowSumMerge (fun x ↦ (e x).elim)
+          (fun z ↦ (((e z.1).elim : PEmpty.{1}).elim : k.1)))
+        (precompMerge_elim I Q q k E (fun x ↦ (e x).elim)
+          (fun z ↦ (((e z.1).elim : PEmpty.{1}).elim : k.1)))
+        (fun x ↦ ((e x).elim : Q ⊕ k.1))
+        (funext (fun x ↦ (e x).elim))
+        (fun x ↦ ((e x).elim : I))
+        (funext (fun x ↦ (e x).elim)).symm
+        (funext (fun x ↦ (e x).elim))
+        n)))
+
+/-- The statement of the `IR.deltaEmptyPush` characterization at one
+code: `IR.interpHom` sends a pushed morphism to the composite with the
+semantic empty-summand inclusion. -/
+def InterpHomDeltaEmptyPushMotive (γ : IR.{max uA uB, uB, uI, uO} I O) : Prop :=
+  ∀ (E : Type uB) (e : E → PEmpty.{1})
+    (M : (E → I) → IR.{max uA uB, uB, uI, uO} I O)
+    (f : Hom.{uA, uB, uI, uO} I O γ (M (fun x ↦ (e x).elim)))
+    (X : FreeCoprodCompDisc.{max uA uB, uI} I),
+    (interpHom I O γ (delta I O E M) (deltaEmptyPush I O γ E e M f)).1 X =
+      FreeCoprodCompDisc.Hom.comp O
+        ((interpHom I O γ (M (fun x ↦ (e x).elim)) f).1 X)
+        (deltaEmptyInj I O E e M X)
+
+/-- The name component of `IR.innerHomEquivCast` at an empty-witnessed
+direction, as a cast of the untransported name, for any proofs of the
+assignment equality. -/
+theorem innerHomEquivCast_fst_cast (o : O) (E : Type uB) (e : E → PEmpty.{1})
+    (M : (E → I) → IR.{max uA uB, uB, uI, uO} I O) :
+    ∀ (j : E → I) (pf : (fun b ↦ ((e b).elim : I)) = j)
+      (h' : (fun b ↦ ((e b).elim : I)) = j)
+      (f : InnerHom.{uA, uB, uI, uO} I O o (M (fun b ↦ (e b).elim))),
+      ((innerHomEquivCast I O o E (M ∘ ULift.down)
+          (fun x ↦ innerHomEquiv I O o ((M ∘ ULift.down) x))
+          (fun b ↦ (e b).elim) j pf) f).1 =
+        cast
+          (congrArg
+            (fun t ↦ (interpObj I O (M t) (FreeCoprodCompDisc.emptyObj I)).1) h')
+          ((innerHomEquiv I O o (M (fun b ↦ (e b).elim)) f).1) :=
+  fun _ pf ↦
+    Eq.rec (motive := fun j' pf' ↦ ∀ (h' : (fun b ↦ ((e b).elim : I)) = j')
+        (f : InnerHom.{uA, uB, uI, uO} I O o (M (fun b ↦ (e b).elim))),
+        ((innerHomEquivCast I O o E (M ∘ ULift.down)
+            (fun x ↦ innerHomEquiv I O o ((M ∘ ULift.down) x))
+            (fun b ↦ (e b).elim) j' pf') f).1 =
+          cast
+            (congrArg
+              (fun t ↦ (interpObj I O (M t)
+                (FreeCoprodCompDisc.emptyObj I)).1) h')
+            ((innerHomEquiv I O o (M (fun b ↦ (e b).elim)) f).1))
+      (fun _ _ ↦ rfl) pf
+
+/-- The singleton morphism at the empty-witnessed `δ`-name factors
+through the semantic empty-summand inclusion. -/
+theorem homSingletonEquiv_symm_deltaEmptyInj (o : O) (E : Type uB)
+    (e : E → PEmpty.{1}) (M : (E → I) → IR.{max uA uB, uB, uI, uO} I O)
+    (f : InnerHom.{uA, uB, uI, uO} I O o (M (fun x ↦ (e x).elim))) :
+    (FreeCoprodCompDisc.homSingletonEquiv O o
+        (interpObj I O (delta I O E M) (FreeCoprodCompDisc.emptyObj I))).symm
+        (innerHomEquiv I O o (delta I O E M) ⟨e, f⟩) =
+      FreeCoprodCompDisc.Hom.comp O
+        ((FreeCoprodCompDisc.homSingletonEquiv O o
+            (interpObj I O (M (fun x ↦ (e x).elim))
+              (FreeCoprodCompDisc.emptyObj I))).symm
+          (innerHomEquiv I O o (M (fun x ↦ (e x).elim)) f))
+        (deltaEmptyInj I O E e M (FreeCoprodCompDisc.emptyObj I)) :=
+  (congrArg
+      (fun (t : InnerHom.{uA, uB, uI, uO} I O o (delta I O E M) ≃
+          {z : (interpObj I O (delta I O E M)
+              (FreeCoprodCompDisc.emptyObj I)).1 //
+            (interpObj I O (delta I O E M)
+              (FreeCoprodCompDisc.emptyObj I)).2 z = o}) ↦
+        (FreeCoprodCompDisc.homSingletonEquiv O o
+          (interpObj I O (delta I O E M)
+            (FreeCoprodCompDisc.emptyObj I))).symm (t ⟨e, f⟩))
+      (innerHomEquiv_mk I O o (Sum.inr (Sum.inr E)) (M ∘ ULift.down))).trans
+    (Subtype.ext (funext (fun _ ↦
+      congrArg
+        (fun t ↦ (⟨fun x ↦ (e x).elim, t⟩ :
+          (interpObj I O (delta I O E M) (FreeCoprodCompDisc.emptyObj I)).1))
+        (innerHomEquivCast_fst_cast I O o E e M
+          ((FreeCoprodCompDisc.emptyObj I).2 ∘ (fun b ↦ (e b).elim))
+          (funext (fun b ↦ (e b).elim)) (funext (fun b ↦ (e b).elim)) f))))
+
+/-- The empty-push equation for the transported `ι`-composite, by
+elimination of the code equality: at the reflexive instance both sides
+compute to singleton morphisms into the initial-object fiber, related
+by `IR.homSingletonEquiv_symm_deltaEmptyInj` and the injection
+square. -/
+theorem interpHomIotaCast_deltaEmptyPush (o : O) (E : Type uB)
+    (e : E → PEmpty.{1}) (M : (E → I) → IR.{max uA uB, uB, uI, uO} I O)
+    (f : InnerHom.{uA, uB, uI, uO} I O o (M (fun x ↦ (e x).elim)))
+    (X : FreeCoprodCompDisc.{max uA uB, uI} I)
+    (ir : IR.{max uA uB, uB, uI, uO} I O)
+    (eIr : iota.{max uA uB, uB, uI, uO} I O o = ir) :
+    ((interpHomIotaCast I O o (delta I O E M) ir eIr) ⟨e, f⟩).1 X =
+      FreeCoprodCompDisc.Hom.comp O
+        (((interpHomIotaCast I O o (M (fun x ↦ (e x).elim)) ir eIr) f).1 X)
+        (deltaEmptyInj I O E e M X) :=
+  Eq.rec (motive := fun ir' eIr' ↦
+      ((interpHomIotaCast I O o (delta I O E M) ir' eIr') ⟨e, f⟩).1 X =
+        FreeCoprodCompDisc.Hom.comp O
+          (((interpHomIotaCast I O o (M (fun x ↦ (e x).elim)) ir' eIr') f).1 X)
+          (deltaEmptyInj I O E e M X))
+    ((congrArg
+        (fun t ↦ FreeCoprodCompDisc.Hom.comp O t
+          (interpMor I O (delta I O E M) (FreeCoprodCompDisc.emptyObj I) X
+            (FreeCoprodCompDisc.emptyDesc I X)))
+        (homSingletonEquiv_symm_deltaEmptyInj I O o E e M f)).trans
+      ((FreeCoprodCompDisc.Hom.comp_assoc O
+            ((FreeCoprodCompDisc.homSingletonEquiv O o
+                (interpObj I O (M (fun x ↦ (e x).elim))
+                  (FreeCoprodCompDisc.emptyObj I))).symm
+              (innerHomEquiv I O o (M (fun x ↦ (e x).elim)) f))
+            (deltaEmptyInj I O E e M (FreeCoprodCompDisc.emptyObj I))
+            (interpMor I O (delta I O E M) (FreeCoprodCompDisc.emptyObj I) X
+              (FreeCoprodCompDisc.emptyDesc I X))).trans
+          ((congrArg
+              (FreeCoprodCompDisc.Hom.comp O
+                ((FreeCoprodCompDisc.homSingletonEquiv O o
+                    (interpObj I O (M (fun x ↦ (e x).elim))
+                      (FreeCoprodCompDisc.emptyObj I))).symm
+                  (innerHomEquiv I O o (M (fun x ↦ (e x).elim)) f)))
+              (interpMor_deltaEmpty_inj I O E e M
+                (FreeCoprodCompDisc.emptyObj I) X
+                (FreeCoprodCompDisc.emptyDesc I X))).trans
+            (FreeCoprodCompDisc.Hom.comp_assoc O
+              ((FreeCoprodCompDisc.homSingletonEquiv O o
+                  (interpObj I O (M (fun x ↦ (e x).elim))
+                    (FreeCoprodCompDisc.emptyObj I))).symm
+                (innerHomEquiv I O o (M (fun x ↦ (e x).elim)) f))
+              (interpMor I O (M (fun x ↦ (e x).elim))
+                (FreeCoprodCompDisc.emptyObj I) X
+                (FreeCoprodCompDisc.emptyDesc I X))
+              (deltaEmptyInj I O E e M X)).symm)))
+    eIr
+
+/-- The `ι`-case of the `IR.deltaEmptyPush` characterization. -/
+theorem interpHom_deltaEmptyPush_mk_iota (o : O)
+    (d : Direction I O (Sum.inl o : Shape.{max uA uB, uB, uO} O) →
+      IR.{max uA uB, uB, uI, uO} I O) :
+    InterpHomDeltaEmptyPushMotive I O (mk I O (Sum.inl o) d) :=
+  fun E e M f X ↦
+    (congrArg
+        (fun t ↦ (interpHom I O (mk I O (Sum.inl o) d)
+          (delta I O E M) t).1 X)
+        (deltaEmptyPush_mk_iota I O o d E e M f)).trans
+      ((congrArg (fun eq ↦ (eq (⟨e, f⟩ :
+            InnerHom.{uA, uB, uI, uO} I O o (delta I O E M))).1 X)
+          (interpHomEquiv_mk I O (Sum.inl o) d (delta I O E M))).trans
+        ((interpHomIotaCast_deltaEmptyPush I O o E e M f X
+            (mk I O (Sum.inl o) d)
+            (mk_congr I O (Sum.inl o)
+              (funext (fun x ↦ nomatch x)) :
+                mk I O (Sum.inl o) PEmpty.elim = mk I O (Sum.inl o) d)).trans
+          (congrArg
+            (fun t ↦ FreeCoprodCompDisc.Hom.comp O t
+              (deltaEmptyInj I O E e M X))
+            (congrArg (fun eq ↦ (eq f).1 X)
+              (interpHomEquiv_mk I O (Sum.inl o) d
+                (M (fun x ↦ (e x).elim)))).symm)))
+
+/-- The `σ`-domain case of the `IR.deltaEmptyPush` characterization:
+componentwise by the inductive hypotheses, then the cotuple
+compatibility. -/
+theorem interpHom_deltaEmptyPush_mk_sigma (A : Type (max uA uB))
+    (d : Direction I O (Sum.inr (Sum.inl A) : Shape.{max uA uB, uB, uO} O) →
+      IR.{max uA uB, uB, uI, uO} I O)
+    (ih : (x : Direction I O (Sum.inr (Sum.inl A) : Shape.{max uA uB, uB, uO} O)) →
+      InterpHomDeltaEmptyPushMotive I O (d x)) :
+    InterpHomDeltaEmptyPushMotive I O (mk I O (Sum.inr (Sum.inl A)) d) :=
+  fun E e M f X ↦
+    (congrArg
+        (fun t ↦ (interpHom I O (mk I O (Sum.inr (Sum.inl A)) d)
+          (delta I O E M) t).1 X)
+        (deltaEmptyPush_mk_sigma I O A d E e M f)).trans
+      ((interpHom_sigma I O A (fun a ↦ d (ULift.up a)) (delta I O E M)
+          (fun b ↦ deltaEmptyPush I O (d (ULift.up b)) E e M (f b)) X).trans
+        ((congrArg
+            (FreeCoprodCompDisc.coprodDesc O A
+              (fun a ↦ interpObj I O (d (ULift.up a)) X)
+              (interpObj I O (delta I O E M) X))
+            (funext (fun b ↦ ih (ULift.up b) E e M (f b) X))).trans
+          ((FreeCoprodCompDisc.coprodDesc_comp O A
+              (fun a ↦ interpObj I O (d (ULift.up a)) X)
+              (interpObj I O (M (fun x ↦ (e x).elim)) X)
+              (interpObj I O (delta I O E M) X)
+              (fun b ↦ (interpHom I O (d (ULift.up b))
+                (M (fun x ↦ (e x).elim)) (f b)).1 X)
+              (deltaEmptyInj I O E e M X)).symm.trans
+            (congrArg
+              (fun t ↦ FreeCoprodCompDisc.Hom.comp O t
+                (deltaEmptyInj I O E e M X))
+              (interpHom_sigma I O A (fun a ↦ d (ULift.up a))
+                (M (fun x ↦ (e x).elim)) f X).symm))))
+
+/-- Elimination of the assignment cast in the `δ`-domain step of
+`IR.deltaEmptyPush`: composing the transported morphism's
+interpretation with the transported summand isomorphism recovers the
+untransported composite. -/
+theorem interpHom_deltaEmptySummand_cast (γ : IR.{max uA uB, uB, uI, uO} I O)
+    (E : Type uB) (e : E → PEmpty.{1})
+    (M : (E → I) → IR.{max uA uB, uB, uI, uO} I O)
+    (Q : Type uB) (q : Q → I) (X : FreeCoprodCompDisc.{max uA uB, uI} I) :
+    ∀ (a : E → I) (h : (fun x ↦ ((e x).elim : I)) = a)
+      (f : Hom.{uA, uB, uI, uO} I O γ
+        (precomp I O Q q (M (fun x ↦ (e x).elim)))),
+      FreeCoprodCompDisc.Hom.comp O
+          ((interpHom I O γ (precomp I O Q q (M a))
+            (cast (congrArg (fun a' ↦ Hom I O γ (precomp I O Q q (M a'))) h)
+              f)).1 X)
+          (FreeCoprodCompDisc.Hom.comp O
+            (FreeCoprodCompDisc.Iso.hom O (interpPrecompIso I O (M a) Q q X))
+            (FreeCoprodCompDisc.Iso.hom O
+              (FreeCoprodCompDisc.isoOfEq O
+                (congrArg
+                  (fun a' ↦ interpObj I O (M a')
+                    (FreeCoprodCompDisc.plus.{uI, uB, max uA uB} I ⟨Q, q⟩ X))
+                  h.symm)))) =
+        FreeCoprodCompDisc.Hom.comp O
+          ((interpHom I O γ (precomp I O Q q (M (fun x ↦ (e x).elim))) f).1 X)
+          (FreeCoprodCompDisc.Iso.hom O
+            (interpPrecompIso I O (M (fun x ↦ (e x).elim)) Q q X)) :=
+  fun _ h ↦
+    Eq.rec (motive := fun a' h' ↦ ∀ (f : Hom.{uA, uB, uI, uO} I O γ
+        (precomp I O Q q (M (fun x ↦ (e x).elim)))),
+        FreeCoprodCompDisc.Hom.comp O
+            ((interpHom I O γ (precomp I O Q q (M a'))
+              (cast
+                (congrArg (fun a'' ↦ Hom I O γ (precomp I O Q q (M a''))) h')
+                f)).1 X)
+            (FreeCoprodCompDisc.Hom.comp O
+              (FreeCoprodCompDisc.Iso.hom O
+                (interpPrecompIso I O (M a') Q q X))
+              (FreeCoprodCompDisc.Iso.hom O
+                (FreeCoprodCompDisc.isoOfEq O
+                  (congrArg
+                    (fun a'' ↦ interpObj I O (M a'')
+                      (FreeCoprodCompDisc.plus.{uI, uB, max uA uB} I ⟨Q, q⟩ X))
+                    h'.symm)))) =
+          FreeCoprodCompDisc.Hom.comp O
+            ((interpHom I O γ
+              (precomp I O Q q (M (fun x ↦ (e x).elim))) f).1 X)
+            (FreeCoprodCompDisc.Iso.hom O
+              (interpPrecompIso I O (M (fun x ↦ (e x).elim)) Q q X)))
+      (fun _ ↦ rfl) h
+
+/-- The transported-composite equation behind the `δ`-domain case of
+the `IR.deltaEmptyPush` characterization: the composite injection
+pushed through the Lemma 4 isomorphism and the bridge factors out of
+the transported composite. -/
+theorem interpHomDeltaSummand_deltaEmpty_theta (B : Type uB)
+    (c : (B → I) → IR.{max uA uB, uB, uI, uO} I O)
+    (E : Type uB) (e : E → PEmpty.{1})
+    (M : (E → I) → IR.{max uA uB, uB, uI, uO} I O) (i : B → I)
+    (u : Hom.{uA, uB, uI, uO} I O (c i) (precomp I O B i (delta I O E M)))
+    (w : Hom.{uA, uB, uI, uO} I O (c i)
+      (precomp I O B i (M (precompMerge I B i (fun x ↦ (e x).elim)
+        (fun z : {z : E // (fun x ↦ (e x).elim : E → B ⊕ PUnit.{uB + 1}) z =
+            Sum.inr PUnit.unit} ↦ (((e z.1).elim : PEmpty.{1}).elim : I))))))
+    (v : Hom.{uA, uB, uI, uO} I O (c i)
+      (precomp I O B i (M (fun x ↦ (e x).elim))))
+    (X : FreeCoprodCompDisc.{max uA uB, uI} I)
+    (hu : (interpHom I O (c i) (precomp I O B i (delta I O E M)) u).1 X =
+      FreeCoprodCompDisc.Hom.comp O
+        ((interpHom I O (c i)
+          (precomp I O B i (M (precompMerge I B i (fun x ↦ (e x).elim)
+            (fun z ↦ (((e z.1).elim : PEmpty.{1}).elim : I))))) w).1 X)
+        (FreeCoprodCompDisc.Hom.comp O
+          (deltaEmptyInj I O
+            {z : E // (fun x ↦ (e x).elim : E → B ⊕ PUnit.{uB + 1}) z =
+              Sum.inr PUnit.unit}
+            (fun z ↦ (e z.1).elim)
+            (fun j ↦ precomp I O B i
+              (M (precompMerge I B i (fun x ↦ (e x).elim) j)))
+            X)
+          (FreeCoprodCompDisc.coprodInj O
+            (ULift.{max uA uB} (E → B ⊕ PUnit.{uB + 1}))
+            (fun cl ↦ interpObj I O
+              (delta I O {z : E // cl.down z = Sum.inr PUnit.unit}
+                (fun j ↦ precomp I O B i
+                  (M (precompMerge I B i cl.down j)))) X)
+            (ULift.up (fun x ↦ (e x).elim)))))
+    (hv : FreeCoprodCompDisc.Hom.comp O
+        ((interpHom I O (c i)
+          (precomp I O B i (M (precompMerge I B i (fun x ↦ (e x).elim)
+            (fun z ↦ (((e z.1).elim : PEmpty.{1}).elim : I))))) w).1 X)
+        (deltaEmptySummandHom I O E e M B i X) =
+      FreeCoprodCompDisc.Hom.comp O
+        ((interpHom I O (c i)
+          (precomp I O B i (M (fun x ↦ (e x).elim))) v).1 X)
+        (FreeCoprodCompDisc.Iso.hom O
+          (interpPrecompIso I O (M (fun x ↦ (e x).elim)) B i X))) :
+    FreeCoprodCompDisc.Hom.comp O
+        (FreeCoprodCompDisc.Hom.comp O
+          ((interpHom I O (c i) (precomp I O B i (delta I O E M)) u).1 X)
+          (FreeCoprodCompDisc.Iso.hom O
+            (interpPrecompIso I O (delta I O E M) B i X)))
+        ((plusLiftBridgeNatInv I O B i (delta I O E M)).1 X) =
+      FreeCoprodCompDisc.Hom.comp O
+        (FreeCoprodCompDisc.Hom.comp O
+          (FreeCoprodCompDisc.Hom.comp O
+            ((interpHom I O (c i)
+              (precomp I O B i (M (fun x ↦ (e x).elim))) v).1 X)
+            (FreeCoprodCompDisc.Iso.hom O
+              (interpPrecompIso I O (M (fun x ↦ (e x).elim)) B i X)))
+          ((plusLiftBridgeNatInv I O B i (M (fun x ↦ (e x).elim))).1 X))
+        (deltaEmptyInj I O E e M
+          (FreeCoprodCompDisc.plus I
+            (FreeCoprodCompDisc.lift.{uB, uI, max uA uB} I ⟨B, i⟩) X)) :=
+  (congrArg
+      (fun t ↦ FreeCoprodCompDisc.Hom.comp O
+        (FreeCoprodCompDisc.Hom.comp O t
+          (FreeCoprodCompDisc.Iso.hom O
+            (interpPrecompIso I O (delta I O E M) B i X)))
+        ((plusLiftBridgeNatInv I O B i (delta I O E M)).1 X))
+      hu).trans
+    ((congrArg
+        (fun t ↦ FreeCoprodCompDisc.Hom.comp O t
+          ((plusLiftBridgeNatInv I O B i (delta I O E M)).1 X))
+        ((FreeCoprodCompDisc.Hom.comp_assoc O
+            ((interpHom I O (c i)
+              (precomp I O B i (M (precompMerge I B i (fun x ↦ (e x).elim)
+                (fun z ↦ (((e z.1).elim : PEmpty.{1}).elim : I))))) w).1 X)
+            (FreeCoprodCompDisc.Hom.comp O
+              (deltaEmptyInj I O
+                {z : E // (fun x ↦ (e x).elim : E → B ⊕ PUnit.{uB + 1}) z =
+                  Sum.inr PUnit.unit}
+                (fun z ↦ (e z.1).elim)
+                (fun j ↦ precomp I O B i
+                  (M (precompMerge I B i (fun x ↦ (e x).elim) j)))
+                X)
+              (FreeCoprodCompDisc.coprodInj O
+                (ULift.{max uA uB} (E → B ⊕ PUnit.{uB + 1}))
+                (fun cl ↦ interpObj I O
+                  (delta I O {z : E // cl.down z = Sum.inr PUnit.unit}
+                    (fun j ↦ precomp I O B i
+                      (M (precompMerge I B i cl.down j)))) X)
+                (ULift.up (fun x ↦ (e x).elim))))
+            (FreeCoprodCompDisc.Iso.hom O
+              (interpPrecompIso I O (delta I O E M) B i X))).trans
+          ((congrArg
+              (FreeCoprodCompDisc.Hom.comp O
+                ((interpHom I O (c i)
+                  (precomp I O B i (M (precompMerge I B i
+                    (fun x ↦ (e x).elim)
+                    (fun z ↦ (((e z.1).elim : PEmpty.{1}).elim : I)))))
+                  w).1 X))
+              (interpPrecompIso_deltaEmpty_inj I O E e M B i X)).trans
+            ((FreeCoprodCompDisc.Hom.comp_assoc O
+                ((interpHom I O (c i)
+                  (precomp I O B i (M (precompMerge I B i
+                    (fun x ↦ (e x).elim)
+                    (fun z ↦ (((e z.1).elim : PEmpty.{1}).elim : I)))))
+                  w).1 X)
+                (deltaEmptySummandHom I O E e M B i X)
+                (deltaEmptyInj I O E e M
+                  (FreeCoprodCompDisc.plus.{uI, uB, max uA uB} I
+                    ⟨B, i⟩ X))).symm.trans
+              (congrArg
+                (fun t ↦ FreeCoprodCompDisc.Hom.comp O t
+                  (deltaEmptyInj I O E e M
+                    (FreeCoprodCompDisc.plus.{uI, uB, max uA uB} I ⟨B, i⟩ X)))
+                hv))))).trans
+      ((FreeCoprodCompDisc.Hom.comp_assoc O
+          (FreeCoprodCompDisc.Hom.comp O
+            ((interpHom I O (c i)
+              (precomp I O B i (M (fun x ↦ (e x).elim))) v).1 X)
+            (FreeCoprodCompDisc.Iso.hom O
+              (interpPrecompIso I O (M (fun x ↦ (e x).elim)) B i X)))
+          (deltaEmptyInj I O E e M
+            (FreeCoprodCompDisc.plus.{uI, uB, max uA uB} I ⟨B, i⟩ X))
+          ((plusLiftBridgeNatInv I O B i (delta I O E M)).1 X)).trans
+        ((congrArg
+            (FreeCoprodCompDisc.Hom.comp O
+              (FreeCoprodCompDisc.Hom.comp O
+                ((interpHom I O (c i)
+                  (precomp I O B i (M (fun x ↦ (e x).elim))) v).1 X)
+                (FreeCoprodCompDisc.Iso.hom O
+                  (interpPrecompIso I O (M (fun x ↦ (e x).elim)) B i X))))
+            (interpMor_deltaEmpty_inj I O E e M
+              (FreeCoprodCompDisc.plus.{uI, uB, max uA uB} I ⟨B, i⟩ X)
+              (FreeCoprodCompDisc.plus I
+                (FreeCoprodCompDisc.lift.{uB, uI, max uA uB} I ⟨B, i⟩) X)
+              (plusLiftBridgeInvHom I B i X))).trans
+          (FreeCoprodCompDisc.Hom.comp_assoc O
+            (FreeCoprodCompDisc.Hom.comp O
+              ((interpHom I O (c i)
+                (precomp I O B i (M (fun x ↦ (e x).elim))) v).1 X)
+              (FreeCoprodCompDisc.Iso.hom O
+                (interpPrecompIso I O (M (fun x ↦ (e x).elim)) B i X)))
+            ((plusLiftBridgeNatInv I O B i (M (fun x ↦ (e x).elim))).1 X)
+            (deltaEmptyInj I O E e M
+              (FreeCoprodCompDisc.plus I
+                (FreeCoprodCompDisc.lift.{uB, uI, max uA uB} I ⟨B, i⟩)
+                X))).symm)))
+
+/-- The per-summand transport of the empty-summand inclusion through
+the `δ`-case target transports, given the summand's own push and cast
+equations. -/
+theorem interpHomDeltaSummand_deltaEmptyInj (B : Type uB)
+    (c : (B → I) → IR.{max uA uB, uB, uI, uO} I O)
+    (E : Type uB) (e : E → PEmpty.{1})
+    (M : (E → I) → IR.{max uA uB, uB, uI, uO} I O) (i : B → I)
+    (u : Hom.{uA, uB, uI, uO} I O (c i) (precomp I O B i (delta I O E M)))
+    (w : Hom.{uA, uB, uI, uO} I O (c i)
+      (precomp I O B i (M (precompMerge I B i (fun x ↦ (e x).elim)
+        (fun z : {z : E // (fun x ↦ (e x).elim : E → B ⊕ PUnit.{uB + 1}) z =
+            Sum.inr PUnit.unit} ↦ (((e z.1).elim : PEmpty.{1}).elim : I))))))
+    (v : Hom.{uA, uB, uI, uO} I O (c i)
+      (precomp I O B i (M (fun x ↦ (e x).elim))))
+    (X : FreeCoprodCompDisc.{max uA uB, uI} I)
+    (hu : (interpHom I O (c i) (precomp I O B i (delta I O E M)) u).1 X =
+      FreeCoprodCompDisc.Hom.comp O
+        ((interpHom I O (c i)
+          (precomp I O B i (M (precompMerge I B i (fun x ↦ (e x).elim)
+            (fun z ↦ (((e z.1).elim : PEmpty.{1}).elim : I))))) w).1 X)
+        (FreeCoprodCompDisc.Hom.comp O
+          (deltaEmptyInj I O
+            {z : E // (fun x ↦ (e x).elim : E → B ⊕ PUnit.{uB + 1}) z =
+              Sum.inr PUnit.unit}
+            (fun z ↦ (e z.1).elim)
+            (fun j ↦ precomp I O B i
+              (M (precompMerge I B i (fun x ↦ (e x).elim) j)))
+            X)
+          (FreeCoprodCompDisc.coprodInj O
+            (ULift.{max uA uB} (E → B ⊕ PUnit.{uB + 1}))
+            (fun cl ↦ interpObj I O
+              (delta I O {z : E // cl.down z = Sum.inr PUnit.unit}
+                (fun j ↦ precomp I O B i
+                  (M (precompMerge I B i cl.down j)))) X)
+            (ULift.up (fun x ↦ (e x).elim)))))
+    (hv : FreeCoprodCompDisc.Hom.comp O
+        ((interpHom I O (c i)
+          (precomp I O B i (M (precompMerge I B i (fun x ↦ (e x).elim)
+            (fun z ↦ (((e z.1).elim : PEmpty.{1}).elim : I))))) w).1 X)
+        (deltaEmptySummandHom I O E e M B i X) =
+      FreeCoprodCompDisc.Hom.comp O
+        ((interpHom I O (c i)
+          (precomp I O B i (M (fun x ↦ (e x).elim))) v).1 X)
+        (FreeCoprodCompDisc.Iso.hom O
+          (interpPrecompIso I O (M (fun x ↦ (e x).elim)) B i X))) :
+    (interpHomDeltaSummand I O B c (delta I O E M) i u).1 X =
+      FreeCoprodCompDisc.Hom.comp O
+        ((interpHomDeltaSummand I O B c (M (fun x ↦ (e x).elim)) i v).1 X)
+        (deltaEmptyInj I O E e M X) :=
+  (congrArg
+      (FreeCoprodCompDisc.coprodDesc O
+        (FreeCoprodCompDisc.Hom I
+          (FreeCoprodCompDisc.lift.{uB, uI, max uA uB} I ⟨B, i⟩) X)
+        (fun _ ↦ interpObj I O (c i) X)
+        (interpObj I O (delta I O E M) X))
+      (funext (fun e' ↦
+        (congrArg
+            (fun t ↦ FreeCoprodCompDisc.Hom.comp O t
+              (interpMor I O (delta I O E M)
+                (FreeCoprodCompDisc.plus I
+                  (FreeCoprodCompDisc.lift.{uB, uI, max uA uB} I ⟨B, i⟩) X)
+                X
+                (FreeCoprodCompDisc.coprodPairDesc I e'
+                  (FreeCoprodCompDisc.Hom.id I X))))
+            (interpHomDeltaSummand_deltaEmpty_theta I O B c E e M i u w v X
+              hu hv)).trans
+          ((FreeCoprodCompDisc.Hom.comp_assoc O
+              (FreeCoprodCompDisc.Hom.comp O
+                (FreeCoprodCompDisc.Hom.comp O
+                  ((interpHom I O (c i)
+                    (precomp I O B i (M (fun x ↦ (e x).elim))) v).1 X)
+                  (FreeCoprodCompDisc.Iso.hom O
+                    (interpPrecompIso I O (M (fun x ↦ (e x).elim)) B i X)))
+                ((plusLiftBridgeNatInv I O B i
+                  (M (fun x ↦ (e x).elim))).1 X))
+              (deltaEmptyInj I O E e M
+                (FreeCoprodCompDisc.plus I
+                  (FreeCoprodCompDisc.lift.{uB, uI, max uA uB} I ⟨B, i⟩) X))
+              (interpMor I O (delta I O E M)
+                (FreeCoprodCompDisc.plus I
+                  (FreeCoprodCompDisc.lift.{uB, uI, max uA uB} I ⟨B, i⟩) X)
+                X
+                (FreeCoprodCompDisc.coprodPairDesc I e'
+                  (FreeCoprodCompDisc.Hom.id I X)))).trans
+            ((congrArg
+                (FreeCoprodCompDisc.Hom.comp O
+                  (FreeCoprodCompDisc.Hom.comp O
+                    (FreeCoprodCompDisc.Hom.comp O
+                      ((interpHom I O (c i)
+                        (precomp I O B i (M (fun x ↦ (e x).elim))) v).1 X)
+                      (FreeCoprodCompDisc.Iso.hom O
+                        (interpPrecompIso I O (M (fun x ↦ (e x).elim))
+                          B i X)))
+                    ((plusLiftBridgeNatInv I O B i
+                      (M (fun x ↦ (e x).elim))).1 X)))
+                (interpMor_deltaEmpty_inj I O E e M
+                  (FreeCoprodCompDisc.plus I
+                    (FreeCoprodCompDisc.lift.{uB, uI, max uA uB} I ⟨B, i⟩) X)
+                  X
+                  (FreeCoprodCompDisc.coprodPairDesc I e'
+                    (FreeCoprodCompDisc.Hom.id I X)))).trans
+              (FreeCoprodCompDisc.Hom.comp_assoc O
+                (FreeCoprodCompDisc.Hom.comp O
+                  (FreeCoprodCompDisc.Hom.comp O
+                    ((interpHom I O (c i)
+                      (precomp I O B i (M (fun x ↦ (e x).elim))) v).1 X)
+                    (FreeCoprodCompDisc.Iso.hom O
+                      (interpPrecompIso I O (M (fun x ↦ (e x).elim)) B i X)))
+                  ((plusLiftBridgeNatInv I O B i
+                    (M (fun x ↦ (e x).elim))).1 X))
+                (interpMor I O (M (fun x ↦ (e x).elim))
+                  (FreeCoprodCompDisc.plus I
+                    (FreeCoprodCompDisc.lift.{uB, uI, max uA uB} I ⟨B, i⟩) X)
+                  X
+                  (FreeCoprodCompDisc.coprodPairDesc I e'
+                    (FreeCoprodCompDisc.Hom.id I X)))
+                (deltaEmptyInj I O E e M X)).symm))))).trans
+    (FreeCoprodCompDisc.coprodDesc_comp O
+        (FreeCoprodCompDisc.Hom I
+          (FreeCoprodCompDisc.lift.{uB, uI, max uA uB} I ⟨B, i⟩) X)
+        (fun _ ↦ interpObj I O (c i) X)
+        (interpObj I O (M (fun x ↦ (e x).elim)) X)
+        (interpObj I O (delta I O E M) X)
+        (fun e' ↦ FreeCoprodCompDisc.Hom.comp O
+          (FreeCoprodCompDisc.Hom.comp O
+            (FreeCoprodCompDisc.Hom.comp O
+              ((interpHom I O (c i)
+                (precomp I O B i (M (fun x ↦ (e x).elim))) v).1 X)
+              (FreeCoprodCompDisc.Iso.hom O
+                (interpPrecompIso I O (M (fun x ↦ (e x).elim)) B i X)))
+            ((plusLiftBridgeNatInv I O B i (M (fun x ↦ (e x).elim))).1 X))
+          (interpMor I O (M (fun x ↦ (e x).elim))
+            (FreeCoprodCompDisc.plus I
+              (FreeCoprodCompDisc.lift.{uB, uI, max uA uB} I ⟨B, i⟩) X) X
+            (FreeCoprodCompDisc.coprodPairDesc I e'
+              (FreeCoprodCompDisc.Hom.id I X))))
+        (deltaEmptyInj I O E e M X)).symm
+
+/-- The `δ`-domain case of the `IR.deltaEmptyPush` characterization. -/
+theorem interpHom_deltaEmptyPush_mk_delta (B : Type uB)
+    (d : Direction I O (Sum.inr (Sum.inr B) : Shape.{max uA uB, uB, uO} O) →
+      IR.{max uA uB, uB, uI, uO} I O)
+    (ih : (x : Direction I O (Sum.inr (Sum.inr B) : Shape.{max uA uB, uB, uO} O)) →
+      InterpHomDeltaEmptyPushMotive I O (d x)) :
+    InterpHomDeltaEmptyPushMotive I O (mk I O (Sum.inr (Sum.inr B)) d) :=
+  fun E e M f X ↦
+    (congrArg
+        (fun t ↦ (interpHom I O (mk I O (Sum.inr (Sum.inr B)) d)
+          (delta I O E M) t).1 X)
+        (deltaEmptyPush_mk_delta I O B d E e M f)).trans
+      ((interpHom_delta I O B (fun j ↦ d (ULift.up j)) (delta I O E M)
+          (fun i ↦ sigmaPush I O (d (ULift.up i))
+            (ULift.{max uA uB} (E → B ⊕ PUnit.{uB + 1}))
+            (fun cl ↦ delta I O {z : E // cl.down z = Sum.inr PUnit.unit}
+              (fun j ↦ precomp I O B i (M (precompMerge I B i cl.down j))))
+            (ULift.up (fun x ↦ (e x).elim))
+            (deltaEmptyPush I O (d (ULift.up i))
+              {z : E // (fun x ↦ (e x).elim) z = Sum.inr PUnit.unit}
+              (fun z ↦ (e z.1).elim)
+              (fun j ↦ precomp I O B i
+                (M (precompMerge I B i (fun x ↦ (e x).elim) j)))
+              (cast (congrArg
+                (fun a ↦ Hom I O (d (ULift.up i)) (precomp I O B i (M a)))
+                (funext (fun x ↦ (e x).elim) :
+                  (fun x ↦ (e x).elim) = precompMerge I B i
+                    (fun x ↦ (e x).elim)
+                    (fun z : {z : E // (fun x ↦ (e x).elim) z =
+                        Sum.inr PUnit.unit}
+                      ↦ ((e z.1).elim : PEmpty.{1}).elim)))
+                (f i)))) X).trans
+        ((congrArg
+            (deltaDesc I O B (fun j ↦ d (ULift.up j)) X
+              (interpObj I O (delta I O E M) X))
+            (funext (fun i ↦
+              interpHomDeltaSummand_deltaEmptyInj I O B
+                (fun j ↦ d (ULift.up j)) E e M i
+                (sigmaPush I O (d (ULift.up i))
+                  (ULift.{max uA uB} (E → B ⊕ PUnit.{uB + 1}))
+                  (fun cl ↦ delta I O
+                    {z : E // cl.down z = Sum.inr PUnit.unit}
+                    (fun j ↦ precomp I O B i
+                      (M (precompMerge I B i cl.down j))))
+                  (ULift.up (fun x ↦ (e x).elim))
+                  (deltaEmptyPush I O (d (ULift.up i))
+                    {z : E // (fun x ↦ (e x).elim) z = Sum.inr PUnit.unit}
+                    (fun z ↦ (e z.1).elim)
+                    (fun j ↦ precomp I O B i
+                      (M (precompMerge I B i (fun x ↦ (e x).elim) j)))
+                    (cast (congrArg
+                      (fun a ↦ Hom I O (d (ULift.up i))
+                        (precomp I O B i (M a)))
+                      (funext (fun x ↦ (e x).elim) :
+                        (fun x ↦ (e x).elim) = precompMerge I B i
+                          (fun x ↦ (e x).elim)
+                          (fun z : {z : E // (fun x ↦ (e x).elim) z =
+                              Sum.inr PUnit.unit}
+                            ↦ ((e z.1).elim : PEmpty.{1}).elim)))
+                      (f i))))
+                (cast (congrArg
+                  (fun a ↦ Hom I O (d (ULift.up i))
+                    (precomp I O B i (M a)))
+                  (funext (fun x ↦ (e x).elim) :
+                    (fun x ↦ (e x).elim) = precompMerge I B i
+                      (fun x ↦ (e x).elim)
+                      (fun z : {z : E // (fun x ↦ (e x).elim) z =
+                          Sum.inr PUnit.unit}
+                        ↦ ((e z.1).elim : PEmpty.{1}).elim)))
+                  (f i))
+                (f i) X
+                ((interpHom_sigmaPush I O (d (ULift.up i))
+                    (ULift.{max uA uB} (E → B ⊕ PUnit.{uB + 1}))
+                    (fun cl ↦ delta I O
+                      {z : E // cl.down z = Sum.inr PUnit.unit}
+                      (fun j ↦ precomp I O B i
+                        (M (precompMerge I B i cl.down j))))
+                    (ULift.up (fun x ↦ (e x).elim))
+                    (deltaEmptyPush I O (d (ULift.up i))
+                      {z : E // (fun x ↦ (e x).elim) z = Sum.inr PUnit.unit}
+                      (fun z ↦ (e z.1).elim)
+                      (fun j ↦ precomp I O B i
+                        (M (precompMerge I B i (fun x ↦ (e x).elim) j)))
+                      (cast (congrArg
+                        (fun a ↦ Hom I O (d (ULift.up i))
+                          (precomp I O B i (M a)))
+                        (funext (fun x ↦ (e x).elim) :
+                          (fun x ↦ (e x).elim) = precompMerge I B i
+                            (fun x ↦ (e x).elim)
+                            (fun z : {z : E // (fun x ↦ (e x).elim) z =
+                                Sum.inr PUnit.unit}
+                              ↦ ((e z.1).elim : PEmpty.{1}).elim)))
+                        (f i))) X).trans
+                  ((congrArg
+                      (fun t ↦ FreeCoprodCompDisc.Hom.comp O t
+                        (FreeCoprodCompDisc.coprodInj O
+                          (ULift.{max uA uB} (E → B ⊕ PUnit.{uB + 1}))
+                          (fun cl ↦ interpObj I O
+                            (delta I O
+                              {z : E // cl.down z = Sum.inr PUnit.unit}
+                              (fun j ↦ precomp I O B i
+                                (M (precompMerge I B i cl.down j)))) X)
+                          (ULift.up (fun x ↦ (e x).elim))))
+                      (ih (ULift.up i)
+                        {z : E // (fun x ↦ (e x).elim :
+                          E → B ⊕ PUnit.{uB + 1}) z = Sum.inr PUnit.unit}
+                        (fun z ↦ (e z.1).elim)
+                        (fun j ↦ precomp I O B i
+                          (M (precompMerge I B i (fun x ↦ (e x).elim) j)))
+                        (cast (congrArg
+                          (fun a ↦ Hom I O (d (ULift.up i))
+                            (precomp I O B i (M a)))
+                          (funext (fun x ↦ (e x).elim) :
+                            (fun x ↦ (e x).elim) = precompMerge I B i
+                              (fun x ↦ (e x).elim)
+                              (fun z : {z : E // (fun x ↦ (e x).elim) z =
+                                  Sum.inr PUnit.unit}
+                                ↦ ((e z.1).elim : PEmpty.{1}).elim)))
+                          (f i))
+                        X)).trans
+                    (FreeCoprodCompDisc.Hom.comp_assoc O
+                      ((interpHom I O (d (ULift.up i))
+                        (precomp I O B i (M (precompMerge I B i
+                          (fun x ↦ (e x).elim)
+                          (fun z ↦ (((e z.1).elim : PEmpty.{1}).elim : I)))))
+                        (cast (congrArg
+                          (fun a ↦ Hom I O (d (ULift.up i))
+                            (precomp I O B i (M a)))
+                          (funext (fun x ↦ (e x).elim) :
+                            (fun x ↦ (e x).elim) = precompMerge I B i
+                              (fun x ↦ (e x).elim)
+                              (fun z : {z : E // (fun x ↦ (e x).elim) z =
+                                  Sum.inr PUnit.unit}
+                                ↦ ((e z.1).elim : PEmpty.{1}).elim)))
+                          (f i))).1 X)
+                      (deltaEmptyInj I O
+                        {z : E // (fun x ↦ (e x).elim :
+                          E → B ⊕ PUnit.{uB + 1}) z = Sum.inr PUnit.unit}
+                        (fun z ↦ (e z.1).elim)
+                        (fun j ↦ precomp I O B i
+                          (M (precompMerge I B i (fun x ↦ (e x).elim) j)))
+                        X)
+                      (FreeCoprodCompDisc.coprodInj O
+                        (ULift.{max uA uB} (E → B ⊕ PUnit.{uB + 1}))
+                        (fun cl ↦ interpObj I O
+                          (delta I O
+                            {z : E // cl.down z = Sum.inr PUnit.unit}
+                            (fun j ↦ precomp I O B i
+                              (M (precompMerge I B i cl.down j)))) X)
+                        (ULift.up (fun x ↦ (e x).elim))))))
+                (interpHom_deltaEmptySummand_cast I O (d (ULift.up i))
+                  E e M B i X
+                  (precompMerge I B i (fun x ↦ (e x).elim)
+                    (fun z ↦ (((e z.1).elim : PEmpty.{1}).elim : I)))
+                  (funext (fun x ↦ (e x).elim))
+                  (f i))))).trans
+          ((deltaDesc_comp I O B (fun j ↦ d (ULift.up j)) X
+              (interpObj I O (M (fun x ↦ (e x).elim)) X)
+              (interpObj I O (delta I O E M) X)
+              (fun i ↦ (interpHomDeltaSummand I O B (fun j ↦ d (ULift.up j))
+                (M (fun x ↦ (e x).elim)) i (f i)).1 X)
+              (deltaEmptyInj I O E e M X)).symm.trans
+            (congrArg
+              (fun t ↦ FreeCoprodCompDisc.Hom.comp O t
+                (deltaEmptyInj I O E e M X))
+              (interpHom_delta I O B (fun j ↦ d (ULift.up j))
+                (M (fun x ↦ (e x).elim)) f X).symm))))
+
+/-- `IR.interpHom` sends `IR.deltaEmptyPush` to composition with the
+semantic empty-summand inclusion, by `IR.induction`. -/
+theorem interpHom_deltaEmptyPush (γ : IR.{max uA uB, uB, uI, uO} I O) :
+    InterpHomDeltaEmptyPushMotive I O γ :=
+  induction I O (InterpHomDeltaEmptyPushMotive I O)
+    (fun s ↦ match s with
+      | Sum.inl o => fun d _ ↦ interpHom_deltaEmptyPush_mk_iota I O o d
+      | Sum.inr (Sum.inl A) => fun d ih ↦
+          interpHom_deltaEmptyPush_mk_sigma I O A d ih
+      | Sum.inr (Sum.inr B) => fun d ih ↦
+          interpHom_deltaEmptyPush_mk_delta I O B d ih)
+    γ
+
+/-! ### The navigation characterizations -/
+
+/-- Cancellation through an isomorphism: a factorization through the
+forward component determines the factorization through the inverse. -/
+theorem eq_comp_invHom (V Y Z : FreeCoprodCompDisc.{uA, uO} O)
+    (f : FreeCoprodCompDisc.Hom O V Y) (g : FreeCoprodCompDisc.Hom O V Z)
+    (e : FreeCoprodCompDisc.Iso O Y Z)
+    (h : FreeCoprodCompDisc.Hom.comp O f (FreeCoprodCompDisc.Iso.hom O e) = g) :
+    f = FreeCoprodCompDisc.Hom.comp O g (FreeCoprodCompDisc.Iso.invHom O e) :=
+  (FreeCoprodCompDisc.Hom.comp_id O f).symm.trans
+    ((congrArg (FreeCoprodCompDisc.Hom.comp O f)
+        (FreeCoprodCompDisc.Iso.hom_invHom O e).symm).trans
+      ((FreeCoprodCompDisc.Hom.comp_assoc O f (FreeCoprodCompDisc.Iso.hom O e)
+          (FreeCoprodCompDisc.Iso.invHom O e)).symm.trans
+        (congrArg
+          (fun t ↦ FreeCoprodCompDisc.Hom.comp O t
+            (FreeCoprodCompDisc.Iso.invHom O e))
+          h)))
+
+/-- The `IR.msigmaPush` characterization: `IR.interpHom` sends a stack
+`σ`-push to the composite with the semantic `σ`-injection conjugated
+through the iterated Lemma 4 isomorphism. -/
+theorem interpHom_msigmaPush (D : IR.{max uA uB, uB, uI, uO} I O)
+    (A' : Type (max uA uB)) (K' : A' → IR.{max uA uB, uB, uI, uO} I O) (a' : A')
+    (L : List (SupObj.{uB, uI} I))
+    (f : Hom.{uA, uB, uI, uO} I O D (mprecomp I O L (K' a')))
+    (X : FreeCoprodCompDisc.{max uA uB, uI} I) :
+    (interpHom I O D (mprecomp I O L (sigma I O A' K'))
+        (msigmaPush I O D A' K' a' L f)).1 X =
+      FreeCoprodCompDisc.Hom.comp O
+        ((interpHom I O D (mprecomp I O L (K' a')) f).1 X)
+        (FreeCoprodCompDisc.Hom.comp O
+          (FreeCoprodCompDisc.Hom.comp O
+            (FreeCoprodCompDisc.Iso.hom O
+              (mprecompIso.{uA, uB, uI, uO} I O L (K' a') X))
+            (FreeCoprodCompDisc.coprodInj O A'
+              (fun a ↦ interpObj I O (K' a) (mplus.{uA, uB, uI} I L X)) a'))
+          (FreeCoprodCompDisc.Iso.invHom O
+            (mprecompIso.{uA, uB, uI, uO} I O L (sigma I O A' K') X))) :=
+  L.rec (motive := fun L' ↦ ∀ (A'' : Type (max uA uB))
+      (K'' : A'' → IR.{max uA uB, uB, uI, uO} I O) (a'' : A'')
+      (f' : Hom.{uA, uB, uI, uO} I O D (mprecomp I O L' (K'' a'')))
+      (X' : FreeCoprodCompDisc.{max uA uB, uI} I),
+      (interpHom I O D (mprecomp I O L' (sigma I O A'' K''))
+          (msigmaPush I O D A'' K'' a'' L' f')).1 X' =
+        FreeCoprodCompDisc.Hom.comp O
+          ((interpHom I O D (mprecomp I O L' (K'' a'')) f').1 X')
+          (FreeCoprodCompDisc.Hom.comp O
+            (FreeCoprodCompDisc.Hom.comp O
+              (FreeCoprodCompDisc.Iso.hom O
+                (mprecompIso.{uA, uB, uI, uO} I O L' (K'' a'') X'))
+              (FreeCoprodCompDisc.coprodInj O A''
+                (fun a ↦ interpObj I O (K'' a) (mplus.{uA, uB, uI} I L' X'))
+                a''))
+            (FreeCoprodCompDisc.Iso.invHom O
+              (mprecompIso.{uA, uB, uI, uO} I O L' (sigma I O A'' K'') X'))))
+    (fun A'' K'' a'' f' X' ↦ interpHom_sigmaPush I O D A'' K'' a'' f' X')
+    (fun b _L ih A'' K'' a'' f' X' ↦
+      (ih (ULift.{uB} A'') (fun x ↦ precomp I O b.1 b.2 (K'' x.down))
+          (ULift.up a'') f' X').trans
+        (congrArg
+          (FreeCoprodCompDisc.Hom.comp O
+            ((interpHom I O D
+              (mprecomp I O _L (precomp I O b.1 b.2 (K'' a''))) f').1 X'))
+          ((congrArg
+              (fun t ↦ FreeCoprodCompDisc.Hom.comp O
+                (FreeCoprodCompDisc.Hom.comp O
+                  (FreeCoprodCompDisc.Iso.hom O
+                    (mprecompIso.{uA, uB, uI, uO} I O _L
+                      (precomp I O b.1 b.2 (K'' a'')) X'))
+                  t)
+                (FreeCoprodCompDisc.Iso.invHom O
+                  (mprecompIso.{uA, uB, uI, uO} I O _L
+                    (precomp I O b.1 b.2 (sigma I O A'' K'')) X')))
+              (eq_comp_invHom O
+                (interpObj I O (precomp I O b.1 b.2 (K'' a''))
+                  (mplus.{uA, uB, uI} I _L X'))
+                (interpObj I O (precomp I O b.1 b.2 (sigma I O A'' K''))
+                  (mplus.{uA, uB, uI} I _L X'))
+                (interpObj I O (sigma I O A'' K'')
+                  (FreeCoprodCompDisc.plus.{uI, uB, max uA uB} I b
+                    (mplus.{uA, uB, uI} I _L X')))
+                (FreeCoprodCompDisc.coprodInj O (ULift.{uB} A'')
+                  (fun x ↦ interpObj I O (precomp I O b.1 b.2 (K'' x.down))
+                    (mplus.{uA, uB, uI} I _L X'))
+                  (ULift.up a''))
+                (FreeCoprodCompDisc.Hom.comp O
+                  (FreeCoprodCompDisc.Iso.hom O
+                    (interpPrecompIso I O (K'' a'') b.1 b.2
+                      (mplus.{uA, uB, uI} I _L X')))
+                  (FreeCoprodCompDisc.coprodInj O A''
+                    (fun a ↦ interpObj I O (K'' a)
+                      (FreeCoprodCompDisc.plus.{uI, uB, max uA uB} I b
+                        (mplus.{uA, uB, uI} I _L X')))
+                    a''))
+                (interpPrecompIso I O (sigma I O A'' K'') b.1 b.2
+                  (mplus.{uA, uB, uI} I _L X'))
+                (interpPrecompIso_sigma_inj I O A'' K'' a'' b.1 b.2
+                  (mplus.{uA, uB, uI} I _L X')))).trans
+            ((FreeCoprodCompDisc.Hom.comp_assoc O
+                (FreeCoprodCompDisc.Iso.hom O
+                  (mprecompIso.{uA, uB, uI, uO} I O _L
+                    (precomp I O b.1 b.2 (K'' a'')) X'))
+                (FreeCoprodCompDisc.Hom.comp O
+                  (FreeCoprodCompDisc.Hom.comp O
+                    (FreeCoprodCompDisc.Iso.hom O
+                      (interpPrecompIso I O (K'' a'') b.1 b.2
+                        (mplus.{uA, uB, uI} I _L X')))
+                    (FreeCoprodCompDisc.coprodInj O A''
+                      (fun a ↦ interpObj I O (K'' a)
+                        (FreeCoprodCompDisc.plus.{uI, uB, max uA uB} I b
+                          (mplus.{uA, uB, uI} I _L X')))
+                      a''))
+                  (FreeCoprodCompDisc.Iso.invHom O
+                    (interpPrecompIso I O (sigma I O A'' K'') b.1 b.2
+                      (mplus.{uA, uB, uI} I _L X'))))
+                (FreeCoprodCompDisc.Iso.invHom O
+                  (mprecompIso.{uA, uB, uI, uO} I O _L
+                    (precomp I O b.1 b.2 (sigma I O A'' K'')) X'))).trans
+              ((congrArg
+                  (FreeCoprodCompDisc.Hom.comp O
+                    (FreeCoprodCompDisc.Iso.hom O
+                      (mprecompIso.{uA, uB, uI, uO} I O _L
+                        (precomp I O b.1 b.2 (K'' a'')) X')))
+                  (FreeCoprodCompDisc.Hom.comp_assoc O
+                    (FreeCoprodCompDisc.Hom.comp O
+                      (FreeCoprodCompDisc.Iso.hom O
+                        (interpPrecompIso I O (K'' a'') b.1 b.2
+                          (mplus.{uA, uB, uI} I _L X')))
+                      (FreeCoprodCompDisc.coprodInj O A''
+                        (fun a ↦ interpObj I O (K'' a)
+                          (FreeCoprodCompDisc.plus.{uI, uB, max uA uB} I b
+                            (mplus.{uA, uB, uI} I _L X')))
+                        a''))
+                    (FreeCoprodCompDisc.Iso.invHom O
+                      (interpPrecompIso I O (sigma I O A'' K'') b.1 b.2
+                        (mplus.{uA, uB, uI} I _L X')))
+                    (FreeCoprodCompDisc.Iso.invHom O
+                      (mprecompIso.{uA, uB, uI, uO} I O _L
+                        (precomp I O b.1 b.2 (sigma I O A'' K'')) X')))).trans
+                ((FreeCoprodCompDisc.Hom.comp_assoc O
+                    (FreeCoprodCompDisc.Iso.hom O
+                      (mprecompIso.{uA, uB, uI, uO} I O _L
+                        (precomp I O b.1 b.2 (K'' a'')) X'))
+                    (FreeCoprodCompDisc.Hom.comp O
+                      (FreeCoprodCompDisc.Iso.hom O
+                        (interpPrecompIso I O (K'' a'') b.1 b.2
+                          (mplus.{uA, uB, uI} I _L X')))
+                      (FreeCoprodCompDisc.coprodInj O A''
+                        (fun a ↦ interpObj I O (K'' a)
+                          (FreeCoprodCompDisc.plus.{uI, uB, max uA uB} I b
+                            (mplus.{uA, uB, uI} I _L X')))
+                        a''))
+                    (FreeCoprodCompDisc.Hom.comp O
+                      (FreeCoprodCompDisc.Iso.invHom O
+                        (interpPrecompIso I O (sigma I O A'' K'') b.1 b.2
+                          (mplus.{uA, uB, uI} I _L X')))
+                      (FreeCoprodCompDisc.Iso.invHom O
+                        (mprecompIso.{uA, uB, uI, uO} I O _L
+                          (precomp I O b.1 b.2 (sigma I O A'' K'')) X')))).symm.trans
+                  (congrArg
+                    (fun t ↦ FreeCoprodCompDisc.Hom.comp O t
+                      (FreeCoprodCompDisc.Hom.comp O
+                        (FreeCoprodCompDisc.Iso.invHom O
+                          (interpPrecompIso I O (sigma I O A'' K'') b.1 b.2
+                            (mplus.{uA, uB, uI} I _L X')))
+                        (FreeCoprodCompDisc.Iso.invHom O
+                          (mprecompIso.{uA, uB, uI, uO} I O _L
+                            (precomp I O b.1 b.2 (sigma I O A'' K'')) X'))))
+                    (FreeCoprodCompDisc.Hom.comp_assoc O
+                      (FreeCoprodCompDisc.Iso.hom O
+                        (mprecompIso.{uA, uB, uI, uO} I O _L
+                          (precomp I O b.1 b.2 (K'' a'')) X'))
+                      (FreeCoprodCompDisc.Iso.hom O
+                        (interpPrecompIso I O (K'' a'') b.1 b.2
+                          (mplus.{uA, uB, uI} I _L X')))
+                      (FreeCoprodCompDisc.coprodInj O A''
+                        (fun a ↦ interpObj I O (K'' a)
+                          (FreeCoprodCompDisc.plus.{uI, uB, max uA uB} I b
+                            (mplus.{uA, uB, uI} I _L X')))
+                        a'')).symm)))))))
+    A' K' a' f X
+
+/-- The `IR.deltaNavBase` characterization: `IR.interpHom` sends the
+base navigation to the composite with the empty-summand inclusion at
+the all-resolved classifier's unresolved subtype, followed by the
+semantic `σ`-injection at that classifier. -/
+theorem interpHom_deltaNavBase (D : IR.{max uA uB, uB, uI, uO} I O)
+    (Bout : Type uB) (iout : Bout → I) (Bin : Type uB)
+    (K : (Bin → I) → IR.{max uA uB, uB, uI, uO} I O) (g : Bin → Bout)
+    (f : Hom.{uA, uB, uI, uO} I O D (precomp I O Bout iout (K (iout ∘ g))))
+    (X : FreeCoprodCompDisc.{max uA uB, uI} I) :
+    (interpHom I O D (precomp I O Bout iout (delta I O Bin K))
+        (deltaNavBase I O D Bout iout Bin K g f)).1 X =
+      FreeCoprodCompDisc.Hom.comp O
+        ((interpHom I O D (precomp I O Bout iout (K (iout ∘ g))) f).1 X)
+        (FreeCoprodCompDisc.Hom.comp O
+          (deltaEmptyInj I O
+            {z : Bin // (fun b ↦ Sum.inl (g b) : Bin → Bout ⊕ PUnit.{uB + 1}) z =
+              Sum.inr PUnit.unit}
+            (fun z ↦ nomatch z.2)
+            (fun j ↦ precomp I O Bout iout
+              (K (precompMerge I Bout iout (fun b ↦ Sum.inl (g b)) j)))
+            X)
+          (FreeCoprodCompDisc.coprodInj O
+            (ULift.{max uA uB} (Bin → Bout ⊕ PUnit.{uB + 1}))
+            (fun cl ↦ interpObj I O
+              (delta I O {z : Bin // cl.down z = Sum.inr PUnit.unit}
+                (fun j ↦ precomp I O Bout iout
+                  (K (precompMerge I Bout iout cl.down j)))) X)
+            (ULift.up (fun b ↦ Sum.inl (g b))))) :=
+  (interpHom_sigmaPush I O D (ULift.{max uA uB} (Bin → Bout ⊕ PUnit.{uB + 1}))
+      (fun cl ↦ delta I O {z : Bin // cl.down z = Sum.inr PUnit.unit}
+        (fun j ↦ precomp I O Bout iout
+          (K (precompMerge I Bout iout cl.down j))))
+      (ULift.up (fun b ↦ Sum.inl (g b)))
+      (deltaEmptyPush I O D
+        {z : Bin // (fun b ↦ Sum.inl (g b) : Bin → Bout ⊕ PUnit.{uB + 1}) z =
+          Sum.inr PUnit.unit}
+        (fun z ↦ nomatch z.2)
+        (fun j ↦ precomp I O Bout iout
+          (K (precompMerge I Bout iout (fun b ↦ Sum.inl (g b)) j)))
+        f)
+      X).trans
+    ((congrArg
+        (fun t ↦ FreeCoprodCompDisc.Hom.comp O t
+          (FreeCoprodCompDisc.coprodInj O
+            (ULift.{max uA uB} (Bin → Bout ⊕ PUnit.{uB + 1}))
+            (fun cl ↦ interpObj I O
+              (delta I O {z : Bin // cl.down z = Sum.inr PUnit.unit}
+                (fun j ↦ precomp I O Bout iout
+                  (K (precompMerge I Bout iout cl.down j)))) X)
+            (ULift.up (fun b ↦ Sum.inl (g b)))))
+        (interpHom_deltaEmptyPush I O D
+          {z : Bin // (fun b ↦ Sum.inl (g b) : Bin → Bout ⊕ PUnit.{uB + 1}) z =
+            Sum.inr PUnit.unit}
+          (fun z ↦ nomatch z.2)
+          (fun j ↦ precomp I O Bout iout
+            (K (precompMerge I Bout iout (fun b ↦ Sum.inl (g b)) j)))
+          f X)).trans
+      (FreeCoprodCompDisc.Hom.comp_assoc O
+        ((interpHom I O D (precomp I O Bout iout (K (iout ∘ g))) f).1 X)
+        (deltaEmptyInj I O
+          {z : Bin // (fun b ↦ Sum.inl (g b) : Bin → Bout ⊕ PUnit.{uB + 1}) z =
+            Sum.inr PUnit.unit}
+          (fun z ↦ nomatch z.2)
+          (fun j ↦ precomp I O Bout iout
+            (K (precompMerge I Bout iout (fun b ↦ Sum.inl (g b)) j)))
+          X)
+        (FreeCoprodCompDisc.coprodInj O
+          (ULift.{max uA uB} (Bin → Bout ⊕ PUnit.{uB + 1}))
+          (fun cl ↦ interpObj I O
+            (delta I O {z : Bin // cl.down z = Sum.inr PUnit.unit}
+              (fun j ↦ precomp I O Bout iout
+                (K (precompMerge I Bout iout cl.down j)))) X)
+          (ULift.up (fun b ↦ Sum.inl (g b))))))
+
+/-- The name-level computation of the Lemma 4 `δ`-square at a summand
+of a classifier's unresolved subtype, with every assignment equality
+generalized: both routes transport the summand's Lemma 4 image along
+propositionally equal paths, identified by proof irrelevance at the
+base. -/
+theorem deltaNav_strip (Bin : Type uB)
+    (K : (Bin → I) → IR.{max uA uB, uB, uI, uO} I O)
+    (Q : Type uB) (q : Q → I) (k : FreeCoprodCompDisc.{max uA uB, uI} I)
+    (cl : Bin → Q ⊕ PUnit.{uB + 1}) :
+    ∀ (j₀ j₂ : {z : Bin // cl z = Sum.inr PUnit.unit} → I) (hj : j₀ = j₂)
+      (w₁ : Bin → Q ⊕ k.1)
+      (s₁ : precompMerge I Q q cl j₂ = Sum.elim q k.2 ∘ w₁)
+      (w₂ : Bin → Q ⊕ k.1) (_hw : w₁ = w₂)
+      (b₀ : Bin → I) (r₀ : precompMerge I Q q cl j₀ = b₀)
+      (s₂ : b₀ = Sum.elim q k.2 ∘ w₂)
+      (n : (interpObj I O
+        (precomp I O Q q (K (precompMerge I Q q cl j₀))) k).1),
+      (⟨w₁, (FreeCoprodCompDisc.isoOfEq O
+          (congrArg (fun m ↦ interpObj I O (K m)
+            (FreeCoprodCompDisc.plus.{uI, uB, max uA uB} I ⟨Q, q⟩ k)) s₁)).1
+          ((FreeCoprodCompDisc.Iso.hom O
+            (interpPrecompIso I O (K (precompMerge I Q q cl j₂)) Q q k)).1
+            (cast (congrArg (fun t ↦ (interpObj I O
+              (precomp I O Q q (K (precompMerge I Q q cl t))) k).1) hj) n))⟩ :
+        (interpObj I O (delta I O Bin K)
+          (FreeCoprodCompDisc.plus.{uI, uB, max uA uB} I ⟨Q, q⟩ k)).1) =
+      ⟨w₂, cast (congrArg (fun m ↦ (interpObj I O (K m)
+          (FreeCoprodCompDisc.plus.{uI, uB, max uA uB} I ⟨Q, q⟩ k)).1) s₂)
+        ((FreeCoprodCompDisc.Iso.hom O
+          (interpPrecompIso I O (K b₀) Q q k)).1
+          (cast (congrArg (fun t ↦ (interpObj I O
+            (precomp I O Q q (K t)) k).1) r₀) n))⟩ :=
+  fun j₀ _ hj ↦
+    Eq.rec (motive := fun j₂' hj' ↦ ∀ (w₁ : Bin → Q ⊕ k.1)
+        (s₁ : precompMerge I Q q cl j₂' = Sum.elim q k.2 ∘ w₁)
+        (w₂ : Bin → Q ⊕ k.1) (_hw : w₁ = w₂)
+        (b₀ : Bin → I) (r₀ : precompMerge I Q q cl j₀ = b₀)
+        (s₂ : b₀ = Sum.elim q k.2 ∘ w₂)
+        (n : (interpObj I O
+          (precomp I O Q q (K (precompMerge I Q q cl j₀))) k).1),
+        (⟨w₁, (FreeCoprodCompDisc.isoOfEq O
+            (congrArg (fun m ↦ interpObj I O (K m)
+              (FreeCoprodCompDisc.plus.{uI, uB, max uA uB} I ⟨Q, q⟩ k)) s₁)).1
+            ((FreeCoprodCompDisc.Iso.hom O
+              (interpPrecompIso I O (K (precompMerge I Q q cl j₂')) Q q k)).1
+              (cast (congrArg (fun t ↦ (interpObj I O
+                (precomp I O Q q (K (precompMerge I Q q cl t))) k).1) hj')
+                n))⟩ :
+          (interpObj I O (delta I O Bin K)
+            (FreeCoprodCompDisc.plus.{uI, uB, max uA uB} I ⟨Q, q⟩ k)).1) =
+        ⟨w₂, cast (congrArg (fun m ↦ (interpObj I O (K m)
+            (FreeCoprodCompDisc.plus.{uI, uB, max uA uB} I ⟨Q, q⟩ k)).1) s₂)
+          ((FreeCoprodCompDisc.Iso.hom O
+            (interpPrecompIso I O (K b₀) Q q k)).1
+            (cast (congrArg (fun t ↦ (interpObj I O
+              (precomp I O Q q (K t)) k).1) r₀) n))⟩)
+      (fun w₁ s₁ _ hw ↦
+        Eq.rec (motive := fun w₂' _ ↦ ∀ (b₀ : Bin → I)
+            (r₀ : precompMerge I Q q cl j₀ = b₀)
+            (s₂ : b₀ = Sum.elim q k.2 ∘ w₂')
+            (n : (interpObj I O
+              (precomp I O Q q (K (precompMerge I Q q cl j₀))) k).1),
+            (⟨w₁, (FreeCoprodCompDisc.isoOfEq O
+                (congrArg (fun m ↦ interpObj I O (K m)
+                  (FreeCoprodCompDisc.plus.{uI, uB, max uA uB} I ⟨Q, q⟩ k))
+                  s₁)).1
+                ((FreeCoprodCompDisc.Iso.hom O
+                  (interpPrecompIso I O (K (precompMerge I Q q cl j₀))
+                    Q q k)).1 n)⟩ :
+              (interpObj I O (delta I O Bin K)
+                (FreeCoprodCompDisc.plus.{uI, uB, max uA uB} I ⟨Q, q⟩ k)).1) =
+            ⟨w₂', cast (congrArg (fun m ↦ (interpObj I O (K m)
+                (FreeCoprodCompDisc.plus.{uI, uB, max uA uB} I ⟨Q, q⟩ k)).1)
+                s₂)
+              ((FreeCoprodCompDisc.Iso.hom O
+                (interpPrecompIso I O (K b₀) Q q k)).1
+                (cast (congrArg (fun t ↦ (interpObj I O
+                  (precomp I O Q q (K t)) k).1) r₀) n))⟩)
+          (fun _ r₀ ↦
+            Eq.rec (motive := fun b₀' r₀' ↦ ∀
+                (s₂ : b₀' = Sum.elim q k.2 ∘ w₁)
+                (n : (interpObj I O
+                  (precomp I O Q q (K (precompMerge I Q q cl j₀))) k).1),
+                (⟨w₁, (FreeCoprodCompDisc.isoOfEq O
+                    (congrArg (fun m ↦ interpObj I O (K m)
+                      (FreeCoprodCompDisc.plus.{uI, uB, max uA uB} I ⟨Q, q⟩ k))
+                      s₁)).1
+                    ((FreeCoprodCompDisc.Iso.hom O
+                      (interpPrecompIso I O (K (precompMerge I Q q cl j₀))
+                        Q q k)).1 n)⟩ :
+                  (interpObj I O (delta I O Bin K)
+                    (FreeCoprodCompDisc.plus.{uI, uB, max uA uB}
+                      I ⟨Q, q⟩ k)).1) =
+                ⟨w₁, cast (congrArg (fun m ↦ (interpObj I O (K m)
+                    (FreeCoprodCompDisc.plus.{uI, uB, max uA uB}
+                      I ⟨Q, q⟩ k)).1) s₂)
+                  ((FreeCoprodCompDisc.Iso.hom O
+                    (interpPrecompIso I O (K b₀') Q q k)).1
+                    (cast (congrArg (fun t ↦ (interpObj I O
+                      (precomp I O Q q (K t)) k).1) r₀') n))⟩)
+              (fun s₂ n ↦
+                congrArg
+                  (fun t ↦ (⟨w₁, t⟩ :
+                    (interpObj I O (delta I O Bin K)
+                      (FreeCoprodCompDisc.plus.{uI, uB, max uA uB}
+                        I ⟨Q, q⟩ k)).1))
+                  (interpObj_isoOfEq_cast I O Bin K
+                    (FreeCoprodCompDisc.plus.{uI, uB, max uA uB} I ⟨Q, q⟩ k)
+                    (precompMerge I Q q cl j₀) (Sum.elim q k.2 ∘ w₁) s₁ s₂
+                    ((FreeCoprodCompDisc.Iso.hom O
+                      (interpPrecompIso I O (K (precompMerge I Q q cl j₀))
+                        Q q k)).1 n)))
+              r₀)
+          hw)
+      hj
+
+/-- The all-resolved navigation square: the composite inclusion of the
+`IR.deltaNavBase` characterization, pushed through the Lemma 4
+isomorphism, is the copower injection at the graph weight of the
+factorization followed by the summand inclusion, after the summand's
+Lemma 4 isomorphism. -/
+theorem interpPrecompIso_deltaNav_inj (Bout : Type uB) (iout : Bout → I)
+    (Bin : Type uB) (K : (Bin → I) → IR.{max uA uB, uB, uI, uO} I O)
+    (g : Bin → Bout) (X : FreeCoprodCompDisc.{max uA uB, uI} I) :
+    FreeCoprodCompDisc.Hom.comp O
+        (FreeCoprodCompDisc.Hom.comp O
+          (deltaEmptyInj I O
+            {z : Bin // (fun b ↦ Sum.inl (g b) : Bin → Bout ⊕ PUnit.{uB + 1}) z =
+              Sum.inr PUnit.unit}
+            (fun z ↦ nomatch z.2)
+            (fun j ↦ precomp I O Bout iout
+              (K (precompMerge I Bout iout (fun b ↦ Sum.inl (g b)) j)))
+            X)
+          (FreeCoprodCompDisc.coprodInj O
+            (ULift.{max uA uB} (Bin → Bout ⊕ PUnit.{uB + 1}))
+            (fun cl ↦ interpObj I O
+              (delta I O {z : Bin // cl.down z = Sum.inr PUnit.unit}
+                (fun j ↦ precomp I O Bout iout
+                  (K (precompMerge I Bout iout cl.down j)))) X)
+            (ULift.up (fun b ↦ Sum.inl (g b)))))
+        (FreeCoprodCompDisc.Iso.hom O
+          (interpPrecompIso I O (delta I O Bin K) Bout iout X)) =
+      FreeCoprodCompDisc.Hom.comp O
+        (FreeCoprodCompDisc.Hom.comp O
+          (FreeCoprodCompDisc.Iso.hom O
+            (interpPrecompIso I O (K (iout ∘ g)) Bout iout X))
+          (FreeCoprodCompDisc.coprodInj O
+            (FreeCoprodCompDisc.Hom I
+              (FreeCoprodCompDisc.lift.{uB, uI, max uA uB} I ⟨Bin, iout ∘ g⟩)
+              (FreeCoprodCompDisc.plus.{uI, uB, max uA uB} I ⟨Bout, iout⟩ X))
+            (fun _ ↦ interpObj I O (K (iout ∘ g))
+              (FreeCoprodCompDisc.plus.{uI, uB, max uA uB} I ⟨Bout, iout⟩ X))
+            ⟨fun z ↦ Sum.inl (g z.down), rfl⟩))
+        (deltaInto I O Bin K (iout ∘ g)
+          (FreeCoprodCompDisc.plus.{uI, uB, max uA uB} I ⟨Bout, iout⟩ X)) :=
+  (congrArg
+      (fun t ↦ FreeCoprodCompDisc.Hom.comp O
+        (FreeCoprodCompDisc.Hom.comp O
+          (deltaEmptyInj I O
+            {z : Bin // (fun b ↦ Sum.inl (g b) : Bin → Bout ⊕ PUnit.{uB + 1}) z =
+              Sum.inr PUnit.unit}
+            (fun z ↦ nomatch z.2)
+            (fun j ↦ precomp I O Bout iout
+              (K (precompMerge I Bout iout (fun b ↦ Sum.inl (g b)) j)))
+            X)
+          (FreeCoprodCompDisc.coprodInj O
+            (ULift.{max uA uB} (Bin → Bout ⊕ PUnit.{uB + 1}))
+            (fun cl ↦ interpObj I O
+              (delta I O {z : Bin // cl.down z = Sum.inr PUnit.unit}
+                (fun j ↦ precomp I O Bout iout
+                  (K (precompMerge I Bout iout cl.down j)))) X)
+            (ULift.up (fun b ↦ Sum.inl (g b)))))
+        (FreeCoprodCompDisc.Iso.hom O (t Bout iout X)))
+      (interpPrecompIso_mk I O (Sum.inr (Sum.inr Bin)) (K ∘ ULift.down))).trans
+    (Subtype.ext (funext (fun n ↦
+      ((rfl :
+        (FreeCoprodCompDisc.Hom.comp O
+            (FreeCoprodCompDisc.Hom.comp O
+              (deltaEmptyInj I O
+                {z : Bin //
+                  (fun b ↦ Sum.inl (g b) : Bin → Bout ⊕ PUnit.{uB + 1}) z =
+                    Sum.inr PUnit.unit}
+                (fun z ↦ nomatch z.2)
+                (fun j ↦ precomp I O Bout iout
+                  (K (precompMerge I Bout iout (fun b ↦ Sum.inl (g b)) j)))
+                X)
+              (FreeCoprodCompDisc.coprodInj O
+                (ULift.{max uA uB} (Bin → Bout ⊕ PUnit.{uB + 1}))
+                (fun cl ↦ interpObj I O
+                  (delta I O {z : Bin // cl.down z = Sum.inr PUnit.unit}
+                    (fun j ↦ precomp I O Bout iout
+                      (K (precompMerge I Bout iout cl.down j)))) X)
+                (ULift.up (fun b ↦ Sum.inl (g b)))))
+            (FreeCoprodCompDisc.Iso.hom O
+              (interpPrecompIsoStep I O (Sum.inr (Sum.inr Bin)) (K ∘ ULift.down)
+                (fun x ↦ interpPrecompIso I O ((K ∘ ULift.down) x))
+                Bout iout X))).1 n =
+          (⟨arrowSumMerge (fun b ↦ Sum.inl (g b))
+            (fun z ↦ ((nomatch z.2 : PEmpty.{1}).elim : X.1)),
+          (FreeCoprodCompDisc.isoOfEq O
+            (congrArg
+              (fun m ↦ interpObj I O (K m)
+                (FreeCoprodCompDisc.plus.{uI, uB, max uA uB} I ⟨Bout, iout⟩ X))
+              (precompMerge_elim I Bout iout X Bin (fun b ↦ Sum.inl (g b))
+                (fun z ↦ ((nomatch z.2 : PEmpty.{1}).elim : X.1))))).1
+            ((FreeCoprodCompDisc.Iso.hom O
+              (interpPrecompIso I O
+                (K (precompMerge I Bout iout (fun b ↦ Sum.inl (g b))
+                  (fun z ↦ X.2 ((nomatch z.2 : PEmpty.{1}).elim))))
+                Bout iout X)).1
+              (cast
+                (congrArg
+                  (fun t ↦ (interpObj I O (precomp I O Bout iout
+                    (K (precompMerge I Bout iout (fun b ↦ Sum.inl (g b)) t)))
+                    X).1)
+                  (funext (fun z ↦ nomatch z.2) :
+                    (fun x : {z : Bin //
+                        (fun b ↦ Sum.inl (g b) :
+                          Bin → Bout ⊕ PUnit.{uB + 1}) z =
+                          Sum.inr PUnit.unit} ↦
+                      ((nomatch x.2 : PEmpty.{1}).elim : I)) =
+                      fun z : {z : Bin //
+                        (fun b ↦ Sum.inl (g b) :
+                          Bin → Bout ⊕ PUnit.{uB + 1}) z =
+                          Sum.inr PUnit.unit} ↦
+                        X.2 ((nomatch z.2 : PEmpty.{1}).elim)))
+                n))⟩ :
+          (interpObj I O (delta I O Bin K)
+            (FreeCoprodCompDisc.plus.{uI, uB, max uA uB} I ⟨Bout, iout⟩ X)).1)).trans
+        ((deltaNav_strip I O Bin K Bout iout X (fun b ↦ Sum.inl (g b))
+          (fun x ↦ ((nomatch x.2 : PEmpty.{1}).elim : I))
+          (fun z ↦ X.2 ((nomatch z.2 : PEmpty.{1}).elim))
+          (funext (fun z ↦ nomatch z.2))
+          (arrowSumMerge (fun b ↦ Sum.inl (g b))
+            (fun z ↦ ((nomatch z.2 : PEmpty.{1}).elim : X.1)))
+          (precompMerge_elim I Bout iout X Bin (fun b ↦ Sum.inl (g b))
+            (fun z ↦ ((nomatch z.2 : PEmpty.{1}).elim : X.1)))
+          (fun z ↦ (Sum.inl (g z) : Bout ⊕ X.1))
+          rfl
+          (iout ∘ g)
+          (funext (fun _ ↦ rfl))
+          (funext (fun _ ↦ rfl))
+          n).trans
+          (rfl :
+            (FreeCoprodCompDisc.Hom.comp O
+            (FreeCoprodCompDisc.Hom.comp O
+              (FreeCoprodCompDisc.Iso.hom O
+                (interpPrecompIso I O (K (iout ∘ g)) Bout iout X))
+              (FreeCoprodCompDisc.coprodInj O
+                (FreeCoprodCompDisc.Hom I
+                  (FreeCoprodCompDisc.lift.{uB, uI, max uA uB} I
+                    ⟨Bin, iout ∘ g⟩)
+                  (FreeCoprodCompDisc.plus.{uI, uB, max uA uB} I
+                    ⟨Bout, iout⟩ X))
+                (fun _ ↦ interpObj I O (K (iout ∘ g))
+                  (FreeCoprodCompDisc.plus.{uI, uB, max uA uB} I
+                    ⟨Bout, iout⟩ X))
+                ⟨fun z ↦ Sum.inl (g z.down), rfl⟩))
+            (deltaInto I O Bin K (iout ∘ g)
+              (FreeCoprodCompDisc.plus.{uI, uB, max uA uB} I
+                ⟨Bout, iout⟩ X))).1 n =
+              (⟨fun z ↦ Sum.inl (g z),
+          cast
+            (congrArg
+              (fun m ↦ (interpObj I O (K m)
+                (FreeCoprodCompDisc.plus.{uI, uB, max uA uB} I
+                  ⟨Bout, iout⟩ X)).1)
+              (funext (fun _ ↦ rfl) :
+                iout ∘ g = Sum.elim iout X.2 ∘ fun z : Bin ↦ Sum.inl (g z)))
+            ((FreeCoprodCompDisc.Iso.hom O
+              (interpPrecompIso I O (K (iout ∘ g)) Bout iout X)).1
+              (cast
+                (congrArg
+                  (fun t ↦ (interpObj I O
+                    (precomp I O Bout iout (K t)) X).1)
+                  (funext (fun _ ↦ rfl) :
+                    precompMerge I Bout iout (fun b ↦ Sum.inl (g b))
+                        (fun x : {z : Bin //
+                          (fun b ↦ Sum.inl (g b) :
+                            Bin → Bout ⊕ PUnit.{uB + 1}) z =
+                              Sum.inr PUnit.unit} ↦
+                          ((nomatch x.2 : PEmpty.{1}).elim : I)) =
+                      iout ∘ g))
+                n))⟩ :
+          (interpObj I O (delta I O Bin K)
+            (FreeCoprodCompDisc.plus.{uI, uB, max uA uB} I ⟨Bout, iout⟩ X)).1)).symm)))))
+
+/-- The tower navigation weight: the graph of the factorization into
+the appended superscript, followed by the iterated right injection up
+the tower. By `List.rec`, so the `cons` equation is definitional. -/
+def navWeight (Bout : Type uB) (iout : Bout → I) (Bin : Type uB) (g : Bin → Bout)
+    (X : FreeCoprodCompDisc.{max uA uB, uI} I) (L : List (SupObj.{uB, uI} I)) :
+    FreeCoprodCompDisc.Hom I
+      (FreeCoprodCompDisc.lift.{uB, uI, max uA uB} I ⟨Bin, iout ∘ g⟩)
+      (mplus.{uA, uB, uI} I (L ++ [(⟨Bout, iout⟩ : SupObj.{uB, uI} I)]) X) :=
+  L.rec (motive := fun L' : List (SupObj.{uB, uI} I) ↦
+      FreeCoprodCompDisc.Hom I
+        (FreeCoprodCompDisc.lift.{uB, uI, max uA uB} I ⟨Bin, iout ∘ g⟩)
+        (mplus.{uA, uB, uI} I (L' ++ [(⟨Bout, iout⟩ : SupObj.{uB, uI} I)]) X))
+    ⟨fun z ↦ Sum.inl (g z.down), rfl⟩
+    (fun a _L ih ↦
+      FreeCoprodCompDisc.Hom.comp I ih
+        (FreeCoprodCompDisc.coprodPairInr.{uI, uB, max uA uB} I a
+          (mplus.{uA, uB, uI} I (_L ++ [(⟨Bout, iout⟩ : SupObj.{uB, uI} I)]) X)))
+
+/-- `IR.navWeight`, transported along `IR.mplus_snoc`, is the graph
+weight at the base followed by the tower injection `IR.mplusInj`. -/
+theorem navWeight_snoc (Bout : Type uB) (iout : Bout → I) (Bin : Type uB)
+    (g : Bin → Bout) (X : FreeCoprodCompDisc.{max uA uB, uI} I)
+    (L : List (SupObj.{uB, uI} I)) :
+    cast
+        (congrArg
+          (FreeCoprodCompDisc.Hom I
+            (FreeCoprodCompDisc.lift.{uB, uI, max uA uB} I ⟨Bin, iout ∘ g⟩))
+          (mplus_snoc.{uA, uB, uI} I L (⟨Bout, iout⟩ : SupObj.{uB, uI} I) X))
+        (navWeight I Bout iout Bin g X L) =
+      FreeCoprodCompDisc.Hom.comp I
+        (⟨fun z ↦ Sum.inl (g z.down), rfl⟩ :
+          FreeCoprodCompDisc.Hom I
+            (FreeCoprodCompDisc.lift.{uB, uI, max uA uB} I ⟨Bin, iout ∘ g⟩)
+            (FreeCoprodCompDisc.plus.{uI, uB, max uA uB} I ⟨Bout, iout⟩ X))
+        (mplusInj.{uA, uB, uI} I L
+          (FreeCoprodCompDisc.plus.{uI, uB, max uA uB} I ⟨Bout, iout⟩ X)) :=
+  L.rec (motive := fun L' ↦
+      cast
+          (congrArg
+            (FreeCoprodCompDisc.Hom I
+              (FreeCoprodCompDisc.lift.{uB, uI, max uA uB} I ⟨Bin, iout ∘ g⟩))
+            (mplus_snoc.{uA, uB, uI} I L' (⟨Bout, iout⟩ : SupObj.{uB, uI} I) X))
+          (navWeight I Bout iout Bin g X L') =
+        FreeCoprodCompDisc.Hom.comp I
+          (⟨fun z ↦ Sum.inl (g z.down), rfl⟩ :
+            FreeCoprodCompDisc.Hom I
+              (FreeCoprodCompDisc.lift.{uB, uI, max uA uB} I ⟨Bin, iout ∘ g⟩)
+              (FreeCoprodCompDisc.plus.{uI, uB, max uA uB} I ⟨Bout, iout⟩ X))
+          (mplusInj.{uA, uB, uI} I L'
+            (FreeCoprodCompDisc.plus.{uI, uB, max uA uB} I ⟨Bout, iout⟩ X)))
+    (FreeCoprodCompDisc.Hom.comp_id I
+      (⟨fun z ↦ Sum.inl (g z.down), rfl⟩ :
+        FreeCoprodCompDisc.Hom I
+          (FreeCoprodCompDisc.lift.{uB, uI, max uA uB} I ⟨Bin, iout ∘ g⟩)
+          (FreeCoprodCompDisc.plus.{uI, uB, max uA uB} I ⟨Bout, iout⟩ X))).symm
+    (fun a _L ih ↦
+      (comp_coprodPairInr_cast I a
+          (FreeCoprodCompDisc.lift.{uB, uI, max uA uB} I ⟨Bin, iout ∘ g⟩)
+          (mplus.{uA, uB, uI} I (_L ++ [(⟨Bout, iout⟩ : SupObj.{uB, uI} I)]) X)
+          (mplus.{uA, uB, uI} I _L
+            (FreeCoprodCompDisc.plus.{uI, uB, max uA uB} I ⟨Bout, iout⟩ X))
+          (mplus_snoc.{uA, uB, uI} I _L (⟨Bout, iout⟩ : SupObj.{uB, uI} I) X)
+          (navWeight I Bout iout Bin g X _L)).trans
+        ((congrArg
+            (fun t ↦ FreeCoprodCompDisc.Hom.comp I t
+              (FreeCoprodCompDisc.coprodPairInr.{uI, uB, max uA uB} I a
+                (mplus.{uA, uB, uI} I _L
+                  (FreeCoprodCompDisc.plus.{uI, uB, max uA uB} I
+                    ⟨Bout, iout⟩ X))))
+            ih).trans
+          (FreeCoprodCompDisc.Hom.comp_assoc I
+            (⟨fun z ↦ Sum.inl (g z.down), rfl⟩ :
+              FreeCoprodCompDisc.Hom I
+                (FreeCoprodCompDisc.lift.{uB, uI, max uA uB} I ⟨Bin, iout ∘ g⟩)
+                (FreeCoprodCompDisc.plus.{uI, uB, max uA uB} I ⟨Bout, iout⟩ X))
+            (mplusInj.{uA, uB, uI} I _L
+              (FreeCoprodCompDisc.plus.{uI, uB, max uA uB} I ⟨Bout, iout⟩ X))
+            (FreeCoprodCompDisc.coprodPairInr.{uI, uB, max uA uB} I a
+              (mplus.{uA, uB, uI} I _L
+                (FreeCoprodCompDisc.plus.{uI, uB, max uA uB} I
+                  ⟨Bout, iout⟩ X))))))
+
+/-- The reindexing of a lifted direction family along the inclusion of
+the all-unresolved classifier's subtype (all of the arity). -/
+def navReindex (Bin : Type uB) (j : Bin → I) (Q : Type uB) :
+    FreeCoprodCompDisc.Hom I
+      (FreeCoprodCompDisc.lift.{uB, uI, max uA uB} I ⟨Bin, j⟩)
+      (FreeCoprodCompDisc.lift.{uB, uI, max uA uB} I
+        ⟨{z : Bin //
+            (fun _ : Bin ↦ (Sum.inr PUnit.unit : Q ⊕ PUnit.{uB + 1})) z =
+              Sum.inr PUnit.unit},
+          fun z ↦ j z.1⟩) :=
+  ⟨fun z ↦ ULift.up ⟨z.down, rfl⟩, rfl⟩
+
+/-- `IR.navWeight` at the all-unresolved classifier's subtype,
+restricted along `IR.navReindex`, is `IR.navWeight` at the base
+arity. -/
+theorem navWeight_reindex (Bout : Type uB) (iout : Bout → I) (Bin : Type uB)
+    (g : Bin → Bout) (Q : Type uB) (X : FreeCoprodCompDisc.{max uA uB, uI} I)
+    (L : List (SupObj.{uB, uI} I)) :
+    FreeCoprodCompDisc.Hom.comp I (navReindex.{uA, uB, uI} I Bin (iout ∘ g) Q)
+        (navWeight I Bout iout
+          {z : Bin //
+            (fun _ : Bin ↦ (Sum.inr PUnit.unit : Q ⊕ PUnit.{uB + 1})) z =
+              Sum.inr PUnit.unit}
+          (fun z ↦ g z.1) X L) =
+      navWeight I Bout iout Bin g X L :=
+  L.rec (motive := fun L' ↦
+      FreeCoprodCompDisc.Hom.comp I (navReindex.{uA, uB, uI} I Bin (iout ∘ g) Q)
+          (navWeight I Bout iout
+            {z : Bin //
+              (fun _ : Bin ↦ (Sum.inr PUnit.unit : Q ⊕ PUnit.{uB + 1})) z =
+                Sum.inr PUnit.unit}
+            (fun z ↦ g z.1) X L') =
+        navWeight I Bout iout Bin g X L')
+    (Subtype.ext rfl)
+    (fun a _L ih ↦
+      (FreeCoprodCompDisc.Hom.comp_assoc I
+          (navReindex.{uA, uB, uI} I Bin (iout ∘ g) Q)
+          (navWeight I Bout iout
+            {z : Bin //
+              (fun _ : Bin ↦ (Sum.inr PUnit.unit : Q ⊕ PUnit.{uB + 1})) z =
+                Sum.inr PUnit.unit}
+            (fun z ↦ g z.1) X _L)
+          (FreeCoprodCompDisc.coprodPairInr.{uI, uB, max uA uB} I a
+            (mplus.{uA, uB, uI} I
+              (_L ++ [(⟨Bout, iout⟩ : SupObj.{uB, uI} I)]) X))).symm.trans
+        (congrArg
+          (fun t ↦ FreeCoprodCompDisc.Hom.comp I t
+            (FreeCoprodCompDisc.coprodPairInr.{uI, uB, max uA uB} I a
+              (mplus.{uA, uB, uI} I
+                (_L ++ [(⟨Bout, iout⟩ : SupObj.{uB, uI} I)]) X)))
+          ih))
+
+/-- The all-unresolved navigation square: the copower injection into
+the all-unresolved classifier summand, pushed through the Lemma 4
+isomorphism, is the copower injection at the reindexed weight followed
+by the summand inclusion, after the summand's Lemma 4 isomorphism. -/
+theorem interpPrecompIso_deltaNavAll_inj (Bin : Type uB)
+    (K : (Bin → I) → IR.{max uA uB, uB, uI, uO} I O)
+    (Q : Type uB) (q : Q → I) (j : Bin → I)
+    (k : FreeCoprodCompDisc.{max uA uB, uI} I)
+    (u : FreeCoprodCompDisc.Hom I
+      (FreeCoprodCompDisc.lift.{uB, uI, max uA uB} I
+        ⟨{z : Bin //
+          (fun _ : Bin ↦ (Sum.inr PUnit.unit : Q ⊕ PUnit.{uB + 1})) z = Sum.inr PUnit.unit},
+          fun z ↦ j z.1⟩)
+      k) :
+    FreeCoprodCompDisc.Hom.comp O
+        (FreeCoprodCompDisc.Hom.comp O
+          (FreeCoprodCompDisc.Hom.comp O
+            (FreeCoprodCompDisc.coprodInj O
+              (FreeCoprodCompDisc.Hom I
+                (FreeCoprodCompDisc.lift.{uB, uI, max uA uB} I
+                  ⟨{z : Bin //
+                    (fun _ : Bin ↦ (Sum.inr PUnit.unit : Q ⊕ PUnit.{uB + 1}))
+                      z = Sum.inr PUnit.unit},
+                    fun z ↦ j z.1⟩)
+                k)
+              (fun _ ↦ interpObj I O
+                (precomp I O Q q (K (precompMerge I Q q
+                  (fun _ : Bin ↦ (Sum.inr PUnit.unit : Q ⊕ PUnit.{uB + 1}))
+                  (fun z : {z : Bin //
+                    (fun _ : Bin ↦ (Sum.inr PUnit.unit : Q ⊕ PUnit.{uB + 1}))
+                      z = Sum.inr PUnit.unit} ↦
+                    j z.1))))
+                k)
+              u)
+            (deltaInto I O {z : Bin //
+              (fun _ : Bin ↦ (Sum.inr PUnit.unit : Q ⊕ PUnit.{uB + 1})) z = Sum.inr PUnit.unit}
+              (fun m ↦ precomp I O Q q (K (precompMerge I Q q
+                (fun _ : Bin ↦ (Sum.inr PUnit.unit : Q ⊕ PUnit.{uB + 1})) m)))
+              (fun z ↦ j z.1) k))
+          (FreeCoprodCompDisc.coprodInj O
+            (ULift.{max uA uB} (Bin → Q ⊕ PUnit.{uB + 1}))
+            (fun cl ↦ interpObj I O
+              (delta I O {z : Bin // cl.down z = Sum.inr PUnit.unit}
+                (fun m ↦ precomp I O Q q
+                  (K (precompMerge I Q q cl.down m)))) k)
+            (ULift.up (fun _ : Bin ↦ (Sum.inr PUnit.unit : Q ⊕ PUnit.{uB + 1})))))
+        (FreeCoprodCompDisc.Iso.hom O
+          (interpPrecompIso I O (delta I O Bin K) Q q k)) =
+      FreeCoprodCompDisc.Hom.comp O
+        (FreeCoprodCompDisc.Hom.comp O
+          (FreeCoprodCompDisc.Iso.hom O (interpPrecompIso I O (K j) Q q k))
+          (FreeCoprodCompDisc.coprodInj O
+            (FreeCoprodCompDisc.Hom I
+              (FreeCoprodCompDisc.lift.{uB, uI, max uA uB} I ⟨Bin, j⟩)
+              (FreeCoprodCompDisc.plus.{uI, uB, max uA uB} I ⟨Q, q⟩ k))
+            (fun _ ↦ interpObj I O (K j)
+              (FreeCoprodCompDisc.plus.{uI, uB, max uA uB} I ⟨Q, q⟩ k))
+            (FreeCoprodCompDisc.Hom.comp I (navReindex.{uA, uB, uI} I Bin j Q)
+              (FreeCoprodCompDisc.Hom.comp I u
+                (FreeCoprodCompDisc.coprodPairInr.{uI, uB, max uA uB} I ⟨Q, q⟩ k)))))
+        (deltaInto I O Bin K j
+          (FreeCoprodCompDisc.plus.{uI, uB, max uA uB} I ⟨Q, q⟩ k)) :=
+  (congrArg
+      (fun t ↦ FreeCoprodCompDisc.Hom.comp O
+        (FreeCoprodCompDisc.Hom.comp O
+          (FreeCoprodCompDisc.Hom.comp O
+            (FreeCoprodCompDisc.coprodInj O
+              (FreeCoprodCompDisc.Hom I
+                (FreeCoprodCompDisc.lift.{uB, uI, max uA uB} I
+                  ⟨{z : Bin //
+                    (fun _ : Bin ↦ (Sum.inr PUnit.unit : Q ⊕ PUnit.{uB + 1}))
+                      z = Sum.inr PUnit.unit},
+                    fun z ↦ j z.1⟩)
+                k)
+              (fun _ ↦ interpObj I O
+                (precomp I O Q q (K (precompMerge I Q q
+                  (fun _ : Bin ↦ (Sum.inr PUnit.unit : Q ⊕ PUnit.{uB + 1}))
+                  (fun z : {z : Bin //
+                    (fun _ : Bin ↦ (Sum.inr PUnit.unit : Q ⊕ PUnit.{uB + 1}))
+                      z = Sum.inr PUnit.unit} ↦
+                    j z.1))))
+                k)
+              u)
+            (deltaInto I O {z : Bin //
+              (fun _ : Bin ↦ (Sum.inr PUnit.unit : Q ⊕ PUnit.{uB + 1})) z = Sum.inr PUnit.unit}
+              (fun m ↦ precomp I O Q q (K (precompMerge I Q q
+                (fun _ : Bin ↦ (Sum.inr PUnit.unit : Q ⊕ PUnit.{uB + 1})) m)))
+              (fun z ↦ j z.1) k))
+          (FreeCoprodCompDisc.coprodInj O
+            (ULift.{max uA uB} (Bin → Q ⊕ PUnit.{uB + 1}))
+            (fun cl ↦ interpObj I O
+              (delta I O {z : Bin // cl.down z = Sum.inr PUnit.unit}
+                (fun m ↦ precomp I O Q q
+                  (K (precompMerge I Q q cl.down m)))) k)
+            (ULift.up (fun _ : Bin ↦ (Sum.inr PUnit.unit : Q ⊕ PUnit.{uB + 1})))))
+        (FreeCoprodCompDisc.Iso.hom O (t Q q k)))
+      (interpPrecompIso_mk I O (Sum.inr (Sum.inr Bin)) (K ∘ ULift.down))).trans
+    (Subtype.ext (funext (fun n ↦
+      ((rfl :
+        (FreeCoprodCompDisc.Hom.comp O
+            (FreeCoprodCompDisc.Hom.comp O
+              (FreeCoprodCompDisc.Hom.comp O
+                (FreeCoprodCompDisc.coprodInj O
+                  (FreeCoprodCompDisc.Hom I
+                    (FreeCoprodCompDisc.lift.{uB, uI, max uA uB} I
+                      ⟨{z : Bin //
+                        (fun _ : Bin ↦ (Sum.inr PUnit.unit : Q ⊕ PUnit.{uB + 1}))
+                          z = Sum.inr PUnit.unit},
+                        fun z ↦ j z.1⟩)
+                    k)
+                  (fun _ ↦ interpObj I O
+                    (precomp I O Q q (K (precompMerge I Q q
+                      (fun _ : Bin ↦ (Sum.inr PUnit.unit : Q ⊕ PUnit.{uB + 1}))
+                      (fun z : {z : Bin //
+                        (fun _ : Bin ↦ (Sum.inr PUnit.unit : Q ⊕ PUnit.{uB + 1}))
+                          z = Sum.inr PUnit.unit} ↦
+                        j z.1))))
+                    k)
+                  u)
+                (deltaInto I O {z : Bin //
+                  (fun _ : Bin ↦ (Sum.inr PUnit.unit : Q ⊕ PUnit.{uB + 1})) z = Sum.inr PUnit.unit}
+                  (fun m ↦ precomp I O Q q (K (precompMerge I Q q
+                    (fun _ : Bin ↦ (Sum.inr PUnit.unit : Q ⊕ PUnit.{uB + 1})) m)))
+                  (fun z ↦ j z.1) k))
+              (FreeCoprodCompDisc.coprodInj O
+                (ULift.{max uA uB} (Bin → Q ⊕ PUnit.{uB + 1}))
+                (fun cl ↦ interpObj I O
+                  (delta I O {z : Bin // cl.down z = Sum.inr PUnit.unit}
+                    (fun m ↦ precomp I O Q q
+                      (K (precompMerge I Q q cl.down m)))) k)
+                (ULift.up (fun _ : Bin ↦ (Sum.inr PUnit.unit : Q ⊕ PUnit.{uB + 1})))))
+            (FreeCoprodCompDisc.Iso.hom O
+              (interpPrecompIsoStep I O (Sum.inr (Sum.inr Bin))
+                (K ∘ ULift.down)
+                (fun x ↦ interpPrecompIso I O ((K ∘ ULift.down) x))
+                Q q k))).1 n =
+          (⟨arrowSumMerge
+            (fun _ : Bin ↦ (Sum.inr PUnit.unit : Q ⊕ PUnit.{uB + 1})) (fun z ↦ u.1 (ULift.up z)),
+            (FreeCoprodCompDisc.isoOfEq O
+              (congrArg
+                (fun m ↦ interpObj I O (K m)
+                  (FreeCoprodCompDisc.plus.{uI, uB, max uA uB} I ⟨Q, q⟩ k))
+                (precompMerge_elim I Q q k Bin
+                  (fun _ : Bin ↦ (Sum.inr PUnit.unit : Q ⊕ PUnit.{uB + 1}))
+                  (fun z ↦ u.1 (ULift.up z))))).1
+              ((FreeCoprodCompDisc.Iso.hom O
+                (interpPrecompIso I O
+                  (K (precompMerge I Q q (fun _ : Bin ↦ (Sum.inr PUnit.unit : Q ⊕ PUnit.{uB + 1}))
+                    (fun z ↦ k.2 (u.1 (ULift.up z)))))
+                  Q q k)).1
+                (cast
+                  (congrArg
+                    (fun t ↦ (interpObj I O (precomp I O Q q
+                      (K (precompMerge I Q q
+                        (fun _ : Bin ↦ (Sum.inr PUnit.unit : Q ⊕ PUnit.{uB + 1})) t))) k).1)
+                    (funext (fun z ↦ (congrFun u.2 (ULift.up z)).symm) :
+                      (fun z : {z : Bin //
+                        (fun _ : Bin ↦ (Sum.inr PUnit.unit : Q ⊕ PUnit.{uB + 1}))
+                          z = Sum.inr PUnit.unit} ↦
+                        j z.1) =
+                        fun z : {z : Bin //
+                          (fun _ : Bin ↦ (Sum.inr PUnit.unit : Q ⊕ PUnit.{uB + 1}))
+                            z = Sum.inr PUnit.unit} ↦
+                          k.2 (u.1 (ULift.up z))))
+                  n))⟩ :
+            (interpObj I O (delta I O Bin K)
+              (FreeCoprodCompDisc.plus.{uI, uB, max uA uB} I ⟨Q, q⟩ k)).1)).trans
+        ((deltaNav_strip I O Bin K Q q k (fun _ : Bin ↦ (Sum.inr PUnit.unit : Q ⊕ PUnit.{uB + 1}))
+          (fun z ↦ j z.1)
+          (fun z ↦ k.2 (u.1 (ULift.up z)))
+          (funext (fun z ↦ (congrFun u.2 (ULift.up z)).symm))
+          (arrowSumMerge
+            (fun _ : Bin ↦ (Sum.inr PUnit.unit : Q ⊕ PUnit.{uB + 1})) (fun z ↦ u.1 (ULift.up z)))
+          (precompMerge_elim I Q q k Bin
+            (fun _ : Bin ↦ (Sum.inr PUnit.unit : Q ⊕ PUnit.{uB + 1})) (fun z ↦ u.1 (ULift.up z)))
+          (fun b ↦ (Sum.inr (u.1 (ULift.up ⟨b, rfl⟩)) : Q ⊕ k.1))
+          rfl
+          j
+          (funext (fun _ ↦ rfl))
+          (funext (fun b ↦ (congrFun u.2 (ULift.up ⟨b, rfl⟩)).symm))
+          n).trans
+          (rfl :
+            (FreeCoprodCompDisc.Hom.comp O
+                (FreeCoprodCompDisc.Hom.comp O
+                  (FreeCoprodCompDisc.Iso.hom O
+                    (interpPrecompIso I O (K j) Q q k))
+                  (FreeCoprodCompDisc.coprodInj O
+                    (FreeCoprodCompDisc.Hom I
+                      (FreeCoprodCompDisc.lift.{uB, uI, max uA uB} I ⟨Bin, j⟩)
+                      (FreeCoprodCompDisc.plus.{uI, uB, max uA uB} I ⟨Q, q⟩ k))
+                    (fun _ ↦ interpObj I O (K j)
+                      (FreeCoprodCompDisc.plus.{uI, uB, max uA uB} I ⟨Q, q⟩ k))
+                    (FreeCoprodCompDisc.Hom.comp I
+                      (navReindex.{uA, uB, uI} I Bin j Q)
+                      (FreeCoprodCompDisc.Hom.comp I u
+                        (FreeCoprodCompDisc.coprodPairInr.{uI, uB, max uA uB} I ⟨Q, q⟩ k)))))
+                (deltaInto I O Bin K j
+                  (FreeCoprodCompDisc.plus.{uI, uB, max uA uB} I
+                    ⟨Q, q⟩ k))).1 n =
+              (⟨fun b ↦ (Sum.inr (u.1 (ULift.up ⟨b, rfl⟩)) : Q ⊕ k.1),
+                cast
+                  (congrArg
+                    (fun m ↦ (interpObj I O (K m)
+                      (FreeCoprodCompDisc.plus.{uI, uB, max uA uB} I
+                        ⟨Q, q⟩ k)).1)
+                    (funext
+                      (fun b ↦ (congrFun u.2 (ULift.up ⟨b, rfl⟩)).symm) :
+                      j = Sum.elim q k.2 ∘
+                        fun b : Bin ↦
+                          (Sum.inr (u.1 (ULift.up ⟨b, rfl⟩)) : Q ⊕ k.1)))
+                  ((FreeCoprodCompDisc.Iso.hom O
+                    (interpPrecompIso I O (K j) Q q k)).1
+                    (cast
+                      (congrArg
+                        (fun t ↦ (interpObj I O
+                          (precomp I O Q q (K t)) k).1)
+                        (funext (fun _ ↦ rfl) :
+                          precompMerge I Q q
+                            (fun _ : Bin ↦ (Sum.inr PUnit.unit : Q ⊕ PUnit.{uB + 1}))
+                              (fun z : {z : Bin //
+                                (fun _ : Bin ↦ (Sum.inr PUnit.unit : Q ⊕ PUnit.{uB + 1}))
+                                  z = Sum.inr PUnit.unit} ↦
+                                j z.1) =
+                            j))
+                      n))⟩ :
+                (interpObj I O (delta I O Bin K)
+                  (FreeCoprodCompDisc.plus.{uI, uB, max uA uB} I
+                    ⟨Q, q⟩ k)).1)).symm)))))
+
+/-- The tower-conjugated navigation inclusion: the copower injection
+at the `IR.navWeight` weight followed by the summand inclusion, both
+at the tower coproduct, conjugated by the iterated Lemma 4
+isomorphisms. -/
+def navInj (Bout : Type uB) (iout : Bout → I) (Bin : Type uB)
+    (K : (Bin → I) → IR.{max uA uB, uB, uI, uO} I O) (g : Bin → Bout)
+    (L : List (SupObj.{uB, uI} I)) (X : FreeCoprodCompDisc.{max uA uB, uI} I) :
+    FreeCoprodCompDisc.Hom O
+      (interpObj I O
+        (mprecomp I O (L ++ [(⟨Bout, iout⟩ : SupObj.{uB, uI} I)])
+          (K (iout ∘ g))) X)
+      (interpObj I O
+        (mprecomp I O (L ++ [(⟨Bout, iout⟩ : SupObj.{uB, uI} I)])
+          (delta I O Bin K)) X) :=
+  FreeCoprodCompDisc.Hom.comp O
+    (FreeCoprodCompDisc.Hom.comp O
+      (FreeCoprodCompDisc.Iso.hom O
+        (mprecompIso.{uA, uB, uI, uO} I O
+          (L ++ [(⟨Bout, iout⟩ : SupObj.{uB, uI} I)]) (K (iout ∘ g)) X))
+      (FreeCoprodCompDisc.Hom.comp O
+        (FreeCoprodCompDisc.coprodInj O
+          (FreeCoprodCompDisc.Hom I
+            (FreeCoprodCompDisc.lift.{uB, uI, max uA uB} I ⟨Bin, iout ∘ g⟩)
+            (mplus.{uA, uB, uI} I
+              (L ++ [(⟨Bout, iout⟩ : SupObj.{uB, uI} I)]) X))
+          (fun _ ↦ interpObj I O (K (iout ∘ g))
+            (mplus.{uA, uB, uI} I
+              (L ++ [(⟨Bout, iout⟩ : SupObj.{uB, uI} I)]) X))
+          (navWeight I Bout iout Bin g X L))
+        (deltaInto I O Bin K (iout ∘ g)
+          (mplus.{uA, uB, uI} I
+            (L ++ [(⟨Bout, iout⟩ : SupObj.{uB, uI} I)]) X))))
+    (FreeCoprodCompDisc.Iso.invHom O
+      (mprecompIso.{uA, uB, uI, uO} I O
+        (L ++ [(⟨Bout, iout⟩ : SupObj.{uB, uI} I)]) (delta I O Bin K) X))
+
+/-- The base-inclusion equation: the composite inclusion of the
+`IR.deltaNavBase` characterization is `IR.navInj` at the empty
+stack. -/
+theorem navInj_nil (Bout : Type uB) (iout : Bout → I) (Bin : Type uB)
+    (K : (Bin → I) → IR.{max uA uB, uB, uI, uO} I O) (g : Bin → Bout)
+    (X : FreeCoprodCompDisc.{max uA uB, uI} I) :
+    FreeCoprodCompDisc.Hom.comp O
+        (deltaEmptyInj I O
+          {z : Bin // (fun b ↦ Sum.inl (g b) : Bin → Bout ⊕ PUnit.{uB + 1}) z =
+            Sum.inr PUnit.unit}
+          (fun z ↦ nomatch z.2)
+          (fun j ↦ precomp I O Bout iout
+            (K (precompMerge I Bout iout (fun b ↦ Sum.inl (g b)) j)))
+          X)
+        (FreeCoprodCompDisc.coprodInj O
+          (ULift.{max uA uB} (Bin → Bout ⊕ PUnit.{uB + 1}))
+          (fun cl ↦ interpObj I O
+            (delta I O {z : Bin // cl.down z = Sum.inr PUnit.unit}
+              (fun j ↦ precomp I O Bout iout
+                (K (precompMerge I Bout iout cl.down j)))) X)
+          (ULift.up (fun b ↦ Sum.inl (g b)))) =
+      navInj I O Bout iout Bin K g [] X :=
+  (eq_comp_invHom O
+      (interpObj I O (precomp I O Bout iout (K (iout ∘ g))) X)
+      (interpObj I O (precomp I O Bout iout (delta I O Bin K)) X)
+      (interpObj I O (delta I O Bin K)
+        (FreeCoprodCompDisc.plus.{uI, uB, max uA uB} I ⟨Bout, iout⟩ X))
+      (FreeCoprodCompDisc.Hom.comp O
+        (deltaEmptyInj I O
+          {z : Bin // (fun b ↦ Sum.inl (g b) : Bin → Bout ⊕ PUnit.{uB + 1}) z =
+            Sum.inr PUnit.unit}
+          (fun z ↦ nomatch z.2)
+          (fun j ↦ precomp I O Bout iout
+            (K (precompMerge I Bout iout (fun b ↦ Sum.inl (g b)) j)))
+          X)
+        (FreeCoprodCompDisc.coprodInj O
+          (ULift.{max uA uB} (Bin → Bout ⊕ PUnit.{uB + 1}))
+          (fun cl ↦ interpObj I O
+            (delta I O {z : Bin // cl.down z = Sum.inr PUnit.unit}
+              (fun j ↦ precomp I O Bout iout
+                (K (precompMerge I Bout iout cl.down j)))) X)
+          (ULift.up (fun b ↦ Sum.inl (g b)))))
+      (FreeCoprodCompDisc.Hom.comp O
+        (FreeCoprodCompDisc.Hom.comp O
+          (FreeCoprodCompDisc.Iso.hom O
+            (interpPrecompIso I O (K (iout ∘ g)) Bout iout X))
+          (FreeCoprodCompDisc.coprodInj O
+            (FreeCoprodCompDisc.Hom I
+              (FreeCoprodCompDisc.lift.{uB, uI, max uA uB} I ⟨Bin, iout ∘ g⟩)
+              (FreeCoprodCompDisc.plus.{uI, uB, max uA uB} I ⟨Bout, iout⟩ X))
+            (fun _ ↦ interpObj I O (K (iout ∘ g))
+              (FreeCoprodCompDisc.plus.{uI, uB, max uA uB} I ⟨Bout, iout⟩ X))
+            ⟨fun z ↦ Sum.inl (g z.down), rfl⟩))
+        (deltaInto I O Bin K (iout ∘ g)
+          (FreeCoprodCompDisc.plus.{uI, uB, max uA uB} I ⟨Bout, iout⟩ X)))
+      (interpPrecompIso I O (delta I O Bin K) Bout iout X)
+      (interpPrecompIso_deltaNav_inj I O Bout iout Bin K g X)).trans
+    (congrArg
+      (fun t ↦ FreeCoprodCompDisc.Hom.comp O t
+        (FreeCoprodCompDisc.Iso.invHom O
+          (interpPrecompIso I O (delta I O Bin K) Bout iout X)))
+      (FreeCoprodCompDisc.Hom.comp_assoc O
+        (FreeCoprodCompDisc.Iso.hom O
+          (interpPrecompIso I O (K (iout ∘ g)) Bout iout X))
+        (FreeCoprodCompDisc.coprodInj O
+          (FreeCoprodCompDisc.Hom I
+            (FreeCoprodCompDisc.lift.{uB, uI, max uA uB} I ⟨Bin, iout ∘ g⟩)
+            (FreeCoprodCompDisc.plus.{uI, uB, max uA uB} I ⟨Bout, iout⟩ X))
+          (fun _ ↦ interpObj I O (K (iout ∘ g))
+            (FreeCoprodCompDisc.plus.{uI, uB, max uA uB} I ⟨Bout, iout⟩ X))
+          ⟨fun z ↦ Sum.inl (g z.down), rfl⟩)
+        (deltaInto I O Bin K (iout ∘ g)
+          (FreeCoprodCompDisc.plus.{uI, uB, max uA uB} I ⟨Bout, iout⟩ X))))
+
+/-- The cons-inclusion equation: the navigation inclusion at the
+unresolved-subtype data, composed with the classifier-summand
+inclusion conjugated through the tower isomorphisms, is `IR.navInj`
+at the extended stack. -/
+theorem navInj_cons (Bout : Type uB) (iout : Bout → I) (Bin : Type uB)
+    (K : (Bin → I) → IR.{max uA uB, uB, uI, uO} I O) (g : Bin → Bout)
+    (a : SupObj.{uB, uI} I) (L : List (SupObj.{uB, uI} I))
+    (X : FreeCoprodCompDisc.{max uA uB, uI} I) :
+    FreeCoprodCompDisc.Hom.comp O
+        (navInj I O Bout iout
+          {z : Bin //
+            (fun _ : Bin ↦ (Sum.inr PUnit.unit : a.1 ⊕ PUnit.{uB + 1})) z =
+              Sum.inr PUnit.unit}
+          (fun m ↦ precomp I O a.1 a.2 (K (precompMerge I a.1 a.2
+            (fun _ : Bin ↦ (Sum.inr PUnit.unit : a.1 ⊕ PUnit.{uB + 1})) m)))
+          (fun z ↦ g z.1) L X)
+        (FreeCoprodCompDisc.Hom.comp O
+            (FreeCoprodCompDisc.Hom.comp O
+              (FreeCoprodCompDisc.Iso.hom O
+                (mprecompIso.{uA, uB, uI, uO} I O (L ++ [(⟨Bout, iout⟩ : SupObj.{uB, uI} I)])
+                    (delta I O
+                      {z : Bin //
+                        (fun _ : Bin ↦ (Sum.inr PUnit.unit : a.1 ⊕ PUnit.{uB + 1})) z =
+                          Sum.inr PUnit.unit}
+                      (fun m ↦ precomp I O a.1 a.2 (K (precompMerge I a.1 a.2
+                        (fun _ : Bin ↦ (Sum.inr PUnit.unit : a.1 ⊕ PUnit.{uB + 1})) m))))
+                    X))
+              (FreeCoprodCompDisc.coprodInj O
+                (ULift.{max uA uB, uB} (Bin → a.1 ⊕ PUnit.{uB + 1}))
+                (fun cl ↦ interpObj I O
+                  (delta I O {z : Bin // cl.down z = Sum.inr PUnit.unit}
+                    (fun m ↦ precomp I O a.1 a.2 (K (precompMerge I a.1 a.2 cl.down m))))
+                  (mplus.{uA, uB, uI} I (L ++ [(⟨Bout, iout⟩ : SupObj.{uB, uI} I)]) X))
+                (ULift.up (fun _ : Bin ↦ (Sum.inr PUnit.unit : a.1 ⊕ PUnit.{uB + 1})))))
+            (FreeCoprodCompDisc.Iso.invHom O
+              (mprecompIso.{uA, uB, uI, uO} I O (L ++ [(⟨Bout, iout⟩ : SupObj.{uB, uI} I)])
+                  (sigma I O (ULift.{max uA uB, uB} (Bin → a.1 ⊕ PUnit.{uB + 1}))
+                    (fun cl ↦ delta I O {z : Bin // cl.down z = Sum.inr PUnit.unit}
+                      (fun m ↦ precomp I O a.1 a.2 (K (precompMerge I a.1 a.2 cl.down m)))))
+                  X))) =
+      navInj I O Bout iout Bin K g (a :: L) X :=
+  Eq.trans
+    (FreeCoprodCompDisc.Hom.comp_assoc O
+      (FreeCoprodCompDisc.Hom.comp O
+        (FreeCoprodCompDisc.Iso.hom O
+          (mprecompIso.{uA, uB, uI, uO} I O (L ++ [(⟨Bout, iout⟩ : SupObj.{uB, uI} I)])
+            (precomp I O a.1 a.2 (K (iout ∘ g))) X))
+        (FreeCoprodCompDisc.Hom.comp O
+          (FreeCoprodCompDisc.coprodInj O
+            (FreeCoprodCompDisc.Hom I
+              (FreeCoprodCompDisc.lift.{uB, uI, max uA uB} I
+                ⟨
+                  {z : Bin // (fun _ : Bin ↦ (Sum.inr PUnit.unit : a.1 ⊕ PUnit.{uB + 1})) z =
+                    Sum.inr PUnit.unit}, fun z ↦ (iout ∘ g) z.1⟩)
+              (mplus.{uA, uB, uI} I (L ++ [(⟨Bout, iout⟩ : SupObj.{uB, uI} I)]) X))
+            (fun _ ↦ interpObj I O
+              (precomp I O a.1 a.2
+                (K
+                  (precompMerge I a.1 a.2
+                    (fun _ : Bin ↦ (Sum.inr PUnit.unit : a.1 ⊕ PUnit.{uB + 1}))
+                    (fun z :
+                      {z : Bin // (fun _ : Bin ↦ (Sum.inr PUnit.unit : a.1 ⊕ PUnit.{uB + 1})) z =
+                        Sum.inr PUnit.unit} ↦ (iout ∘ g) z.1))))
+              (mplus.{uA, uB, uI} I (L ++ [(⟨Bout, iout⟩ : SupObj.{uB, uI} I)]) X))
+            (navWeight I Bout iout
+              {z : Bin // (fun _ : Bin ↦ (Sum.inr PUnit.unit : a.1 ⊕ PUnit.{uB + 1})) z = Sum.inr
+                PUnit.unit} (fun z ↦ g z.1) X L))
+          (deltaInto I O
+            {z : Bin // (fun _ : Bin ↦ (Sum.inr PUnit.unit : a.1 ⊕ PUnit.{uB + 1})) z = Sum.inr
+              PUnit.unit}
+            (fun m ↦ precomp I O a.1 a.2
+              (K
+                (precompMerge I a.1 a.2 (fun _ : Bin ↦ (Sum.inr PUnit.unit : a.1 ⊕ PUnit.{uB + 1}))
+                  m))) (fun z ↦ (iout ∘ g) z.1)
+            (mplus.{uA, uB, uI} I (L ++ [(⟨Bout, iout⟩ : SupObj.{uB, uI} I)]) X))))
+      (FreeCoprodCompDisc.Iso.invHom O
+        (mprecompIso.{uA, uB, uI, uO} I O (L ++ [(⟨Bout, iout⟩ : SupObj.{uB, uI} I)])
+          (delta I O
+            {z : Bin // (fun _ : Bin ↦ (Sum.inr PUnit.unit : a.1 ⊕ PUnit.{uB + 1})) z = Sum.inr
+              PUnit.unit}
+            (fun m ↦ precomp I O a.1 a.2
+              (K
+                (precompMerge I a.1 a.2 (fun _ : Bin ↦ (Sum.inr PUnit.unit : a.1 ⊕ PUnit.{uB + 1}))
+                  m)))) X))
+      (FreeCoprodCompDisc.Hom.comp O
+        (FreeCoprodCompDisc.Hom.comp O
+          (FreeCoprodCompDisc.Iso.hom O
+            (mprecompIso.{uA, uB, uI, uO} I O (L ++ [(⟨Bout, iout⟩ : SupObj.{uB, uI} I)])
+              (delta I O
+                {z : Bin // (fun _ : Bin ↦ (Sum.inr PUnit.unit : a.1 ⊕ PUnit.{uB + 1})) z = Sum.inr
+                  PUnit.unit}
+                (fun m ↦ precomp I O a.1 a.2
+                  (K
+                    (precompMerge I a.1 a.2
+                      (fun _ : Bin ↦ (Sum.inr PUnit.unit : a.1 ⊕ PUnit.{uB + 1})) m)))) X))
+          (FreeCoprodCompDisc.coprodInj O (ULift.{max uA uB, uB} (Bin → a.1 ⊕ PUnit.{uB + 1}))
+            (fun cl ↦ interpObj I O
+              (delta I O {z : Bin // cl.down z = Sum.inr PUnit.unit}
+                (fun m ↦ precomp I O a.1 a.2 (K (precompMerge I a.1 a.2 cl.down m))))
+              (mplus.{uA, uB, uI} I (L ++ [(⟨Bout, iout⟩ : SupObj.{uB, uI} I)]) X))
+            (ULift.up (fun _ : Bin ↦ (Sum.inr PUnit.unit : a.1 ⊕ PUnit.{uB + 1})))))
+        (FreeCoprodCompDisc.Iso.invHom O
+          (mprecompIso.{uA, uB, uI, uO} I O (L ++ [(⟨Bout, iout⟩ : SupObj.{uB, uI} I)])
+            (sigma I O (ULift.{max uA uB, uB} (Bin → a.1 ⊕ PUnit.{uB + 1}))
+              (fun cl ↦ delta I O {z : Bin // cl.down z = Sum.inr PUnit.unit}
+                (fun m ↦ precomp I O a.1 a.2 (K (precompMerge I a.1 a.2 cl.down m))))) X))))
+    (Eq.trans
+      (congrArg
+        (FreeCoprodCompDisc.Hom.comp O
+          (FreeCoprodCompDisc.Hom.comp O
+            (FreeCoprodCompDisc.Iso.hom O
+              (mprecompIso.{uA, uB, uI, uO} I O (L ++ [(⟨Bout, iout⟩ : SupObj.{uB, uI} I)])
+                (precomp I O a.1 a.2 (K (iout ∘ g))) X))
+            (FreeCoprodCompDisc.Hom.comp O
+              (FreeCoprodCompDisc.coprodInj O
+                (FreeCoprodCompDisc.Hom I
+                  (FreeCoprodCompDisc.lift.{uB, uI, max uA uB} I
+                    ⟨
+                      {z : Bin // (fun _ : Bin ↦ (Sum.inr PUnit.unit : a.1 ⊕ PUnit.{uB + 1})) z =
+                        Sum.inr PUnit.unit}, fun z ↦ (iout ∘ g) z.1⟩)
+                  (mplus.{uA, uB, uI} I (L ++ [(⟨Bout, iout⟩ : SupObj.{uB, uI} I)]) X))
+                (fun _ ↦ interpObj I O
+                  (precomp I O a.1 a.2
+                    (K
+                      (precompMerge I a.1 a.2
+                        (fun _ : Bin ↦ (Sum.inr PUnit.unit : a.1 ⊕ PUnit.{uB + 1}))
+                        (fun z :
+                          {z : Bin // (fun _ : Bin ↦ (Sum.inr PUnit.unit : a.1 ⊕ PUnit.{uB + 1})) z
+                            = Sum.inr PUnit.unit} ↦ (iout ∘ g) z.1))))
+                  (mplus.{uA, uB, uI} I (L ++ [(⟨Bout, iout⟩ : SupObj.{uB, uI} I)]) X))
+                (navWeight I Bout iout
+                  {z : Bin // (fun _ : Bin ↦ (Sum.inr PUnit.unit : a.1 ⊕ PUnit.{uB + 1})) z =
+                    Sum.inr PUnit.unit} (fun z ↦ g z.1) X L))
+              (deltaInto I O
+                {z : Bin // (fun _ : Bin ↦ (Sum.inr PUnit.unit : a.1 ⊕ PUnit.{uB + 1})) z = Sum.inr
+                  PUnit.unit}
+                (fun m ↦ precomp I O a.1 a.2
+                  (K
+                    (precompMerge I a.1 a.2
+                      (fun _ : Bin ↦ (Sum.inr PUnit.unit : a.1 ⊕ PUnit.{uB + 1})) m)))
+                (fun z ↦ (iout ∘ g) z.1)
+                (mplus.{uA, uB, uI} I (L ++ [(⟨Bout, iout⟩ : SupObj.{uB, uI} I)]) X)))))
+        (Eq.trans
+          (Eq.symm
+            (FreeCoprodCompDisc.Hom.comp_assoc O
+              (FreeCoprodCompDisc.Iso.invHom O
+                (mprecompIso.{uA, uB, uI, uO} I O (L ++ [(⟨Bout, iout⟩ : SupObj.{uB, uI} I)])
+                  (delta I O
+                    {z : Bin // (fun _ : Bin ↦ (Sum.inr PUnit.unit : a.1 ⊕ PUnit.{uB + 1})) z =
+                      Sum.inr PUnit.unit}
+                    (fun m ↦ precomp I O a.1 a.2
+                      (K
+                        (precompMerge I a.1 a.2
+                          (fun _ : Bin ↦ (Sum.inr PUnit.unit : a.1 ⊕ PUnit.{uB + 1})) m)))) X))
+              (FreeCoprodCompDisc.Hom.comp O
+                (FreeCoprodCompDisc.Iso.hom O
+                  (mprecompIso.{uA, uB, uI, uO} I O (L ++ [(⟨Bout, iout⟩ : SupObj.{uB, uI} I)])
+                    (delta I O
+                      {z : Bin // (fun _ : Bin ↦ (Sum.inr PUnit.unit : a.1 ⊕ PUnit.{uB + 1})) z =
+                        Sum.inr PUnit.unit}
+                      (fun m ↦ precomp I O a.1 a.2
+                        (K
+                          (precompMerge I a.1 a.2
+                            (fun _ : Bin ↦ (Sum.inr PUnit.unit : a.1 ⊕ PUnit.{uB + 1})) m)))) X))
+                (FreeCoprodCompDisc.coprodInj O (ULift.{max uA uB, uB} (Bin → a.1 ⊕ PUnit.{uB + 1}))
+                  (fun cl ↦ interpObj I O
+                    (delta I O {z : Bin // cl.down z = Sum.inr PUnit.unit}
+                      (fun m ↦ precomp I O a.1 a.2 (K (precompMerge I a.1 a.2 cl.down m))))
+                    (mplus.{uA, uB, uI} I (L ++ [(⟨Bout, iout⟩ : SupObj.{uB, uI} I)]) X))
+                  (ULift.up (fun _ : Bin ↦ (Sum.inr PUnit.unit : a.1 ⊕ PUnit.{uB + 1})))))
+              (FreeCoprodCompDisc.Iso.invHom O
+                (mprecompIso.{uA, uB, uI, uO} I O (L ++ [(⟨Bout, iout⟩ : SupObj.{uB, uI} I)])
+                  (sigma I O (ULift.{max uA uB, uB} (Bin → a.1 ⊕ PUnit.{uB + 1}))
+                    (fun cl ↦ delta I O {z : Bin // cl.down z = Sum.inr PUnit.unit}
+                      (fun m ↦ precomp I O a.1 a.2 (K (precompMerge I a.1 a.2 cl.down m))))) X))))
+          (congrArg
+            (fun t ↦ FreeCoprodCompDisc.Hom.comp O t
+              (FreeCoprodCompDisc.Iso.invHom O
+                (mprecompIso.{uA, uB, uI, uO} I O (L ++ [(⟨Bout, iout⟩ : SupObj.{uB, uI} I)])
+                  (sigma I O (ULift.{max uA uB, uB} (Bin → a.1 ⊕ PUnit.{uB + 1}))
+                    (fun cl ↦ delta I O {z : Bin // cl.down z = Sum.inr PUnit.unit}
+                      (fun m ↦ precomp I O a.1 a.2 (K (precompMerge I a.1 a.2 cl.down m))))) X)))
+            (Eq.trans
+              (Eq.symm
+                (FreeCoprodCompDisc.Hom.comp_assoc O
+                  (FreeCoprodCompDisc.Iso.invHom O
+                    (mprecompIso.{uA, uB, uI, uO} I O (L ++ [(⟨Bout, iout⟩ : SupObj.{uB, uI} I)])
+                      (delta I O
+                        {z : Bin // (fun _ : Bin ↦ (Sum.inr PUnit.unit : a.1 ⊕ PUnit.{uB + 1})) z =
+                          Sum.inr PUnit.unit}
+                        (fun m ↦ precomp I O a.1 a.2
+                          (K
+                            (precompMerge I a.1 a.2
+                              (fun _ : Bin ↦ (Sum.inr PUnit.unit : a.1 ⊕ PUnit.{uB + 1})) m)))) X))
+                  (FreeCoprodCompDisc.Iso.hom O
+                    (mprecompIso.{uA, uB, uI, uO} I O (L ++ [(⟨Bout, iout⟩ : SupObj.{uB, uI} I)])
+                      (delta I O
+                        {z : Bin // (fun _ : Bin ↦ (Sum.inr PUnit.unit : a.1 ⊕ PUnit.{uB + 1})) z =
+                          Sum.inr PUnit.unit}
+                        (fun m ↦ precomp I O a.1 a.2
+                          (K
+                            (precompMerge I a.1 a.2
+                              (fun _ : Bin ↦ (Sum.inr PUnit.unit : a.1 ⊕ PUnit.{uB + 1})) m)))) X))
+                  (FreeCoprodCompDisc.coprodInj O
+                    (ULift.{max uA uB, uB} (Bin → a.1 ⊕ PUnit.{uB + 1}))
+                    (fun cl ↦ interpObj I O
+                      (delta I O {z : Bin // cl.down z = Sum.inr PUnit.unit}
+                        (fun m ↦ precomp I O a.1 a.2 (K (precompMerge I a.1 a.2 cl.down m))))
+                      (mplus.{uA, uB, uI} I (L ++ [(⟨Bout, iout⟩ : SupObj.{uB, uI} I)]) X))
+                    (ULift.up (fun _ : Bin ↦ (Sum.inr PUnit.unit : a.1 ⊕ PUnit.{uB + 1}))))))
+              (Eq.trans
+                (congrArg
+                  (fun t ↦ FreeCoprodCompDisc.Hom.comp O t
+                    (FreeCoprodCompDisc.coprodInj O
+                      (ULift.{max uA uB, uB} (Bin → a.1 ⊕ PUnit.{uB + 1}))
+                      (fun cl ↦ interpObj I O
+                        (delta I O {z : Bin // cl.down z = Sum.inr PUnit.unit}
+                          (fun m ↦ precomp I O a.1 a.2 (K (precompMerge I a.1 a.2 cl.down m))))
+                        (mplus.{uA, uB, uI} I (L ++ [(⟨Bout, iout⟩ : SupObj.{uB, uI} I)]) X))
+                      (ULift.up (fun _ : Bin ↦ (Sum.inr PUnit.unit : a.1 ⊕ PUnit.{uB + 1})))))
+                  (FreeCoprodCompDisc.Iso.invHom_hom O
+                    (mprecompIso.{uA, uB, uI, uO} I O (L ++ [(⟨Bout, iout⟩ : SupObj.{uB, uI} I)])
+                      (delta I O
+                        {z : Bin // (fun _ : Bin ↦ (Sum.inr PUnit.unit : a.1 ⊕ PUnit.{uB + 1})) z =
+                          Sum.inr PUnit.unit}
+                        (fun m ↦ precomp I O a.1 a.2
+                          (K
+                            (precompMerge I a.1 a.2
+                              (fun _ : Bin ↦ (Sum.inr PUnit.unit : a.1 ⊕ PUnit.{uB + 1})) m)))) X)))
+                (FreeCoprodCompDisc.Hom.id_comp O
+                  (FreeCoprodCompDisc.coprodInj O
+                    (ULift.{max uA uB, uB} (Bin → a.1 ⊕ PUnit.{uB + 1}))
+                    (fun cl ↦ interpObj I O
+                      (delta I O {z : Bin // cl.down z = Sum.inr PUnit.unit}
+                        (fun m ↦ precomp I O a.1 a.2 (K (precompMerge I a.1 a.2 cl.down m))))
+                      (mplus.{uA, uB, uI} I (L ++ [(⟨Bout, iout⟩ : SupObj.{uB, uI} I)]) X))
+                    (ULift.up (fun _ : Bin ↦ (Sum.inr PUnit.unit : a.1 ⊕ PUnit.{uB + 1}))))))))))
+      (Eq.trans
+        (FreeCoprodCompDisc.Hom.comp_assoc O
+          (FreeCoprodCompDisc.Iso.hom O
+            (mprecompIso.{uA, uB, uI, uO} I O (L ++ [(⟨Bout, iout⟩ : SupObj.{uB, uI} I)])
+              (precomp I O a.1 a.2 (K (iout ∘ g))) X))
+          (FreeCoprodCompDisc.Hom.comp O
+            (FreeCoprodCompDisc.coprodInj O
+              (FreeCoprodCompDisc.Hom I
+                (FreeCoprodCompDisc.lift.{uB, uI, max uA uB} I
+                  ⟨
+                    {z : Bin // (fun _ : Bin ↦ (Sum.inr PUnit.unit : a.1 ⊕ PUnit.{uB + 1})) z =
+                      Sum.inr PUnit.unit}, fun z ↦ (iout ∘ g) z.1⟩)
+                (mplus.{uA, uB, uI} I (L ++ [(⟨Bout, iout⟩ : SupObj.{uB, uI} I)]) X))
+              (fun _ ↦ interpObj I O
+                (precomp I O a.1 a.2
+                  (K
+                    (precompMerge I a.1 a.2
+                      (fun _ : Bin ↦ (Sum.inr PUnit.unit : a.1 ⊕ PUnit.{uB + 1}))
+                      (fun z :
+                        {z : Bin // (fun _ : Bin ↦ (Sum.inr PUnit.unit : a.1 ⊕ PUnit.{uB + 1})) z =
+                          Sum.inr PUnit.unit} ↦ (iout ∘ g) z.1))))
+                (mplus.{uA, uB, uI} I (L ++ [(⟨Bout, iout⟩ : SupObj.{uB, uI} I)]) X))
+              (navWeight I Bout iout
+                {z : Bin // (fun _ : Bin ↦ (Sum.inr PUnit.unit : a.1 ⊕ PUnit.{uB + 1})) z = Sum.inr
+                  PUnit.unit} (fun z ↦ g z.1) X L))
+            (deltaInto I O
+              {z : Bin // (fun _ : Bin ↦ (Sum.inr PUnit.unit : a.1 ⊕ PUnit.{uB + 1})) z = Sum.inr
+                PUnit.unit}
+              (fun m ↦ precomp I O a.1 a.2
+                (K
+                  (precompMerge I a.1 a.2
+                    (fun _ : Bin ↦ (Sum.inr PUnit.unit : a.1 ⊕ PUnit.{uB + 1})) m)))
+              (fun z ↦ (iout ∘ g) z.1)
+              (mplus.{uA, uB, uI} I (L ++ [(⟨Bout, iout⟩ : SupObj.{uB, uI} I)]) X)))
+          (FreeCoprodCompDisc.Hom.comp O
+            (FreeCoprodCompDisc.coprodInj O (ULift.{max uA uB, uB} (Bin → a.1 ⊕ PUnit.{uB + 1}))
+              (fun cl ↦ interpObj I O
+                (delta I O {z : Bin // cl.down z = Sum.inr PUnit.unit}
+                  (fun m ↦ precomp I O a.1 a.2 (K (precompMerge I a.1 a.2 cl.down m))))
+                (mplus.{uA, uB, uI} I (L ++ [(⟨Bout, iout⟩ : SupObj.{uB, uI} I)]) X))
+              (ULift.up (fun _ : Bin ↦ (Sum.inr PUnit.unit : a.1 ⊕ PUnit.{uB + 1}))))
+            (FreeCoprodCompDisc.Iso.invHom O
+              (mprecompIso.{uA, uB, uI, uO} I O (L ++ [(⟨Bout, iout⟩ : SupObj.{uB, uI} I)])
+                (sigma I O (ULift.{max uA uB, uB} (Bin → a.1 ⊕ PUnit.{uB + 1}))
+                  (fun cl ↦ delta I O {z : Bin // cl.down z = Sum.inr PUnit.unit}
+                    (fun m ↦ precomp I O a.1 a.2 (K (precompMerge I a.1 a.2 cl.down m))))) X))))
+        (Eq.trans
+          (congrArg
+            (FreeCoprodCompDisc.Hom.comp O
+              (FreeCoprodCompDisc.Iso.hom O
+                (mprecompIso.{uA, uB, uI, uO} I O (L ++ [(⟨Bout, iout⟩ : SupObj.{uB, uI} I)])
+                  (precomp I O a.1 a.2 (K (iout ∘ g))) X)))
+            (Eq.symm
+              (FreeCoprodCompDisc.Hom.comp_assoc O
+                (FreeCoprodCompDisc.Hom.comp O
+                  (FreeCoprodCompDisc.coprodInj O
+                    (FreeCoprodCompDisc.Hom I
+                      (FreeCoprodCompDisc.lift.{uB, uI, max uA uB} I
+                        ⟨
+                          {z : Bin // (fun _ : Bin ↦ (Sum.inr PUnit.unit : a.1 ⊕ PUnit.{uB + 1})) z
+                            = Sum.inr PUnit.unit}, fun z ↦ (iout ∘ g) z.1⟩)
+                      (mplus.{uA, uB, uI} I (L ++ [(⟨Bout, iout⟩ : SupObj.{uB, uI} I)]) X))
+                    (fun _ ↦ interpObj I O
+                      (precomp I O a.1 a.2
+                        (K
+                          (precompMerge I a.1 a.2
+                            (fun _ : Bin ↦ (Sum.inr PUnit.unit : a.1 ⊕ PUnit.{uB + 1}))
+                            (fun z :
+                              {z : Bin //
+                                (fun _ : Bin ↦ (Sum.inr PUnit.unit : a.1 ⊕ PUnit.{uB + 1})) z =
+                                Sum.inr PUnit.unit} ↦ (iout ∘ g) z.1))))
+                      (mplus.{uA, uB, uI} I (L ++ [(⟨Bout, iout⟩ : SupObj.{uB, uI} I)]) X))
+                    (navWeight I Bout iout
+                      {z : Bin // (fun _ : Bin ↦ (Sum.inr PUnit.unit : a.1 ⊕ PUnit.{uB + 1})) z =
+                        Sum.inr PUnit.unit} (fun z ↦ g z.1) X L))
+                  (deltaInto I O
+                    {z : Bin // (fun _ : Bin ↦ (Sum.inr PUnit.unit : a.1 ⊕ PUnit.{uB + 1})) z =
+                      Sum.inr PUnit.unit}
+                    (fun m ↦ precomp I O a.1 a.2
+                      (K
+                        (precompMerge I a.1 a.2
+                          (fun _ : Bin ↦ (Sum.inr PUnit.unit : a.1 ⊕ PUnit.{uB + 1})) m)))
+                    (fun z ↦ (iout ∘ g) z.1)
+                    (mplus.{uA, uB, uI} I (L ++ [(⟨Bout, iout⟩ : SupObj.{uB, uI} I)]) X)))
+                (FreeCoprodCompDisc.coprodInj O (ULift.{max uA uB, uB} (Bin → a.1 ⊕ PUnit.{uB + 1}))
+                  (fun cl ↦ interpObj I O
+                    (delta I O {z : Bin // cl.down z = Sum.inr PUnit.unit}
+                      (fun m ↦ precomp I O a.1 a.2 (K (precompMerge I a.1 a.2 cl.down m))))
+                    (mplus.{uA, uB, uI} I (L ++ [(⟨Bout, iout⟩ : SupObj.{uB, uI} I)]) X))
+                  (ULift.up (fun _ : Bin ↦ (Sum.inr PUnit.unit : a.1 ⊕ PUnit.{uB + 1}))))
+                (FreeCoprodCompDisc.Iso.invHom O
+                  (mprecompIso.{uA, uB, uI, uO} I O (L ++ [(⟨Bout, iout⟩ : SupObj.{uB, uI} I)])
+                    (sigma I O (ULift.{max uA uB, uB} (Bin → a.1 ⊕ PUnit.{uB + 1}))
+                      (fun cl ↦ delta I O {z : Bin // cl.down z = Sum.inr PUnit.unit}
+                        (fun m ↦ precomp I O a.1 a.2 (K (precompMerge I a.1 a.2 cl.down m))))) X))))
+                        )
+          (Eq.trans
+            (congrArg
+              (fun t ↦ FreeCoprodCompDisc.Hom.comp O
+                (FreeCoprodCompDisc.Iso.hom O
+                  (mprecompIso.{uA, uB, uI, uO} I O (L ++ [(⟨Bout, iout⟩ : SupObj.{uB, uI} I)])
+                    (precomp I O a.1 a.2 (K (iout ∘ g))) X))
+                (FreeCoprodCompDisc.Hom.comp O t
+                  (FreeCoprodCompDisc.Iso.invHom O
+                    (mprecompIso.{uA, uB, uI, uO} I O (L ++ [(⟨Bout, iout⟩ : SupObj.{uB, uI} I)])
+                      (sigma I O (ULift.{max uA uB, uB} (Bin → a.1 ⊕ PUnit.{uB + 1}))
+                        (fun cl ↦ delta I O {z : Bin // cl.down z = Sum.inr PUnit.unit}
+                          (fun m ↦ precomp I O a.1 a.2 (K (precompMerge I a.1 a.2 cl.down m))))) X))
+                          ))
+              (eq_comp_invHom O
+                (interpObj I O
+                  (precomp I O a.1 a.2
+                    (K
+                      (precompMerge I a.1 a.2
+                        (fun _ : Bin ↦ (Sum.inr PUnit.unit : a.1 ⊕ PUnit.{uB + 1}))
+                        (fun z :
+                          {z : Bin // (fun _ : Bin ↦ (Sum.inr PUnit.unit : a.1 ⊕ PUnit.{uB + 1})) z
+                            = Sum.inr PUnit.unit} ↦ (iout ∘ g) z.1))))
+                  (mplus.{uA, uB, uI} I (L ++ [(⟨Bout, iout⟩ : SupObj.{uB, uI} I)]) X))
+                (interpObj I O (precomp I O a.1 a.2 (delta I O Bin K))
+                  (mplus.{uA, uB, uI} I (L ++ [(⟨Bout, iout⟩ : SupObj.{uB, uI} I)]) X))
+                (interpObj I O (delta I O Bin K)
+                  (FreeCoprodCompDisc.plus.{uI, uB, max uA uB} I a
+                    (mplus.{uA, uB, uI} I (L ++ [(⟨Bout, iout⟩ : SupObj.{uB, uI} I)]) X)))
+                (FreeCoprodCompDisc.Hom.comp O
+                  (FreeCoprodCompDisc.Hom.comp O
+                    (FreeCoprodCompDisc.coprodInj O
+                      (FreeCoprodCompDisc.Hom I
+                        (FreeCoprodCompDisc.lift.{uB, uI, max uA uB} I
+                          ⟨
+                            {z : Bin // (fun _ : Bin ↦ (Sum.inr PUnit.unit : a.1 ⊕ PUnit.{uB + 1}))
+                              z = Sum.inr PUnit.unit}, fun z ↦ (iout ∘ g) z.1⟩)
+                        (mplus.{uA, uB, uI} I (L ++ [(⟨Bout, iout⟩ : SupObj.{uB, uI} I)]) X))
+                      (fun _ ↦ interpObj I O
+                        (precomp I O a.1 a.2
+                          (K
+                            (precompMerge I a.1 a.2
+                              (fun _ : Bin ↦ (Sum.inr PUnit.unit : a.1 ⊕ PUnit.{uB + 1}))
+                              (fun z :
+                                {z : Bin //
+                                  (fun _ : Bin ↦ (Sum.inr PUnit.unit : a.1 ⊕ PUnit.{uB + 1})) z =
+                                  Sum.inr PUnit.unit} ↦ (iout ∘ g) z.1))))
+                        (mplus.{uA, uB, uI} I (L ++ [(⟨Bout, iout⟩ : SupObj.{uB, uI} I)]) X))
+                      (navWeight I Bout iout
+                        {z : Bin // (fun _ : Bin ↦ (Sum.inr PUnit.unit : a.1 ⊕ PUnit.{uB + 1})) z =
+                          Sum.inr PUnit.unit} (fun z ↦ g z.1) X L))
+                    (deltaInto I O
+                      {z : Bin // (fun _ : Bin ↦ (Sum.inr PUnit.unit : a.1 ⊕ PUnit.{uB + 1})) z =
+                        Sum.inr PUnit.unit}
+                      (fun m ↦ precomp I O a.1 a.2
+                        (K
+                          (precompMerge I a.1 a.2
+                            (fun _ : Bin ↦ (Sum.inr PUnit.unit : a.1 ⊕ PUnit.{uB + 1})) m)))
+                      (fun z ↦ (iout ∘ g) z.1)
+                      (mplus.{uA, uB, uI} I (L ++ [(⟨Bout, iout⟩ : SupObj.{uB, uI} I)]) X)))
+                  (FreeCoprodCompDisc.coprodInj O
+                    (ULift.{max uA uB, uB} (Bin → a.1 ⊕ PUnit.{uB + 1}))
+                    (fun cl ↦ interpObj I O
+                      (delta I O {z : Bin // cl.down z = Sum.inr PUnit.unit}
+                        (fun m ↦ precomp I O a.1 a.2 (K (precompMerge I a.1 a.2 cl.down m))))
+                      (mplus.{uA, uB, uI} I (L ++ [(⟨Bout, iout⟩ : SupObj.{uB, uI} I)]) X))
+                    (ULift.up (fun _ : Bin ↦ (Sum.inr PUnit.unit : a.1 ⊕ PUnit.{uB + 1})))))
+                (FreeCoprodCompDisc.Hom.comp O
+                  (FreeCoprodCompDisc.Hom.comp O
+                    (FreeCoprodCompDisc.Iso.hom O
+                      (interpPrecompIso I O (K (iout ∘ g)) a.1 a.2
+                        (mplus.{uA, uB, uI} I (L ++ [(⟨Bout, iout⟩ : SupObj.{uB, uI} I)]) X)))
+                    (FreeCoprodCompDisc.coprodInj O
+                      (FreeCoprodCompDisc.Hom I
+                        (FreeCoprodCompDisc.lift.{uB, uI, max uA uB} I ⟨Bin, iout ∘ g⟩)
+                        (FreeCoprodCompDisc.plus.{uI, uB, max uA uB} I a
+                          (mplus.{uA, uB, uI} I (L ++ [(⟨Bout, iout⟩ : SupObj.{uB, uI} I)]) X)))
+                      (fun _ ↦ interpObj I O (K (iout ∘ g))
+                        (FreeCoprodCompDisc.plus.{uI, uB, max uA uB} I a
+                          (mplus.{uA, uB, uI} I (L ++ [(⟨Bout, iout⟩ : SupObj.{uB, uI} I)]) X)))
+                      (FreeCoprodCompDisc.Hom.comp I (navReindex.{uA, uB, uI} I Bin (iout ∘ g) a.1)
+                        (FreeCoprodCompDisc.Hom.comp I
+                          (navWeight I Bout iout
+                            {z : Bin // (fun _ : Bin ↦ (Sum.inr PUnit.unit : a.1 ⊕ PUnit.{uB + 1}))
+                              z = Sum.inr PUnit.unit} (fun z ↦ g z.1) X L)
+                          (FreeCoprodCompDisc.coprodPairInr.{uI, uB, max uA uB} I a
+                            (mplus.{uA, uB, uI} I (L ++ [(⟨Bout, iout⟩ : SupObj.{uB, uI} I)]) X)))))
+                            )
+                  (deltaInto I O Bin K (iout ∘ g)
+                    (FreeCoprodCompDisc.plus.{uI, uB, max uA uB} I a
+                      (mplus.{uA, uB, uI} I (L ++ [(⟨Bout, iout⟩ : SupObj.{uB, uI} I)]) X))))
+                (interpPrecompIso I O (delta I O Bin K) a.1 a.2
+                  (mplus.{uA, uB, uI} I (L ++ [(⟨Bout, iout⟩ : SupObj.{uB, uI} I)]) X))
+                (interpPrecompIso_deltaNavAll_inj I O Bin K a.1 a.2 (iout ∘ g)
+                  (mplus.{uA, uB, uI} I (L ++ [(⟨Bout, iout⟩ : SupObj.{uB, uI} I)]) X)
+                  (navWeight I Bout iout
+                    {z : Bin // (fun _ : Bin ↦ (Sum.inr PUnit.unit : a.1 ⊕ PUnit.{uB + 1})) z =
+                      Sum.inr PUnit.unit} (fun z ↦ g z.1) X L))))
+            (Eq.trans
+              (congrArg
+                (fun w ↦ FreeCoprodCompDisc.Hom.comp O
+                  (FreeCoprodCompDisc.Iso.hom O
+                    (mprecompIso.{uA, uB, uI, uO} I O (L ++ [(⟨Bout, iout⟩ : SupObj.{uB, uI} I)])
+                      (precomp I O a.1 a.2 (K (iout ∘ g))) X))
+                  (FreeCoprodCompDisc.Hom.comp O
+                    (FreeCoprodCompDisc.Hom.comp O
+                      (FreeCoprodCompDisc.Hom.comp O
+                        (FreeCoprodCompDisc.Hom.comp O
+                          (FreeCoprodCompDisc.Iso.hom O
+                            (interpPrecompIso I O (K (iout ∘ g)) a.1 a.2
+                              (mplus.{uA, uB, uI} I (L ++ [(⟨Bout, iout⟩ : SupObj.{uB, uI} I)]) X)))
+                          (FreeCoprodCompDisc.coprodInj O
+                            (FreeCoprodCompDisc.Hom I
+                              (FreeCoprodCompDisc.lift.{uB, uI, max uA uB} I ⟨Bin, iout ∘ g⟩)
+                              (FreeCoprodCompDisc.plus.{uI, uB, max uA uB} I a
+                                (mplus.{uA, uB, uI} I (L ++ [(⟨Bout, iout⟩ : SupObj.{uB, uI} I)]) X)
+                                ))
+                            (fun _ ↦ interpObj I O (K (iout ∘ g))
+                              (FreeCoprodCompDisc.plus.{uI, uB, max uA uB} I a
+                                (mplus.{uA, uB, uI} I (L ++ [(⟨Bout, iout⟩ : SupObj.{uB, uI} I)]) X)
+                                )) (w)))
+                        (deltaInto I O Bin K (iout ∘ g)
+                          (FreeCoprodCompDisc.plus.{uI, uB, max uA uB} I a
+                            (mplus.{uA, uB, uI} I (L ++ [(⟨Bout, iout⟩ : SupObj.{uB, uI} I)]) X))))
+                      (FreeCoprodCompDisc.Iso.invHom O
+                        (interpPrecompIso I O (delta I O Bin K) a.1 a.2
+                          (mplus.{uA, uB, uI} I (L ++ [(⟨Bout, iout⟩ : SupObj.{uB, uI} I)]) X))))
+                    (FreeCoprodCompDisc.Iso.invHom O
+                      (mprecompIso.{uA, uB, uI, uO} I O (L ++ [(⟨Bout, iout⟩ : SupObj.{uB, uI} I)])
+                        (sigma I O (ULift.{max uA uB, uB} (Bin → a.1 ⊕ PUnit.{uB + 1}))
+                          (fun cl ↦ delta I O {z : Bin // cl.down z = Sum.inr PUnit.unit}
+                            (fun m ↦ precomp I O a.1 a.2 (K (precompMerge I a.1 a.2 cl.down m))))) X
+                            ))))
+                (Eq.trans
+                  (Eq.symm
+                    (FreeCoprodCompDisc.Hom.comp_assoc I
+                      (navReindex.{uA, uB, uI} I Bin (iout ∘ g) a.1)
+                      (navWeight I Bout iout
+                        {z : Bin // (fun _ : Bin ↦ (Sum.inr PUnit.unit : a.1 ⊕ PUnit.{uB + 1})) z =
+                          Sum.inr PUnit.unit} (fun z ↦ g z.1) X L)
+                      (FreeCoprodCompDisc.coprodPairInr.{uI, uB, max uA uB} I a
+                        (mplus.{uA, uB, uI} I (L ++ [(⟨Bout, iout⟩ : SupObj.{uB, uI} I)]) X))))
+                  (congrArg
+                    (fun t ↦ FreeCoprodCompDisc.Hom.comp I t
+                      (FreeCoprodCompDisc.coprodPairInr.{uI, uB, max uA uB} I a
+                        (mplus.{uA, uB, uI} I (L ++ [(⟨Bout, iout⟩ : SupObj.{uB, uI} I)]) X)))
+                    (navWeight_reindex I Bout iout Bin g a.1 X L))))
+              (Eq.trans
+                (congrArg
+                  (FreeCoprodCompDisc.Hom.comp O
+                    (FreeCoprodCompDisc.Iso.hom O
+                      (mprecompIso.{uA, uB, uI, uO} I O (L ++ [(⟨Bout, iout⟩ : SupObj.{uB, uI} I)])
+                        (precomp I O a.1 a.2 (K (iout ∘ g))) X)))
+                  (FreeCoprodCompDisc.Hom.comp_assoc O
+                    (FreeCoprodCompDisc.Hom.comp O
+                      (FreeCoprodCompDisc.Hom.comp O
+                        (FreeCoprodCompDisc.Iso.hom O
+                          (interpPrecompIso I O (K (iout ∘ g)) a.1 a.2
+                            (mplus.{uA, uB, uI} I (L ++ [(⟨Bout, iout⟩ : SupObj.{uB, uI} I)]) X)))
+                        (FreeCoprodCompDisc.coprodInj O
+                          (FreeCoprodCompDisc.Hom I
+                            (FreeCoprodCompDisc.lift.{uB, uI, max uA uB} I ⟨Bin, iout ∘ g⟩)
+                            (FreeCoprodCompDisc.plus.{uI, uB, max uA uB} I a
+                              (mplus.{uA, uB, uI} I (L ++ [(⟨Bout, iout⟩ : SupObj.{uB, uI} I)]) X)))
+                          (fun _ ↦ interpObj I O (K (iout ∘ g))
+                            (FreeCoprodCompDisc.plus.{uI, uB, max uA uB} I a
+                              (mplus.{uA, uB, uI} I (L ++ [(⟨Bout, iout⟩ : SupObj.{uB, uI} I)]) X)))
+                          (FreeCoprodCompDisc.Hom.comp I (navWeight I Bout iout Bin g X L)
+                            (FreeCoprodCompDisc.coprodPairInr.{uI, uB, max uA uB} I a
+                              (mplus.{uA, uB, uI} I (L ++ [(⟨Bout, iout⟩ : SupObj.{uB, uI} I)]) X)))
+                              ))
+                      (deltaInto I O Bin K (iout ∘ g)
+                        (FreeCoprodCompDisc.plus.{uI, uB, max uA uB} I a
+                          (mplus.{uA, uB, uI} I (L ++ [(⟨Bout, iout⟩ : SupObj.{uB, uI} I)]) X))))
+                    (FreeCoprodCompDisc.Iso.invHom O
+                      (interpPrecompIso I O (delta I O Bin K) a.1 a.2
+                        (mplus.{uA, uB, uI} I (L ++ [(⟨Bout, iout⟩ : SupObj.{uB, uI} I)]) X)))
+                    (FreeCoprodCompDisc.Iso.invHom O
+                      (mprecompIso.{uA, uB, uI, uO} I O (L ++ [(⟨Bout, iout⟩ : SupObj.{uB, uI} I)])
+                        (sigma I O (ULift.{max uA uB, uB} (Bin → a.1 ⊕ PUnit.{uB + 1}))
+                          (fun cl ↦ delta I O {z : Bin // cl.down z = Sum.inr PUnit.unit}
+                            (fun m ↦ precomp I O a.1 a.2 (K (precompMerge I a.1 a.2 cl.down m))))) X
+                            ))))
+                (Eq.trans
+                  (congrArg
+                    (fun t ↦ FreeCoprodCompDisc.Hom.comp O
+                      (FreeCoprodCompDisc.Iso.hom O
+                        (mprecompIso.{uA, uB, uI, uO} I O
+                          (L ++ [(⟨Bout, iout⟩ : SupObj.{uB, uI} I)])
+                          (precomp I O a.1 a.2 (K (iout ∘ g))) X))
+                      (FreeCoprodCompDisc.Hom.comp O t
+                        (FreeCoprodCompDisc.Hom.comp O
+                          (FreeCoprodCompDisc.Iso.invHom O
+                            (interpPrecompIso I O (delta I O Bin K) a.1 a.2
+                              (mplus.{uA, uB, uI} I (L ++ [(⟨Bout, iout⟩ : SupObj.{uB, uI} I)]) X)))
+                          (FreeCoprodCompDisc.Iso.invHom O
+                            (mprecompIso.{uA, uB, uI, uO} I O
+                              (L ++ [(⟨Bout, iout⟩ : SupObj.{uB, uI} I)])
+                              (sigma I O (ULift.{max uA uB, uB} (Bin → a.1 ⊕ PUnit.{uB + 1}))
+                                (fun cl ↦ delta I O {z : Bin // cl.down z = Sum.inr PUnit.unit}
+                                  (fun m ↦ precomp I O a.1 a.2
+                                    (K (precompMerge I a.1 a.2 cl.down m))))) X)))))
+                    (FreeCoprodCompDisc.Hom.comp_assoc O
+                      (FreeCoprodCompDisc.Iso.hom O
+                        (interpPrecompIso I O (K (iout ∘ g)) a.1 a.2
+                          (mplus.{uA, uB, uI} I (L ++ [(⟨Bout, iout⟩ : SupObj.{uB, uI} I)]) X)))
+                      (FreeCoprodCompDisc.coprodInj O
+                        (FreeCoprodCompDisc.Hom I
+                          (FreeCoprodCompDisc.lift.{uB, uI, max uA uB} I ⟨Bin, iout ∘ g⟩)
+                          (FreeCoprodCompDisc.plus.{uI, uB, max uA uB} I a
+                            (mplus.{uA, uB, uI} I (L ++ [(⟨Bout, iout⟩ : SupObj.{uB, uI} I)]) X)))
+                        (fun _ ↦ interpObj I O (K (iout ∘ g))
+                          (FreeCoprodCompDisc.plus.{uI, uB, max uA uB} I a
+                            (mplus.{uA, uB, uI} I (L ++ [(⟨Bout, iout⟩ : SupObj.{uB, uI} I)]) X)))
+                        (FreeCoprodCompDisc.Hom.comp I (navWeight I Bout iout Bin g X L)
+                          (FreeCoprodCompDisc.coprodPairInr.{uI, uB, max uA uB} I a
+                            (mplus.{uA, uB, uI} I (L ++ [(⟨Bout, iout⟩ : SupObj.{uB, uI} I)]) X))))
+                      (deltaInto I O Bin K (iout ∘ g)
+                        (FreeCoprodCompDisc.plus.{uI, uB, max uA uB} I a
+                          (mplus.{uA, uB, uI} I (L ++ [(⟨Bout, iout⟩ : SupObj.{uB, uI} I)]) X)))))
+                  (Eq.trans
+                    (Eq.symm
+                      (FreeCoprodCompDisc.Hom.comp_assoc O
+                        (FreeCoprodCompDisc.Iso.hom O
+                          (mprecompIso.{uA, uB, uI, uO} I O
+                            (L ++ [(⟨Bout, iout⟩ : SupObj.{uB, uI} I)])
+                            (precomp I O a.1 a.2 (K (iout ∘ g))) X))
+                        (FreeCoprodCompDisc.Hom.comp O
+                          (FreeCoprodCompDisc.Iso.hom O
+                            (interpPrecompIso I O (K (iout ∘ g)) a.1 a.2
+                              (mplus.{uA, uB, uI} I (L ++ [(⟨Bout, iout⟩ : SupObj.{uB, uI} I)]) X)))
+                          (FreeCoprodCompDisc.Hom.comp O
+                            (FreeCoprodCompDisc.coprodInj O
+                              (FreeCoprodCompDisc.Hom I
+                                (FreeCoprodCompDisc.lift.{uB, uI, max uA uB} I ⟨Bin, iout ∘ g⟩)
+                                (FreeCoprodCompDisc.plus.{uI, uB, max uA uB} I a
+                                  (mplus.{uA, uB, uI} I (L ++ [(⟨Bout, iout⟩ : SupObj.{uB, uI} I)])
+                                    X)))
+                              (fun _ ↦ interpObj I O (K (iout ∘ g))
+                                (FreeCoprodCompDisc.plus.{uI, uB, max uA uB} I a
+                                  (mplus.{uA, uB, uI} I (L ++ [(⟨Bout, iout⟩ : SupObj.{uB, uI} I)])
+                                    X)))
+                              (FreeCoprodCompDisc.Hom.comp I (navWeight I Bout iout Bin g X L)
+                                (FreeCoprodCompDisc.coprodPairInr.{uI, uB, max uA uB} I a
+                                  (mplus.{uA, uB, uI} I (L ++ [(⟨Bout, iout⟩ : SupObj.{uB, uI} I)])
+                                    X))))
+                            (deltaInto I O Bin K (iout ∘ g)
+                              (FreeCoprodCompDisc.plus.{uI, uB, max uA uB} I a
+                                (mplus.{uA, uB, uI} I (L ++ [(⟨Bout, iout⟩ : SupObj.{uB, uI} I)]) X)
+                                ))))
+                        (FreeCoprodCompDisc.Hom.comp O
+                          (FreeCoprodCompDisc.Iso.invHom O
+                            (interpPrecompIso I O (delta I O Bin K) a.1 a.2
+                              (mplus.{uA, uB, uI} I (L ++ [(⟨Bout, iout⟩ : SupObj.{uB, uI} I)]) X)))
+                          (FreeCoprodCompDisc.Iso.invHom O
+                            (mprecompIso.{uA, uB, uI, uO} I O
+                              (L ++ [(⟨Bout, iout⟩ : SupObj.{uB, uI} I)])
+                              (sigma I O (ULift.{max uA uB, uB} (Bin → a.1 ⊕ PUnit.{uB + 1}))
+                                (fun cl ↦ delta I O {z : Bin // cl.down z = Sum.inr PUnit.unit}
+                                  (fun m ↦ precomp I O a.1 a.2
+                                    (K (precompMerge I a.1 a.2 cl.down m))))) X)))))
+                    (congrArg
+                      (fun t ↦ FreeCoprodCompDisc.Hom.comp O t
+                        (FreeCoprodCompDisc.Hom.comp O
+                          (FreeCoprodCompDisc.Iso.invHom O
+                            (interpPrecompIso I O (delta I O Bin K) a.1 a.2
+                              (mplus.{uA, uB, uI} I (L ++ [(⟨Bout, iout⟩ : SupObj.{uB, uI} I)]) X)))
+                          (FreeCoprodCompDisc.Iso.invHom O
+                            (mprecompIso.{uA, uB, uI, uO} I O
+                              (L ++ [(⟨Bout, iout⟩ : SupObj.{uB, uI} I)])
+                              (sigma I O (ULift.{max uA uB, uB} (Bin → a.1 ⊕ PUnit.{uB + 1}))
+                                (fun cl ↦ delta I O {z : Bin // cl.down z = Sum.inr PUnit.unit}
+                                  (fun m ↦ precomp I O a.1 a.2
+                                    (K (precompMerge I a.1 a.2 cl.down m))))) X))))
+                      (Eq.symm
+                        (FreeCoprodCompDisc.Hom.comp_assoc O
+                          (FreeCoprodCompDisc.Iso.hom O
+                            (mprecompIso.{uA, uB, uI, uO} I O
+                              (L ++ [(⟨Bout, iout⟩ : SupObj.{uB, uI} I)])
+                              (precomp I O a.1 a.2 (K (iout ∘ g))) X))
+                          (FreeCoprodCompDisc.Iso.hom O
+                            (interpPrecompIso I O (K (iout ∘ g)) a.1 a.2
+                              (mplus.{uA, uB, uI} I (L ++ [(⟨Bout, iout⟩ : SupObj.{uB, uI} I)]) X)))
+                          (FreeCoprodCompDisc.Hom.comp O
+                            (FreeCoprodCompDisc.coprodInj O
+                              (FreeCoprodCompDisc.Hom I
+                                (FreeCoprodCompDisc.lift.{uB, uI, max uA uB} I ⟨Bin, iout ∘ g⟩)
+                                (FreeCoprodCompDisc.plus.{uI, uB, max uA uB} I a
+                                  (mplus.{uA, uB, uI} I (L ++ [(⟨Bout, iout⟩ : SupObj.{uB, uI} I)])
+                                    X)))
+                              (fun _ ↦ interpObj I O (K (iout ∘ g))
+                                (FreeCoprodCompDisc.plus.{uI, uB, max uA uB} I a
+                                  (mplus.{uA, uB, uI} I (L ++ [(⟨Bout, iout⟩ : SupObj.{uB, uI} I)])
+                                    X)))
+                              (FreeCoprodCompDisc.Hom.comp I (navWeight I Bout iout Bin g X L)
+                                (FreeCoprodCompDisc.coprodPairInr.{uI, uB, max uA uB} I a
+                                  (mplus.{uA, uB, uI} I (L ++ [(⟨Bout, iout⟩ : SupObj.{uB, uI} I)])
+                                    X))))
+                            (deltaInto I O Bin K (iout ∘ g)
+                              (FreeCoprodCompDisc.plus.{uI, uB, max uA uB} I a
+                                (mplus.{uA, uB, uI} I (L ++ [(⟨Bout, iout⟩ : SupObj.{uB, uI} I)]) X)
+                                ))))))))))))))
+
+/-- The `IR.deltaNav` characterization: `IR.interpHom` sends the
+tower navigation to the composite with the tower-conjugated
+navigation inclusion `IR.navInj`, by `List.rec` following
+`IR.deltaNav`'s own recursion. -/
+theorem interpHom_deltaNav (D : IR.{max uA uB, uB, uI, uO} I O)
+    (Bout : Type uB) (iout : Bout → I) (Bin : Type uB)
+    (K : (Bin → I) → IR.{max uA uB, uB, uI, uO} I O) (g : Bin → Bout)
+    (L : List (SupObj.{uB, uI} I))
+    (f : Hom.{uA, uB, uI, uO} I O D
+      (mprecomp I O (L ++ [(⟨Bout, iout⟩ : SupObj.{uB, uI} I)]) (K (iout ∘ g))))
+    (X : FreeCoprodCompDisc.{max uA uB, uI} I) :
+    (interpHom I O D
+        (mprecomp I O (L ++ [(⟨Bout, iout⟩ : SupObj.{uB, uI} I)])
+          (delta I O Bin K))
+        (deltaNav I O D Bout iout Bin K g L f)).1 X =
+      FreeCoprodCompDisc.Hom.comp O
+        ((interpHom I O D
+          (mprecomp I O (L ++ [(⟨Bout, iout⟩ : SupObj.{uB, uI} I)])
+            (K (iout ∘ g))) f).1 X)
+        (navInj I O Bout iout Bin K g L X) :=
+  L.rec (motive := fun L' : List (SupObj.{uB, uI} I) ↦
+      ∀ (Bin' : Type uB) (K' : (Bin' → I) → IR.{max uA uB, uB, uI, uO} I O)
+        (g' : Bin' → Bout)
+        (f' : Hom.{uA, uB, uI, uO} I O D
+          (mprecomp I O (L' ++ [(⟨Bout, iout⟩ : SupObj.{uB, uI} I)])
+            (K' (iout ∘ g'))))
+        (X' : FreeCoprodCompDisc.{max uA uB, uI} I),
+      (interpHom I O D
+          (mprecomp I O (L' ++ [(⟨Bout, iout⟩ : SupObj.{uB, uI} I)])
+            (delta I O Bin' K'))
+          (deltaNav I O D Bout iout Bin' K' g' L' f')).1 X' =
+        FreeCoprodCompDisc.Hom.comp O
+          ((interpHom I O D
+            (mprecomp I O (L' ++ [(⟨Bout, iout⟩ : SupObj.{uB, uI} I)])
+              (K' (iout ∘ g'))) f').1 X')
+          (navInj I O Bout iout Bin' K' g' L' X'))
+    (fun Bin' K' g' f' X' ↦
+      (interpHom_deltaNavBase I O D Bout iout Bin' K' g' f' X').trans
+        (congrArg
+          (FreeCoprodCompDisc.Hom.comp O
+            ((interpHom I O D (precomp I O Bout iout (K' (iout ∘ g'))) f').1 X'))
+          (navInj_nil I O Bout iout Bin' K' g' X')))
+    (fun a _L ih Bin' K' g' f' X' ↦
+      Eq.trans (interpHom_msigmaPush I O D (ULift.{max uA uB, uB} (Bin' → a.1 ⊕ PUnit.{uB + 1}))
+        (fun cl ↦ delta I O {z : Bin' // cl.down z = Sum.inr PUnit.unit} (fun m ↦ precomp I O
+        a.1 a.2 (K' (precompMerge I a.1 a.2 cl.down m)))) (ULift.up (fun _ ↦ Sum.inr PUnit.unit))
+        (_L ++ [(⟨Bout, iout⟩ : SupObj.{uB, uI} I)]) (deltaNav I O D Bout iout {z : Bin' // (fun _
+        : Bin' ↦ (Sum.inr PUnit.unit : a.1 ⊕ PUnit.{uB + 1})) z = Sum.inr PUnit.unit} (fun m ↦
+        precomp I O a.1 a.2 (K' (precompMerge I a.1 a.2 (fun _ : Bin' ↦ (Sum.inr PUnit.unit : a.1
+        ⊕ PUnit.{uB + 1})) m))) (fun z ↦ g' z.1) _L f') X') (Eq.trans (congrArg (fun t ↦
+        FreeCoprodCompDisc.Hom.comp O t (FreeCoprodCompDisc.Hom.comp O
+        (FreeCoprodCompDisc.Hom.comp O (FreeCoprodCompDisc.Iso.hom O (mprecompIso.{uA, uB, uI, uO}
+        I O (_L ++ [(⟨Bout, iout⟩ : SupObj.{uB, uI} I)]) (delta I O {z : Bin' // (fun _ : Bin' ↦
+        (Sum.inr PUnit.unit : a.1 ⊕ PUnit.{uB + 1})) z = Sum.inr PUnit.unit} (fun m ↦ precomp I O
+        a.1 a.2 (K' (precompMerge I a.1 a.2 (fun _ : Bin' ↦ (Sum.inr PUnit.unit : a.1 ⊕ PUnit.{uB
+        + 1})) m)))) X')) (FreeCoprodCompDisc.coprodInj O (ULift.{max uA uB, uB} (Bin' → a.1 ⊕
+        PUnit.{uB + 1})) (fun cl ↦ interpObj I O (delta I O {z : Bin' // cl.down z = Sum.inr
+        PUnit.unit} (fun m ↦ precomp I O a.1 a.2 (K' (precompMerge I a.1 a.2 cl.down m))))
+        (mplus.{uA, uB, uI} I (_L ++ [(⟨Bout, iout⟩ : SupObj.{uB, uI} I)]) X')) (ULift.up (fun _
+        ↦ Sum.inr PUnit.unit)))) (FreeCoprodCompDisc.Iso.invHom O (mprecompIso.{uA, uB, uI, uO} I
+        O (_L ++ [(⟨Bout, iout⟩ : SupObj.{uB, uI} I)]) (sigma I O (ULift.{max uA uB, uB} (Bin' →
+        a.1 ⊕ PUnit.{uB + 1})) (fun cl ↦ delta I O {z : Bin' // cl.down z = Sum.inr PUnit.unit}
+        (fun m ↦ precomp I O a.1 a.2 (K' (precompMerge I a.1 a.2 cl.down m))))) X')))) (ih {z :
+        Bin' // (fun _ : Bin' ↦ (Sum.inr PUnit.unit : a.1 ⊕ PUnit.{uB + 1})) z = Sum.inr
+        PUnit.unit} (fun m ↦ precomp I O a.1 a.2 (K' (precompMerge I a.1 a.2 (fun _ : Bin' ↦
+        (Sum.inr PUnit.unit : a.1 ⊕ PUnit.{uB + 1})) m))) (fun z ↦ g' z.1) f' X')) (Eq.trans
+        (FreeCoprodCompDisc.Hom.comp_assoc O ((interpHom I O D (mprecomp I O (_L ++ [(⟨Bout, iout⟩
+        : SupObj.{uB, uI} I)]) (precomp I O a.1 a.2 (K' (iout ∘ g')))) f').1 X') (navInj I O Bout
+        iout {z : Bin' // (fun _ : Bin' ↦ (Sum.inr PUnit.unit : a.1 ⊕ PUnit.{uB + 1})) z =
+        Sum.inr PUnit.unit} (fun m ↦ precomp I O a.1 a.2 (K' (precompMerge I a.1 a.2 (fun _ :
+        Bin' ↦ (Sum.inr PUnit.unit : a.1 ⊕ PUnit.{uB + 1})) m))) (fun z ↦ g' z.1) _L X')
+        (FreeCoprodCompDisc.Hom.comp O (FreeCoprodCompDisc.Hom.comp O (FreeCoprodCompDisc.Iso.hom
+        O (mprecompIso.{uA, uB, uI, uO} I O (_L ++ [(⟨Bout, iout⟩ : SupObj.{uB, uI} I)]) (delta I
+        O {z : Bin' // (fun _ : Bin' ↦ (Sum.inr PUnit.unit : a.1 ⊕ PUnit.{uB + 1})) z = Sum.inr
+        PUnit.unit} (fun m ↦ precomp I O a.1 a.2 (K' (precompMerge I a.1 a.2 (fun _ : Bin' ↦
+        (Sum.inr PUnit.unit : a.1 ⊕ PUnit.{uB + 1})) m)))) X')) (FreeCoprodCompDisc.coprodInj O
+        (ULift.{max uA uB, uB} (Bin' → a.1 ⊕ PUnit.{uB + 1})) (fun cl ↦ interpObj I O (delta I O
+        {z : Bin' // cl.down z = Sum.inr PUnit.unit} (fun m ↦ precomp I O a.1 a.2 (K'
+        (precompMerge I a.1 a.2 cl.down m)))) (mplus.{uA, uB, uI} I (_L ++ [(⟨Bout, iout⟩ :
+        SupObj.{uB, uI} I)]) X')) (ULift.up (fun _ ↦ Sum.inr PUnit.unit))))
+        (FreeCoprodCompDisc.Iso.invHom O (mprecompIso.{uA, uB, uI, uO} I O (_L ++ [(⟨Bout, iout⟩ :
+        SupObj.{uB, uI} I)]) (sigma I O (ULift.{max uA uB, uB} (Bin' → a.1 ⊕ PUnit.{uB + 1})) (fun
+        cl ↦ delta I O {z : Bin' // cl.down z = Sum.inr PUnit.unit} (fun m ↦ precomp I O a.1 a.2
+        (K' (precompMerge I a.1 a.2 cl.down m))))) X')))) (congrArg (FreeCoprodCompDisc.Hom.comp O
+        ((interpHom I O D (mprecomp I O (_L ++ [(⟨Bout, iout⟩ : SupObj.{uB, uI} I)]) (precomp I O
+        a.1 a.2 (K' (iout ∘ g')))) f').1 X')) (navInj_cons I O Bout iout Bin' K' g' a _L X')))))
+    Bin K g f X
+
+/-! ### The identity-image induction -/
+
+/-- The statement of the identity-image equation at one code: the
+component of `IR.interpHom` at the pre-unit is the semantic pre-unit
+component. -/
+def InterpHomPreUnitMotive (γ : IR.{max uA uB, uB, uI, uO} I O) : Prop :=
+  ∀ (L : List (SupObj.{uB, uI} I)) (X : FreeCoprodCompDisc.{max uA uB, uI} I),
+    (interpHom I O γ (mprecomp I O L γ) (preUnitStack I O γ L)).1 X =
+      preUnitComponent I O γ L X
+
+/-- Elimination of a codomain-code transport inside `IR.interpHom`, by
+elimination of the generalized equality: the transport passes to an
+object-equality transport on the component. -/
+theorem interpHom_cast_cod (D : IR.{max uA uB, uB, uI, uO} I O)
+    (γ₀ : IR.{max uA uB, uB, uI, uO} I O)
+    (X : FreeCoprodCompDisc.{max uA uB, uI} I) :
+    ∀ (γ'' : IR.{max uA uB, uB, uI, uO} I O) (h : γ₀ = γ'')
+      (f : Hom.{uA, uB, uI, uO} I O D γ₀),
+      (interpHom I O D γ'' (cast (congrArg (Hom I O D) h) f)).1 X =
+        FreeCoprodCompDisc.Hom.comp O ((interpHom I O D γ₀ f).1 X)
+          (FreeCoprodCompDisc.Iso.hom O (FreeCoprodCompDisc.isoOfEq O
+            (congrArg (fun cc ↦ interpObj I O cc X) h))) :=
+  fun _ h ↦
+    Eq.rec (motive := fun γ'' h' ↦
+        ∀ f : Hom.{uA, uB, uI, uO} I O D γ₀,
+          (interpHom I O D γ'' (cast (congrArg (Hom I O D) h') f)).1 X =
+            FreeCoprodCompDisc.Hom.comp O ((interpHom I O D γ₀ f).1 X)
+              (FreeCoprodCompDisc.Iso.hom O (FreeCoprodCompDisc.isoOfEq O
+                (congrArg (fun cc ↦ interpObj I O cc X) h'))))
+      (fun f ↦ (FreeCoprodCompDisc.Hom.comp_id O
+        ((interpHom I O D γ₀ f).1 X)).symm)
+      h
+/-- Postcomposition with an object-equality transport is the transport
+of the morphism's codomain, by elimination of the generalized
+equality. -/
+@[nolint checkUnivs]
+theorem comp_isoOfEq_hom (Z W : FreeCoprodCompDisc.{max uA uB, uI} I) :
+    ∀ (V : FreeCoprodCompDisc.{max uA uB, uI} I) (q : W = V)
+      (f : FreeCoprodCompDisc.Hom I Z W),
+      FreeCoprodCompDisc.Hom.comp I f
+          (FreeCoprodCompDisc.Iso.hom I (FreeCoprodCompDisc.isoOfEq I q)) =
+        cast (congrArg (FreeCoprodCompDisc.Hom I Z) q) f :=
+  fun _ q ↦
+    Eq.rec (motive := fun _V' q' ↦
+        ∀ f : FreeCoprodCompDisc.Hom I Z W,
+          FreeCoprodCompDisc.Hom.comp I f
+              (FreeCoprodCompDisc.Iso.hom I
+                (FreeCoprodCompDisc.isoOfEq I q')) =
+            cast (congrArg (FreeCoprodCompDisc.Hom I Z) q') f)
+      (fun f ↦ FreeCoprodCompDisc.Hom.comp_id I f) q
+/-- An object-equality transport followed by its inverse is the
+identity, by elimination of the generalized equality. -/
+@[nolint checkUnivs]
+theorem isoOfEq_symm_hom_comp (Z : FreeCoprodCompDisc.{max uA uB, uO} O) :
+    ∀ (W : FreeCoprodCompDisc.{max uA uB, uO} O) (q : Z = W),
+      FreeCoprodCompDisc.Hom.comp O
+          (FreeCoprodCompDisc.Iso.hom O (FreeCoprodCompDisc.isoOfEq O q.symm))
+          (FreeCoprodCompDisc.Iso.hom O (FreeCoprodCompDisc.isoOfEq O q)) =
+        FreeCoprodCompDisc.Hom.id O W :=
+  fun _ q ↦
+    Eq.rec (motive := fun W' q' ↦
+        FreeCoprodCompDisc.Hom.comp O
+            (FreeCoprodCompDisc.Iso.hom O
+              (FreeCoprodCompDisc.isoOfEq O q'.symm))
+            (FreeCoprodCompDisc.Iso.hom O (FreeCoprodCompDisc.isoOfEq O q')) =
+          FreeCoprodCompDisc.Hom.id O W')
+      (Subtype.ext rfl) q
+
+/-- An object-equality transport of the interpreted argument passes
+through `IR.interpMor`, by elimination of the generalized equality. -/
+theorem interpMor_isoOfEq_dom (γ' : IR.{max uA uB, uB, uI, uO} I O)
+    (W Y : FreeCoprodCompDisc.{max uA uB, uI} I) :
+    ∀ (V : FreeCoprodCompDisc.{max uA uB, uI} I) (q : W = V)
+      (h : FreeCoprodCompDisc.Hom I V Y),
+      FreeCoprodCompDisc.Hom.comp O
+          (FreeCoprodCompDisc.Iso.hom O (FreeCoprodCompDisc.isoOfEq O
+            (congrArg (interpObj I O γ') q)))
+          (interpMor I O γ' V Y h) =
+        interpMor I O γ' W Y
+          (FreeCoprodCompDisc.Hom.comp I
+            (FreeCoprodCompDisc.Iso.hom I (FreeCoprodCompDisc.isoOfEq I q)) h) :=
+  fun _ q ↦
+    Eq.rec (motive := fun V' q' ↦
+        ∀ h : FreeCoprodCompDisc.Hom I V' Y,
+          FreeCoprodCompDisc.Hom.comp O
+              (FreeCoprodCompDisc.Iso.hom O (FreeCoprodCompDisc.isoOfEq O
+                (congrArg (interpObj I O γ') q')))
+              (interpMor I O γ' V' Y h) =
+            interpMor I O γ' W Y
+              (FreeCoprodCompDisc.Hom.comp I
+                (FreeCoprodCompDisc.Iso.hom I
+                  (FreeCoprodCompDisc.isoOfEq I q')) h))
+      (fun _ ↦ rfl) q
+
+/-- The fresh right injection commutes past a coproduct-pair morphism
+with identity left component. -/
+theorem coprodPairInr_mor (a : SupObj.{uB, uI} I)
+    (Z W : FreeCoprodCompDisc.{max uA uB, uI} I)
+    (h : FreeCoprodCompDisc.Hom I Z W) :
+    FreeCoprodCompDisc.Hom.comp I (FreeCoprodCompDisc.coprodPairInr.{uI, uB, max uA uB} I a Z)
+        (FreeCoprodCompDisc.coprodPairMor I
+          (FreeCoprodCompDisc.Hom.id I a) h) =
+      FreeCoprodCompDisc.Hom.comp I h
+        (FreeCoprodCompDisc.coprodPairInr.{uI, uB, max uA uB} I a W) :=
+  Subtype.ext rfl
+
+/-- Naturality of the iterated right injection `IR.mplusInj` in the
+base object. -/
+theorem mplusInj_natural (L : List (SupObj.{uB, uI} I))
+    (Z W : FreeCoprodCompDisc.{max uA uB, uI} I)
+    (h : FreeCoprodCompDisc.Hom I Z W) :
+    FreeCoprodCompDisc.Hom.comp I (mplusInj.{uA, uB, uI} I L Z)
+        (mplusMorMap.{uA, uB, uI} I L Z W h) =
+      FreeCoprodCompDisc.Hom.comp I h (mplusInj.{uA, uB, uI} I L W) :=
+  L.rec (motive := fun L' ↦
+      FreeCoprodCompDisc.Hom.comp I (mplusInj.{uA, uB, uI} I L' Z)
+          (mplusMorMap.{uA, uB, uI} I L' Z W h) =
+        FreeCoprodCompDisc.Hom.comp I h (mplusInj.{uA, uB, uI} I L' W))
+    ((FreeCoprodCompDisc.Hom.id_comp I h).trans
+      (FreeCoprodCompDisc.Hom.comp_id I h).symm)
+    (fun a _L ih ↦
+      (FreeCoprodCompDisc.Hom.comp_assoc I (mplusInj.{uA, uB, uI} I _L Z)
+          (FreeCoprodCompDisc.coprodPairInr.{uI, uB, max uA uB} I a (mplus.{uA, uB, uI} I _L Z))
+          (FreeCoprodCompDisc.coprodPairMor I
+            (FreeCoprodCompDisc.Hom.id I a)
+            (mplusMorMap.{uA, uB, uI} I _L Z W h))).trans
+        ((congrArg
+            (FreeCoprodCompDisc.Hom.comp I (mplusInj.{uA, uB, uI} I _L Z) :
+              _ → _)
+            (coprodPairInr_mor I a (mplus.{uA, uB, uI} I _L Z)
+              (mplus.{uA, uB, uI} I _L W)
+              (mplusMorMap.{uA, uB, uI} I _L Z W h))).trans
+          ((FreeCoprodCompDisc.Hom.comp_assoc I (mplusInj.{uA, uB, uI} I _L Z)
+              (mplusMorMap.{uA, uB, uI} I _L Z W h)
+              (FreeCoprodCompDisc.coprodPairInr.{uI, uB, max uA uB} I a
+                (mplus.{uA, uB, uI} I _L W))).symm.trans
+            ((congrArg
+                (fun t ↦ FreeCoprodCompDisc.Hom.comp I t
+                  (FreeCoprodCompDisc.coprodPairInr.{uI, uB, max uA uB} I a
+                    (mplus.{uA, uB, uI} I _L W)))
+                ih).trans
+              (FreeCoprodCompDisc.Hom.comp_assoc I h
+                (mplusInj.{uA, uB, uI} I _L W)
+                (FreeCoprodCompDisc.coprodPairInr.{uI, uB, max uA uB} I a
+                  (mplus.{uA, uB, uI} I _L W)))))))
+
+/-- The weighted summand inclusion commutes with the interpreted
+morphism: reindexing the weight moves the inclusion to the codomain
+object. -/
+theorem deltaIntoWeight_comp (B : Type uB)
+    (c : (B → I) → IR.{max uA uB, uB, uI, uO} I O) (i : B → I)
+    (Z W : FreeCoprodCompDisc.{max uA uB, uI} I)
+    (h : FreeCoprodCompDisc.Hom I Z W)
+    (u : FreeCoprodCompDisc.Hom I
+      (FreeCoprodCompDisc.lift.{uB, uI, max uA uB} I ⟨B, i⟩) Z) :
+    FreeCoprodCompDisc.Hom.comp O
+        (FreeCoprodCompDisc.Hom.comp O
+          (FreeCoprodCompDisc.coprodInj O
+            (FreeCoprodCompDisc.Hom I
+              (FreeCoprodCompDisc.lift.{uB, uI, max uA uB} I ⟨B, i⟩) Z)
+            (fun _ ↦ interpObj I O (c i) Z) u)
+          (deltaInto I O B c i Z))
+        (interpMor I O (delta I O B c) Z W h) =
+      FreeCoprodCompDisc.Hom.comp O
+        (FreeCoprodCompDisc.Hom.comp O (interpMor I O (c i) Z W h)
+          (FreeCoprodCompDisc.coprodInj O
+            (FreeCoprodCompDisc.Hom I
+              (FreeCoprodCompDisc.lift.{uB, uI, max uA uB} I ⟨B, i⟩) W)
+            (fun _ ↦ interpObj I O (c i) W)
+            (FreeCoprodCompDisc.Hom.comp I u h)))
+        (deltaInto I O B c i W) :=
+  (FreeCoprodCompDisc.Hom.comp_assoc O
+      (FreeCoprodCompDisc.coprodInj O
+        (FreeCoprodCompDisc.Hom I
+          (FreeCoprodCompDisc.lift.{uB, uI, max uA uB} I ⟨B, i⟩) Z)
+        (fun _ ↦ interpObj I O (c i) Z) u)
+      (deltaInto I O B c i Z) (interpMor I O (delta I O B c) Z W h)).trans
+    ((congrArg
+        (FreeCoprodCompDisc.Hom.comp O
+          (FreeCoprodCompDisc.coprodInj O
+            (FreeCoprodCompDisc.Hom I
+              (FreeCoprodCompDisc.lift.{uB, uI, max uA uB} I ⟨B, i⟩) Z)
+            (fun _ ↦ interpObj I O (c i) Z) u))
+        (deltaInto_natural I O B c i Z W h).symm).trans
+      ((FreeCoprodCompDisc.Hom.comp_assoc O
+          (FreeCoprodCompDisc.coprodInj O
+            (FreeCoprodCompDisc.Hom I
+              (FreeCoprodCompDisc.lift.{uB, uI, max uA uB} I ⟨B, i⟩) Z)
+            (fun _ ↦ interpObj I O (c i) Z) u)
+          (FreeCoprodCompDisc.copowerHomMapMor
+            (FreeCoprodCompDisc.lift.{uB, uI, max uA uB} I ⟨B, i⟩)
+            (interpMor I O (c i)) Z W h)
+          (deltaInto I O B c i W)).symm.trans
+        (congrArg
+          (fun t ↦ FreeCoprodCompDisc.Hom.comp O t (deltaInto I O B c i W))
+          (FreeCoprodCompDisc.coprodInj_mor O
+            (FreeCoprodCompDisc.Hom I
+              (FreeCoprodCompDisc.lift.{uB, uI, max uA uB} I ⟨B, i⟩) Z)
+            (FreeCoprodCompDisc.Hom I
+              (FreeCoprodCompDisc.lift.{uB, uI, max uA uB} I ⟨B, i⟩) W)
+            (fun e' ↦ FreeCoprodCompDisc.Hom.comp I e' h)
+            (fun _ ↦ interpObj I O (c i) Z)
+            (fun _ ↦ interpObj I O (c i) W)
+            (fun _ ↦ interpMor I O (c i) Z W h) u))))
+
+/-- The forward component of `IR.mprecompIso` at a right-appended
+superscript, with the `IR.mplus_snoc` transport moved to the other
+side. -/
+theorem mprecompIso_snoc_hom_comp (L : List (SupObj.{uB, uI} I))
+    (b : SupObj.{uB, uI} I) (γ : IR.{max uA uB, uB, uI, uO} I O)
+    (X : FreeCoprodCompDisc.{max uA uB, uI} I) :
+    FreeCoprodCompDisc.Hom.comp O
+        (FreeCoprodCompDisc.Hom.comp O
+          (FreeCoprodCompDisc.Iso.hom O (FreeCoprodCompDisc.isoOfEq O
+            (congrArg (fun cc ↦ interpObj I O cc X) (mprecomp_snoc I O L b γ))))
+          (FreeCoprodCompDisc.Iso.hom O
+            (interpPrecompIso I O (mprecomp I O L γ) b.1 b.2 X)))
+        (FreeCoprodCompDisc.Iso.hom O (mprecompIso.{uA, uB, uI, uO} I O L γ
+          (FreeCoprodCompDisc.plus.{uI, uB, max uA uB} I b X))) =
+      FreeCoprodCompDisc.Hom.comp O
+        (FreeCoprodCompDisc.Iso.hom O
+          (mprecompIso.{uA, uB, uI, uO} I O (L ++ [b]) γ X))
+        (FreeCoprodCompDisc.Iso.hom O (FreeCoprodCompDisc.isoOfEq O
+          (congrArg (interpObj I O γ) (mplus_snoc.{uA, uB, uI} I L b X)))) :=
+  ((congrArg
+      (fun t ↦ FreeCoprodCompDisc.Hom.comp O t
+        (FreeCoprodCompDisc.Iso.hom O (FreeCoprodCompDisc.isoOfEq O
+          (congrArg (interpObj I O γ) (mplus_snoc.{uA, uB, uI} I L b X)))))
+      (mprecompIso_snoc_hom I O L b γ X)).trans
+    ((FreeCoprodCompDisc.Hom.comp_assoc O
+        (FreeCoprodCompDisc.Hom.comp O
+          (FreeCoprodCompDisc.Iso.hom O (FreeCoprodCompDisc.isoOfEq O
+            (congrArg (fun cc ↦ interpObj I O cc X) (mprecomp_snoc I O L b γ))))
+          (FreeCoprodCompDisc.Iso.hom O
+            (interpPrecompIso I O (mprecomp I O L γ) b.1 b.2 X)))
+        (FreeCoprodCompDisc.Hom.comp O
+          (FreeCoprodCompDisc.Iso.hom O (mprecompIso.{uA, uB, uI, uO} I O L γ
+            (FreeCoprodCompDisc.plus.{uI, uB, max uA uB} I b X)))
+          (FreeCoprodCompDisc.Iso.hom O (FreeCoprodCompDisc.isoOfEq O
+            (congrArg (interpObj I O γ)
+              (mplus_snoc.{uA, uB, uI} I L b X).symm))))
+        (FreeCoprodCompDisc.Iso.hom O (FreeCoprodCompDisc.isoOfEq O
+          (congrArg (interpObj I O γ) (mplus_snoc.{uA, uB, uI} I L b X))))).trans
+      (congrArg
+        (FreeCoprodCompDisc.Hom.comp O
+          (FreeCoprodCompDisc.Hom.comp O
+            (FreeCoprodCompDisc.Iso.hom O (FreeCoprodCompDisc.isoOfEq O
+              (congrArg (fun cc ↦ interpObj I O cc X)
+                (mprecomp_snoc I O L b γ))))
+            (FreeCoprodCompDisc.Iso.hom O
+              (interpPrecompIso I O (mprecomp I O L γ) b.1 b.2 X))))
+        ((FreeCoprodCompDisc.Hom.comp_assoc O
+            (FreeCoprodCompDisc.Iso.hom O
+              (mprecompIso.{uA, uB, uI, uO} I O L γ
+                (FreeCoprodCompDisc.plus.{uI, uB, max uA uB} I b X)))
+            (FreeCoprodCompDisc.Iso.hom O (FreeCoprodCompDisc.isoOfEq O
+              (congrArg (interpObj I O γ)
+                (mplus_snoc.{uA, uB, uI} I L b X).symm)))
+            (FreeCoprodCompDisc.Iso.hom O (FreeCoprodCompDisc.isoOfEq O
+              (congrArg (interpObj I O γ)
+                (mplus_snoc.{uA, uB, uI} I L b X))))).trans
+          ((congrArg
+              (FreeCoprodCompDisc.Hom.comp O
+                (FreeCoprodCompDisc.Iso.hom O
+                  (mprecompIso.{uA, uB, uI, uO} I O L γ
+                    (FreeCoprodCompDisc.plus.{uI, uB, max uA uB} I b X))))
+              (isoOfEq_symm_hom_comp.{uA, uB, uO} O
+                (interpObj I O γ (mplus.{uA, uB, uI} I (L ++ [b]) X))
+                (interpObj I O γ (mplus.{uA, uB, uI} I L
+                  (FreeCoprodCompDisc.plus.{uI, uB, max uA uB} I b X)))
+                (congrArg (interpObj I O γ)
+                  (mplus_snoc.{uA, uB, uI} I L b X)))).trans
+            (FreeCoprodCompDisc.Hom.comp_id O
+              (FreeCoprodCompDisc.Iso.hom O
+                (mprecompIso.{uA, uB, uI, uO} I O L γ
+                  (FreeCoprodCompDisc.plus.{uI, uB, max uA uB} I b X))))))))).symm
+
+/-- The tower morphism induced by a weight at a right-appended
+superscript: the `IR.mplus_snoc` transport followed by the tower action
+on the bridge cotuple at the base. -/
+def navBridgeMor (B : Type uB) (i : B → I) (L : List (SupObj.{uB, uI} I))
+    (X : FreeCoprodCompDisc.{max uA uB, uI} I)
+    (e : FreeCoprodCompDisc.Hom I
+      (FreeCoprodCompDisc.lift.{uB, uI, max uA uB} I ⟨B, i⟩) X) :
+    FreeCoprodCompDisc.Hom I
+      (mplus.{uA, uB, uI} I (L ++ [(⟨B, i⟩ : SupObj.{uB, uI} I)]) X)
+      (mplus.{uA, uB, uI} I L X) :=
+  FreeCoprodCompDisc.Hom.comp I
+    (FreeCoprodCompDisc.Iso.hom I (FreeCoprodCompDisc.isoOfEq I
+      (mplus_snoc.{uA, uB, uI} I L (⟨B, i⟩ : SupObj.{uB, uI} I) X)))
+    (mplusMorMap.{uA, uB, uI} I L
+      (FreeCoprodCompDisc.plus.{uI, uB, max uA uB} I ⟨B, i⟩ X) X
+      (FreeCoprodCompDisc.Hom.comp I (plusLiftBridgeInvHom I B i X)
+        (FreeCoprodCompDisc.coprodPairDesc I e (FreeCoprodCompDisc.Hom.id I X))))
+
+/-- The tower injection at a right-appended superscript, followed by the
+weight's tower morphism, is the tower injection at the base stack. -/
+theorem mplusInj_navBridge (B : Type uB) (i : B → I)
+    (L : List (SupObj.{uB, uI} I)) (X : FreeCoprodCompDisc.{max uA uB, uI} I)
+    (e : FreeCoprodCompDisc.Hom I
+      (FreeCoprodCompDisc.lift.{uB, uI, max uA uB} I ⟨B, i⟩) X) :
+    FreeCoprodCompDisc.Hom.comp I
+        (mplusInj.{uA, uB, uI} I (L ++ [(⟨B, i⟩ : SupObj.{uB, uI} I)]) X)
+        (navBridgeMor.{uA, uB, uI} I B i L X e) =
+      mplusInj.{uA, uB, uI} I L X :=
+  (FreeCoprodCompDisc.Hom.comp_assoc I
+      (mplusInj.{uA, uB, uI} I (L ++ [(⟨B, i⟩ : SupObj.{uB, uI} I)]) X)
+      (FreeCoprodCompDisc.Iso.hom I (FreeCoprodCompDisc.isoOfEq I
+        (mplus_snoc.{uA, uB, uI} I L (⟨B, i⟩ : SupObj.{uB, uI} I) X)))
+      (mplusMorMap.{uA, uB, uI} I L
+        (FreeCoprodCompDisc.plus.{uI, uB, max uA uB} I ⟨B, i⟩ X) X
+        (FreeCoprodCompDisc.Hom.comp I (plusLiftBridgeInvHom I B i X)
+          (FreeCoprodCompDisc.coprodPairDesc I e
+            (FreeCoprodCompDisc.Hom.id I X))))).symm.trans
+    ((congrArg
+        (fun t ↦ FreeCoprodCompDisc.Hom.comp I t
+          (mplusMorMap.{uA, uB, uI} I L
+            (FreeCoprodCompDisc.plus.{uI, uB, max uA uB} I ⟨B, i⟩ X) X
+            (FreeCoprodCompDisc.Hom.comp I (plusLiftBridgeInvHom I B i X)
+              (FreeCoprodCompDisc.coprodPairDesc I e
+                (FreeCoprodCompDisc.Hom.id I X)))))
+        ((comp_isoOfEq_hom.{uA, uB, uI} I X
+            (mplus.{uA, uB, uI} I (L ++ [(⟨B, i⟩ : SupObj.{uB, uI} I)]) X)
+            (mplus.{uA, uB, uI} I L
+              (FreeCoprodCompDisc.plus.{uI, uB, max uA uB} I ⟨B, i⟩ X))
+            (mplus_snoc.{uA, uB, uI} I L (⟨B, i⟩ : SupObj.{uB, uI} I) X)
+            (mplusInj.{uA, uB, uI} I
+              (L ++ [(⟨B, i⟩ : SupObj.{uB, uI} I)]) X)).trans
+          (mplusInj_snoc.{uA, uB, uI} I L
+            (⟨B, i⟩ : SupObj.{uB, uI} I) X))).trans
+      ((FreeCoprodCompDisc.Hom.comp_assoc I
+          (FreeCoprodCompDisc.coprodPairInr.{uI, uB, max uA uB} I (⟨B, i⟩ : SupObj.{uB, uI} I) X)
+          (mplusInj.{uA, uB, uI} I L
+            (FreeCoprodCompDisc.plus.{uI, uB, max uA uB} I ⟨B, i⟩ X))
+          (mplusMorMap.{uA, uB, uI} I L
+            (FreeCoprodCompDisc.plus.{uI, uB, max uA uB} I ⟨B, i⟩ X) X
+            (FreeCoprodCompDisc.Hom.comp I (plusLiftBridgeInvHom I B i X)
+              (FreeCoprodCompDisc.coprodPairDesc I e
+                (FreeCoprodCompDisc.Hom.id I X))))).trans
+        ((congrArg
+            (FreeCoprodCompDisc.Hom.comp I
+              (FreeCoprodCompDisc.coprodPairInr.{uI, uB, max uA uB} I
+                (⟨B, i⟩ : SupObj.{uB, uI} I) X))
+            (mplusInj_natural.{uA, uB, uI} I L
+              (FreeCoprodCompDisc.plus.{uI, uB, max uA uB} I ⟨B, i⟩ X) X
+              (FreeCoprodCompDisc.Hom.comp I (plusLiftBridgeInvHom I B i X)
+                (FreeCoprodCompDisc.coprodPairDesc I e
+                  (FreeCoprodCompDisc.Hom.id I X))))).trans
+          ((FreeCoprodCompDisc.Hom.comp_assoc I
+              (FreeCoprodCompDisc.coprodPairInr.{uI, uB, max uA uB} I
+                (⟨B, i⟩ : SupObj.{uB, uI} I) X)
+              (FreeCoprodCompDisc.Hom.comp I (plusLiftBridgeInvHom I B i X)
+                (FreeCoprodCompDisc.coprodPairDesc I e
+                  (FreeCoprodCompDisc.Hom.id I X)))
+              (mplusInj.{uA, uB, uI} I L X)).symm.trans
+            ((congrArg
+                (fun t ↦ FreeCoprodCompDisc.Hom.comp I t
+                  (mplusInj.{uA, uB, uI} I L X))
+                (Subtype.ext rfl :
+                  FreeCoprodCompDisc.Hom.comp I
+                      (FreeCoprodCompDisc.coprodPairInr.{uI, uB, max uA uB} I
+                        (⟨B, i⟩ : SupObj.{uB, uI} I) X)
+                      (FreeCoprodCompDisc.Hom.comp I
+                        (plusLiftBridgeInvHom I B i X)
+                        (FreeCoprodCompDisc.coprodPairDesc I e
+                          (FreeCoprodCompDisc.Hom.id I X))) =
+                    FreeCoprodCompDisc.Hom.id I X)).trans
+              (FreeCoprodCompDisc.Hom.id_comp I
+                (mplusInj.{uA, uB, uI} I L X)))))))
+
+/-- The tower navigation weight, followed by the weight's tower
+morphism, is the weight followed by the tower injection at the base
+stack. -/
+theorem navWeight_navBridge (B : Type uB) (i : B → I)
+    (L : List (SupObj.{uB, uI} I)) (X : FreeCoprodCompDisc.{max uA uB, uI} I)
+    (e : FreeCoprodCompDisc.Hom I
+      (FreeCoprodCompDisc.lift.{uB, uI, max uA uB} I ⟨B, i⟩) X) :
+    FreeCoprodCompDisc.Hom.comp I
+        (navWeight I B i B _root_.id X L)
+        (navBridgeMor.{uA, uB, uI} I B i L X e) =
+      FreeCoprodCompDisc.Hom.comp I e (mplusInj.{uA, uB, uI} I L X) :=
+  (FreeCoprodCompDisc.Hom.comp_assoc I
+      (navWeight I B i B _root_.id X L)
+      (FreeCoprodCompDisc.Iso.hom I (FreeCoprodCompDisc.isoOfEq I
+        (mplus_snoc.{uA, uB, uI} I L (⟨B, i⟩ : SupObj.{uB, uI} I) X)))
+      (mplusMorMap.{uA, uB, uI} I L
+        (FreeCoprodCompDisc.plus.{uI, uB, max uA uB} I ⟨B, i⟩ X) X
+        (FreeCoprodCompDisc.Hom.comp I (plusLiftBridgeInvHom I B i X)
+          (FreeCoprodCompDisc.coprodPairDesc I e
+            (FreeCoprodCompDisc.Hom.id I X))))).symm.trans
+    ((congrArg
+        (fun t ↦ FreeCoprodCompDisc.Hom.comp I t
+          (mplusMorMap.{uA, uB, uI} I L
+            (FreeCoprodCompDisc.plus.{uI, uB, max uA uB} I ⟨B, i⟩ X) X
+            (FreeCoprodCompDisc.Hom.comp I (plusLiftBridgeInvHom I B i X)
+              (FreeCoprodCompDisc.coprodPairDesc I e
+                (FreeCoprodCompDisc.Hom.id I X)))))
+        ((comp_isoOfEq_hom.{uA, uB, uI} I
+            (FreeCoprodCompDisc.lift.{uB, uI, max uA uB} I ⟨B, i⟩)
+            (mplus.{uA, uB, uI} I (L ++ [(⟨B, i⟩ : SupObj.{uB, uI} I)]) X)
+            (mplus.{uA, uB, uI} I L
+              (FreeCoprodCompDisc.plus.{uI, uB, max uA uB} I ⟨B, i⟩ X))
+            (mplus_snoc.{uA, uB, uI} I L (⟨B, i⟩ : SupObj.{uB, uI} I) X)
+            (navWeight I B i B _root_.id X L)).trans
+          (navWeight_snoc I B i B _root_.id X L))).trans
+      ((FreeCoprodCompDisc.Hom.comp_assoc I
+          (⟨fun z ↦ Sum.inl (_root_.id z.down), rfl⟩ :
+            FreeCoprodCompDisc.Hom I
+              (FreeCoprodCompDisc.lift.{uB, uI, max uA uB} I ⟨B, i⟩)
+              (FreeCoprodCompDisc.plus.{uI, uB, max uA uB} I ⟨B, i⟩ X))
+          (mplusInj.{uA, uB, uI} I L
+            (FreeCoprodCompDisc.plus.{uI, uB, max uA uB} I ⟨B, i⟩ X))
+          (mplusMorMap.{uA, uB, uI} I L
+            (FreeCoprodCompDisc.plus.{uI, uB, max uA uB} I ⟨B, i⟩ X) X
+            (FreeCoprodCompDisc.Hom.comp I (plusLiftBridgeInvHom I B i X)
+              (FreeCoprodCompDisc.coprodPairDesc I e
+                (FreeCoprodCompDisc.Hom.id I X))))).trans
+        ((congrArg
+            (FreeCoprodCompDisc.Hom.comp I
+              (⟨fun z ↦ Sum.inl (_root_.id z.down), rfl⟩ :
+                FreeCoprodCompDisc.Hom I
+                  (FreeCoprodCompDisc.lift.{uB, uI, max uA uB} I ⟨B, i⟩)
+                  (FreeCoprodCompDisc.plus.{uI, uB, max uA uB} I ⟨B, i⟩ X)))
+            (mplusInj_natural.{uA, uB, uI} I L
+              (FreeCoprodCompDisc.plus.{uI, uB, max uA uB} I ⟨B, i⟩ X) X
+              (FreeCoprodCompDisc.Hom.comp I (plusLiftBridgeInvHom I B i X)
+                (FreeCoprodCompDisc.coprodPairDesc I e
+                  (FreeCoprodCompDisc.Hom.id I X))))).trans
+          ((FreeCoprodCompDisc.Hom.comp_assoc I
+              (⟨fun z ↦ Sum.inl (_root_.id z.down), rfl⟩ :
+                FreeCoprodCompDisc.Hom I
+                  (FreeCoprodCompDisc.lift.{uB, uI, max uA uB} I ⟨B, i⟩)
+                  (FreeCoprodCompDisc.plus.{uI, uB, max uA uB} I ⟨B, i⟩ X))
+              (FreeCoprodCompDisc.Hom.comp I (plusLiftBridgeInvHom I B i X)
+                (FreeCoprodCompDisc.coprodPairDesc I e
+                  (FreeCoprodCompDisc.Hom.id I X)))
+              (mplusInj.{uA, uB, uI} I L X)).symm.trans
+            (congrArg
+              (fun t ↦ FreeCoprodCompDisc.Hom.comp I t
+                (mplusInj.{uA, uB, uI} I L X))
+              (Subtype.ext rfl :
+                FreeCoprodCompDisc.Hom.comp I
+                    (⟨fun z ↦ Sum.inl (_root_.id z.down), rfl⟩ :
+                      FreeCoprodCompDisc.Hom I
+                        (FreeCoprodCompDisc.lift.{uB, uI, max uA uB} I ⟨B, i⟩)
+                        (FreeCoprodCompDisc.plus.{uI, uB, max uA uB}
+                          I ⟨B, i⟩ X))
+                    (FreeCoprodCompDisc.Hom.comp I
+                      (plusLiftBridgeInvHom I B i X)
+                      (FreeCoprodCompDisc.coprodPairDesc I e
+                        (FreeCoprodCompDisc.Hom.id I X))) =
+                  e))))))
+
+/-- The tower-conjugated navigation inclusion, followed by the tower
+isomorphism at the extended stack, is the weighted copower injection
+and the summand inclusion at the tower coproduct. -/
+theorem navInj_comp_hom (Bout : Type uB) (iout : Bout → I) (Bin : Type uB)
+    (K : (Bin → I) → IR.{max uA uB, uB, uI, uO} I O) (g : Bin → Bout)
+    (L : List (SupObj.{uB, uI} I)) (X : FreeCoprodCompDisc.{max uA uB, uI} I) :
+    FreeCoprodCompDisc.Hom.comp O (navInj I O Bout iout Bin K g L X)
+        (FreeCoprodCompDisc.Iso.hom O
+          (mprecompIso.{uA, uB, uI, uO} I O
+            (L ++ [(⟨Bout, iout⟩ : SupObj.{uB, uI} I)]) (delta I O Bin K) X)) =
+      FreeCoprodCompDisc.Hom.comp O
+        (FreeCoprodCompDisc.Iso.hom O
+          (mprecompIso.{uA, uB, uI, uO} I O
+            (L ++ [(⟨Bout, iout⟩ : SupObj.{uB, uI} I)]) (K (iout ∘ g)) X))
+        (FreeCoprodCompDisc.Hom.comp O
+          (FreeCoprodCompDisc.coprodInj O
+            (FreeCoprodCompDisc.Hom I
+              (FreeCoprodCompDisc.lift.{uB, uI, max uA uB} I ⟨Bin, iout ∘ g⟩)
+              (mplus.{uA, uB, uI} I
+                (L ++ [(⟨Bout, iout⟩ : SupObj.{uB, uI} I)]) X))
+            (fun _ ↦ interpObj I O (K (iout ∘ g))
+              (mplus.{uA, uB, uI} I
+                (L ++ [(⟨Bout, iout⟩ : SupObj.{uB, uI} I)]) X))
+            (navWeight I Bout iout Bin g X L))
+          (deltaInto I O Bin K (iout ∘ g)
+            (mplus.{uA, uB, uI} I
+              (L ++ [(⟨Bout, iout⟩ : SupObj.{uB, uI} I)]) X))) :=
+  (congrArg
+      (FreeCoprodCompDisc.Hom.comp O
+        (FreeCoprodCompDisc.Hom.comp O
+          (FreeCoprodCompDisc.Iso.hom O
+            (mprecompIso.{uA, uB, uI, uO} I O
+              (L ++ [(⟨Bout, iout⟩ : SupObj.{uB, uI} I)]) (K (iout ∘ g)) X))
+          (FreeCoprodCompDisc.Hom.comp O
+            (FreeCoprodCompDisc.coprodInj O
+              (FreeCoprodCompDisc.Hom I
+                (FreeCoprodCompDisc.lift.{uB, uI, max uA uB} I ⟨Bin, iout ∘ g⟩)
+                (mplus.{uA, uB, uI} I
+                  (L ++ [(⟨Bout, iout⟩ : SupObj.{uB, uI} I)]) X))
+              (fun _ ↦ interpObj I O (K (iout ∘ g))
+                (mplus.{uA, uB, uI} I
+                  (L ++ [(⟨Bout, iout⟩ : SupObj.{uB, uI} I)]) X))
+              (navWeight I Bout iout Bin g X L))
+            (deltaInto I O Bin K (iout ∘ g)
+              (mplus.{uA, uB, uI} I
+                (L ++ [(⟨Bout, iout⟩ : SupObj.{uB, uI} I)]) X)))))
+      (FreeCoprodCompDisc.Iso.invHom_hom O
+        (mprecompIso.{uA, uB, uI, uO} I O
+          (L ++ [(⟨Bout, iout⟩ : SupObj.{uB, uI} I)])
+          (delta I O Bin K) X))).trans
+    (FreeCoprodCompDisc.Hom.comp_id O
+      (FreeCoprodCompDisc.Hom.comp O
+        (FreeCoprodCompDisc.Iso.hom O
+          (mprecompIso.{uA, uB, uI, uO} I O
+            (L ++ [(⟨Bout, iout⟩ : SupObj.{uB, uI} I)]) (K (iout ∘ g)) X))
+        (FreeCoprodCompDisc.Hom.comp O
+          (FreeCoprodCompDisc.coprodInj O
+            (FreeCoprodCompDisc.Hom I
+              (FreeCoprodCompDisc.lift.{uB, uI, max uA uB} I ⟨Bin, iout ∘ g⟩)
+              (mplus.{uA, uB, uI} I
+                (L ++ [(⟨Bout, iout⟩ : SupObj.{uB, uI} I)]) X))
+            (fun _ ↦ interpObj I O (K (iout ∘ g))
+              (mplus.{uA, uB, uI} I
+                (L ++ [(⟨Bout, iout⟩ : SupObj.{uB, uI} I)]) X))
+            (navWeight I Bout iout Bin g X L))
+          (deltaInto I O Bin K (iout ∘ g)
+            (mplus.{uA, uB, uI} I
+              (L ++ [(⟨Bout, iout⟩ : SupObj.{uB, uI} I)]) X)))))
+
+/-- The semantic pre-unit component, followed by the tower
+isomorphism, is the interpreted tower injection. -/
+theorem preUnitComponent_comp_hom (γ : IR.{max uA uB, uB, uI, uO} I O)
+    (L : List (SupObj.{uB, uI} I)) (X : FreeCoprodCompDisc.{max uA uB, uI} I) :
+    FreeCoprodCompDisc.Hom.comp O (preUnitComponent I O γ L X)
+        (FreeCoprodCompDisc.Iso.hom O
+          (mprecompIso.{uA, uB, uI, uO} I O L γ X)) =
+      interpMor I O γ X (mplus.{uA, uB, uI} I L X)
+        (mplusInj.{uA, uB, uI} I L X) :=
+  (congrArg
+      (FreeCoprodCompDisc.Hom.comp O
+        (interpMor I O γ X (mplus.{uA, uB, uI} I L X)
+          (mplusInj.{uA, uB, uI} I L X)))
+      (FreeCoprodCompDisc.Iso.invHom_hom O
+        (mprecompIso.{uA, uB, uI, uO} I O L γ X))).trans
+    (FreeCoprodCompDisc.Hom.comp_id O
+      (interpMor I O γ X (mplus.{uA, uB, uI} I L X)
+        (mplusInj.{uA, uB, uI} I L X)))
+
+/-- The reduced form of the per-weight identity-image equation: after
+the tower isomorphisms cancel, both routes are the interpreted tower
+injection followed by the reindexed weighted summand inclusion. -/
+theorem interpHomPreUnit_deltaWeightRight (B : Type uB)
+    (d : Direction I O (Sum.inr (Sum.inr B) : Shape.{max uA uB, uB, uO} O) →
+      IR.{max uA uB, uB, uI, uO} I O)
+    (ih : (x : Direction I O (Sum.inr (Sum.inr B) : Shape.{max uA uB, uB, uO} O)) →
+      InterpHomPreUnitMotive I O (d x))
+    (L : List (SupObj.{uB, uI} I)) (X : FreeCoprodCompDisc.{max uA uB, uI} I)
+    (i : B → I)
+    (e : FreeCoprodCompDisc.Hom I
+      (FreeCoprodCompDisc.lift.{uB, uI, max uA uB} I ⟨B, i⟩) X) :
+    FreeCoprodCompDisc.Hom.comp O
+        ((interpHom I O (d (ULift.up i))
+          (mprecomp I O (L ++ [(⟨B, i⟩ : SupObj.{uB, uI} I)])
+            (mk I O (Sum.inr (Sum.inr B)) d))
+          (deltaNav I O (d (ULift.up i)) B i B (fun i' ↦ d (ULift.up i'))
+            _root_.id L
+            (preUnitStack I O (d (ULift.up i))
+              (L ++ [(⟨B, i⟩ : SupObj.{uB, uI} I)])))).1 X)
+        (FreeCoprodCompDisc.Hom.comp O
+          (FreeCoprodCompDisc.Iso.hom O
+            (mprecompIso.{uA, uB, uI, uO} I O
+              (L ++ [(⟨B, i⟩ : SupObj.{uB, uI} I)])
+              (mk I O (Sum.inr (Sum.inr B)) d) X))
+          (interpMor I O (mk I O (Sum.inr (Sum.inr B)) d)
+            (mplus.{uA, uB, uI} I (L ++ [(⟨B, i⟩ : SupObj.{uB, uI} I)]) X)
+            (mplus.{uA, uB, uI} I L X)
+            (navBridgeMor.{uA, uB, uI} I B i L X e))) =
+      FreeCoprodCompDisc.Hom.comp O
+        (FreeCoprodCompDisc.coprodInj O
+          (FreeCoprodCompDisc.Hom I
+            (FreeCoprodCompDisc.lift.{uB, uI, max uA uB} I ⟨B, i⟩) X)
+          (fun _ ↦ interpObj I O (d (ULift.up i)) X) e)
+        (FreeCoprodCompDisc.Hom.comp O
+          (deltaInto I O B (fun j ↦ d (ULift.up j)) i X)
+          (interpMor I O (mk I O (Sum.inr (Sum.inr B)) d) X
+            (mplus.{uA, uB, uI} I L X) (mplusInj.{uA, uB, uI} I L X))) :=
+  (congrArg
+      (fun t ↦ FreeCoprodCompDisc.Hom.comp O t
+        (FreeCoprodCompDisc.Hom.comp O
+          (FreeCoprodCompDisc.Iso.hom O
+            (mprecompIso.{uA, uB, uI, uO} I O
+              (L ++ [(⟨B, i⟩ : SupObj.{uB, uI} I)])
+              (mk I O (Sum.inr (Sum.inr B)) d) X))
+          (interpMor I O (mk I O (Sum.inr (Sum.inr B)) d)
+            (mplus.{uA, uB, uI} I (L ++ [(⟨B, i⟩ : SupObj.{uB, uI} I)]) X)
+            (mplus.{uA, uB, uI} I L X)
+            (navBridgeMor.{uA, uB, uI} I B i L X e))))
+      ((interpHom_deltaNav I O (d (ULift.up i)) B i B
+          (fun i' ↦ d (ULift.up i')) _root_.id L
+          (preUnitStack I O (d (ULift.up i))
+            (L ++ [(⟨B, i⟩ : SupObj.{uB, uI} I)])) X).trans
+        (congrArg
+          (fun t ↦ FreeCoprodCompDisc.Hom.comp O t
+            (navInj I O B i B (fun i' ↦ d (ULift.up i')) _root_.id L X))
+          (ih (ULift.up i) (L ++ [(⟨B, i⟩ : SupObj.{uB, uI} I)]) X)))).trans
+    ((congrArg
+        (fun t ↦ FreeCoprodCompDisc.Hom.comp O
+          (preUnitComponent I O (d (ULift.up i))
+            (L ++ [(⟨B, i⟩ : SupObj.{uB, uI} I)]) X)
+          (FreeCoprodCompDisc.Hom.comp O t
+            (interpMor I O (mk I O (Sum.inr (Sum.inr B)) d)
+              (mplus.{uA, uB, uI} I (L ++ [(⟨B, i⟩ : SupObj.{uB, uI} I)]) X)
+              (mplus.{uA, uB, uI} I L X)
+              (navBridgeMor.{uA, uB, uI} I B i L X e))))
+        (navInj_comp_hom I O B i B (fun i' ↦ d (ULift.up i')) _root_.id
+          L X)).trans
+      ((congrArg
+          (fun t ↦ FreeCoprodCompDisc.Hom.comp O t
+            (FreeCoprodCompDisc.Hom.comp O
+              (FreeCoprodCompDisc.Hom.comp O
+                (FreeCoprodCompDisc.coprodInj O
+                  (FreeCoprodCompDisc.Hom I
+                    (FreeCoprodCompDisc.lift.{uB, uI, max uA uB} I ⟨B, i⟩)
+                    (mplus.{uA, uB, uI} I
+                      (L ++ [(⟨B, i⟩ : SupObj.{uB, uI} I)]) X))
+                  (fun _ ↦ interpObj I O (d (ULift.up i))
+                    (mplus.{uA, uB, uI} I
+                      (L ++ [(⟨B, i⟩ : SupObj.{uB, uI} I)]) X))
+                  (navWeight I B i B _root_.id X L))
+                (deltaInto I O B (fun j ↦ d (ULift.up j)) i
+                  (mplus.{uA, uB, uI} I
+                    (L ++ [(⟨B, i⟩ : SupObj.{uB, uI} I)]) X)))
+              (interpMor I O (mk I O (Sum.inr (Sum.inr B)) d)
+                (mplus.{uA, uB, uI} I (L ++ [(⟨B, i⟩ : SupObj.{uB, uI} I)]) X)
+                (mplus.{uA, uB, uI} I L X)
+                (navBridgeMor.{uA, uB, uI} I B i L X e))))
+          (preUnitComponent_comp_hom I O (d (ULift.up i))
+            (L ++ [(⟨B, i⟩ : SupObj.{uB, uI} I)]) X)).trans
+        ((congrArg
+            (FreeCoprodCompDisc.Hom.comp O
+              (interpMor I O (d (ULift.up i)) X
+                (mplus.{uA, uB, uI} I (L ++ [(⟨B, i⟩ : SupObj.{uB, uI} I)]) X)
+                (mplusInj.{uA, uB, uI} I
+                  (L ++ [(⟨B, i⟩ : SupObj.{uB, uI} I)]) X)))
+            (deltaIntoWeight_comp I O B (fun j ↦ d (ULift.up j)) i
+              (mplus.{uA, uB, uI} I (L ++ [(⟨B, i⟩ : SupObj.{uB, uI} I)]) X)
+              (mplus.{uA, uB, uI} I L X)
+              (navBridgeMor.{uA, uB, uI} I B i L X e)
+              (navWeight I B i B _root_.id X L))).trans
+          ((congrArg
+              (fun t ↦ FreeCoprodCompDisc.Hom.comp O
+                (FreeCoprodCompDisc.Hom.comp O t
+                  (FreeCoprodCompDisc.coprodInj O
+                    (FreeCoprodCompDisc.Hom I
+                      (FreeCoprodCompDisc.lift.{uB, uI, max uA uB} I ⟨B, i⟩)
+                      (mplus.{uA, uB, uI} I L X))
+                    (fun _ ↦ interpObj I O (d (ULift.up i))
+                      (mplus.{uA, uB, uI} I L X))
+                    (FreeCoprodCompDisc.Hom.comp I
+                      (navWeight I B i B _root_.id X L)
+                      (navBridgeMor.{uA, uB, uI} I B i L X e))))
+                (deltaInto I O B (fun j ↦ d (ULift.up j)) i
+                  (mplus.{uA, uB, uI} I L X)))
+              (interpMor_comp I O (d (ULift.up i)) X
+                (mplus.{uA, uB, uI} I (L ++ [(⟨B, i⟩ : SupObj.{uB, uI} I)]) X)
+                (mplus.{uA, uB, uI} I L X)
+                (mplusInj.{uA, uB, uI} I
+                  (L ++ [(⟨B, i⟩ : SupObj.{uB, uI} I)]) X)
+                (navBridgeMor.{uA, uB, uI} I B i L X e)).symm).trans
+            ((congrArg
+                (fun t ↦ FreeCoprodCompDisc.Hom.comp O
+                  (FreeCoprodCompDisc.Hom.comp O
+                    (interpMor I O (d (ULift.up i)) X
+                      (mplus.{uA, uB, uI} I L X) t)
+                    (FreeCoprodCompDisc.coprodInj O
+                      (FreeCoprodCompDisc.Hom I
+                        (FreeCoprodCompDisc.lift.{uB, uI, max uA uB} I ⟨B, i⟩)
+                        (mplus.{uA, uB, uI} I L X))
+                      (fun _ ↦ interpObj I O (d (ULift.up i))
+                        (mplus.{uA, uB, uI} I L X))
+                      (FreeCoprodCompDisc.Hom.comp I
+                        (navWeight I B i B _root_.id X L)
+                        (navBridgeMor.{uA, uB, uI} I B i L X e))))
+                  (deltaInto I O B (fun j ↦ d (ULift.up j)) i
+                    (mplus.{uA, uB, uI} I L X)))
+                (mplusInj_navBridge.{uA, uB, uI} I B i L X e)).trans
+              ((congrArg
+                  (fun t ↦ FreeCoprodCompDisc.Hom.comp O
+                    (FreeCoprodCompDisc.Hom.comp O
+                      (interpMor I O (d (ULift.up i)) X
+                        (mplus.{uA, uB, uI} I L X)
+                        (mplusInj.{uA, uB, uI} I L X))
+                      (FreeCoprodCompDisc.coprodInj O
+                        (FreeCoprodCompDisc.Hom I
+                          (FreeCoprodCompDisc.lift.{uB, uI, max uA uB} I ⟨B, i⟩)
+                          (mplus.{uA, uB, uI} I L X))
+                        (fun _ ↦ interpObj I O (d (ULift.up i))
+                          (mplus.{uA, uB, uI} I L X))
+                        t))
+                    (deltaInto I O B (fun j ↦ d (ULift.up j)) i
+                      (mplus.{uA, uB, uI} I L X)))
+                  (navWeight_navBridge.{uA, uB, uI} I B i L X e)).trans
+                (deltaIntoWeight_comp I O B (fun j ↦ d (ULift.up j)) i X
+                  (mplus.{uA, uB, uI} I L X)
+                  (mplusInj.{uA, uB, uI} I L X) e).symm))))))
+
+/-- The per-weight identity-image equation at a `δ`-domain: at each
+weight out of the lifted arity, the copower-adjunction transport of the
+navigated subcode pre-unit is the weight's injection followed by the
+summand inclusion and the semantic pre-unit component. -/
+theorem interpHomPreUnit_deltaWeight (B : Type uB)
+    (d : Direction I O (Sum.inr (Sum.inr B) : Shape.{max uA uB, uB, uO} O) →
+      IR.{max uA uB, uB, uI, uO} I O)
+    (ih : (x : Direction I O (Sum.inr (Sum.inr B) : Shape.{max uA uB, uB, uO} O)) →
+      InterpHomPreUnitMotive I O (d x))
+    (L : List (SupObj.{uB, uI} I)) (X : FreeCoprodCompDisc.{max uA uB, uI} I)
+    (i : B → I)
+    (e : FreeCoprodCompDisc.Hom I
+      (FreeCoprodCompDisc.lift.{uB, uI, max uA uB} I ⟨B, i⟩) X) :
+    FreeCoprodCompDisc.Hom.comp O
+        (FreeCoprodCompDisc.Hom.comp O
+          (FreeCoprodCompDisc.Hom.comp O
+            ((interpHom I O (d (ULift.up i))
+              (precomp I O B i (mprecomp I O L (mk I O (Sum.inr (Sum.inr B)) d)))
+              (preUnitDeltaData I O B d L i)).1 X)
+            (FreeCoprodCompDisc.Iso.hom O
+              (interpPrecompIso I O
+                (mprecomp I O L (mk I O (Sum.inr (Sum.inr B)) d)) B i X)))
+          ((plusLiftBridgeNatInv I O B i
+            (mprecomp I O L (mk I O (Sum.inr (Sum.inr B)) d))).1 X))
+        (interpMor I O (mprecomp I O L (mk I O (Sum.inr (Sum.inr B)) d))
+          (FreeCoprodCompDisc.plus I
+            (FreeCoprodCompDisc.lift.{uB, uI, max uA uB} I ⟨B, i⟩) X)
+          X
+          (FreeCoprodCompDisc.coprodPairDesc I e
+            (FreeCoprodCompDisc.Hom.id I X))) =
+      FreeCoprodCompDisc.Hom.comp O
+        (FreeCoprodCompDisc.coprodInj O
+          (FreeCoprodCompDisc.Hom I
+            (FreeCoprodCompDisc.lift.{uB, uI, max uA uB} I ⟨B, i⟩) X)
+          (fun _ ↦ interpObj I O (d (ULift.up i)) X) e)
+        (FreeCoprodCompDisc.Hom.comp O
+          (deltaInto I O B (fun j ↦ d (ULift.up j)) i X)
+          (preUnitComponent I O (mk I O (Sum.inr (Sum.inr B)) d) L X)) :=
+  eq_comp_invHom O (interpObj I O (d (ULift.up i)) X)
+    (interpObj I O (mprecomp I O L (mk I O (Sum.inr (Sum.inr B)) d)) X)
+    (interpObj I O (mk I O (Sum.inr (Sum.inr B)) d) (mplus.{uA, uB, uI} I L X))
+    (FreeCoprodCompDisc.Hom.comp O
+      (FreeCoprodCompDisc.Hom.comp O
+        (FreeCoprodCompDisc.Hom.comp O
+          ((interpHom I O (d (ULift.up i))
+            (precomp I O B i (mprecomp I O L (mk I O (Sum.inr (Sum.inr B)) d)))
+            (preUnitDeltaData I O B d L i)).1 X)
+          (FreeCoprodCompDisc.Iso.hom O
+            (interpPrecompIso I O
+              (mprecomp I O L (mk I O (Sum.inr (Sum.inr B)) d)) B i X)))
+        ((plusLiftBridgeNatInv I O B i
+          (mprecomp I O L (mk I O (Sum.inr (Sum.inr B)) d))).1 X))
+      (interpMor I O (mprecomp I O L (mk I O (Sum.inr (Sum.inr B)) d))
+        (FreeCoprodCompDisc.plus I
+          (FreeCoprodCompDisc.lift.{uB, uI, max uA uB} I ⟨B, i⟩) X)
+        X
+        (FreeCoprodCompDisc.coprodPairDesc I e (FreeCoprodCompDisc.Hom.id I X))))
+    (FreeCoprodCompDisc.Hom.comp O
+      (FreeCoprodCompDisc.coprodInj O
+        (FreeCoprodCompDisc.Hom I
+          (FreeCoprodCompDisc.lift.{uB, uI, max uA uB} I ⟨B, i⟩) X)
+        (fun _ ↦ interpObj I O (d (ULift.up i)) X) e)
+      (FreeCoprodCompDisc.Hom.comp O
+        (deltaInto I O B (fun j ↦ d (ULift.up j)) i X)
+        (interpMor I O (mk I O (Sum.inr (Sum.inr B)) d) X
+          (mplus.{uA, uB, uI} I L X) (mplusInj.{uA, uB, uI} I L X))))
+    (mprecompIso.{uA, uB, uI, uO} I O L (mk I O (Sum.inr (Sum.inr B)) d) X)
+    ((congrArg
+        (fun t ↦ FreeCoprodCompDisc.Hom.comp O
+          (FreeCoprodCompDisc.Hom.comp O
+            ((interpHom I O (d (ULift.up i))
+              (precomp I O B i
+                (mprecomp I O L (mk I O (Sum.inr (Sum.inr B)) d)))
+              (preUnitDeltaData I O B d L i)).1 X)
+            (FreeCoprodCompDisc.Iso.hom O
+              (interpPrecompIso I O
+                (mprecomp I O L (mk I O (Sum.inr (Sum.inr B)) d)) B i X)))
+          (FreeCoprodCompDisc.Hom.comp O t
+            (FreeCoprodCompDisc.Iso.hom O
+              (mprecompIso.{uA, uB, uI, uO} I O L
+                (mk I O (Sum.inr (Sum.inr B)) d) X))))
+        (interpMor_comp I O (mprecomp I O L (mk I O (Sum.inr (Sum.inr B)) d))
+            (FreeCoprodCompDisc.plus.{uI, uB, max uA uB} I ⟨B, i⟩ X)
+            (FreeCoprodCompDisc.plus I
+              (FreeCoprodCompDisc.lift.{uB, uI, max uA uB} I ⟨B, i⟩) X)
+            X (plusLiftBridgeInvHom I B i X)
+            (FreeCoprodCompDisc.coprodPairDesc I e
+              (FreeCoprodCompDisc.Hom.id I X))).symm).trans
+      ((congrArg
+          (FreeCoprodCompDisc.Hom.comp O
+            (FreeCoprodCompDisc.Hom.comp O
+              ((interpHom I O (d (ULift.up i))
+                (precomp I O B i
+                  (mprecomp I O L (mk I O (Sum.inr (Sum.inr B)) d)))
+                (preUnitDeltaData I O B d L i)).1 X)
+              (FreeCoprodCompDisc.Iso.hom O
+                (interpPrecompIso I O
+                  (mprecomp I O L (mk I O (Sum.inr (Sum.inr B)) d)) B i X))))
+          (mprecompIso_natural.{uA, uB, uI, uO} I O L
+            (mk I O (Sum.inr (Sum.inr B)) d)
+            (FreeCoprodCompDisc.plus.{uI, uB, max uA uB} I ⟨B, i⟩ X) X
+            (FreeCoprodCompDisc.Hom.comp I (plusLiftBridgeInvHom I B i X)
+              (FreeCoprodCompDisc.coprodPairDesc I e
+                (FreeCoprodCompDisc.Hom.id I X))))).trans
+        ((congrArg
+            (fun t ↦ FreeCoprodCompDisc.Hom.comp O
+              (FreeCoprodCompDisc.Hom.comp O t
+                (FreeCoprodCompDisc.Iso.hom O
+                  (interpPrecompIso I O
+                    (mprecomp I O L (mk I O (Sum.inr (Sum.inr B)) d)) B i X)))
+              (FreeCoprodCompDisc.Hom.comp O
+                (FreeCoprodCompDisc.Iso.hom O
+                  (mprecompIso.{uA, uB, uI, uO} I O L
+                    (mk I O (Sum.inr (Sum.inr B)) d)
+                    (FreeCoprodCompDisc.plus.{uI, uB, max uA uB} I ⟨B, i⟩ X)))
+                (interpMor I O (mk I O (Sum.inr (Sum.inr B)) d)
+                  (mplus.{uA, uB, uI} I L
+                    (FreeCoprodCompDisc.plus.{uI, uB, max uA uB} I ⟨B, i⟩ X))
+                  (mplus.{uA, uB, uI} I L X)
+                  (mplusMorMap.{uA, uB, uI} I L
+                    (FreeCoprodCompDisc.plus.{uI, uB, max uA uB} I ⟨B, i⟩ X) X
+                    (FreeCoprodCompDisc.Hom.comp I
+                      (plusLiftBridgeInvHom I B i X)
+                      (FreeCoprodCompDisc.coprodPairDesc I e
+                        (FreeCoprodCompDisc.Hom.id I X)))))))
+            (interpHom_cast_cod I O (d (ULift.up i))
+              (mprecomp I O (L ++ [(⟨B, i⟩ : SupObj.{uB, uI} I)])
+                (mk I O (Sum.inr (Sum.inr B)) d))
+              X
+              (precomp I O B i
+                (mprecomp I O L (mk I O (Sum.inr (Sum.inr B)) d)))
+              (mprecomp_snoc I O L (⟨B, i⟩ : SupObj.{uB, uI} I)
+                (mk I O (Sum.inr (Sum.inr B)) d))
+              (deltaNav I O (d (ULift.up i)) B i B (fun i' ↦ d (ULift.up i'))
+                _root_.id L
+                (preUnitStack I O (d (ULift.up i))
+                  (L ++ [(⟨B, i⟩ : SupObj.{uB, uI} I)]))))).trans
+          ((congrArg
+              (fun t ↦ FreeCoprodCompDisc.Hom.comp O
+                ((interpHom I O (d (ULift.up i))
+                  (mprecomp I O (L ++ [(⟨B, i⟩ : SupObj.{uB, uI} I)])
+                    (mk I O (Sum.inr (Sum.inr B)) d))
+                  (deltaNav I O (d (ULift.up i)) B i B
+                    (fun i' ↦ d (ULift.up i')) _root_.id L
+                    (preUnitStack I O (d (ULift.up i))
+                      (L ++ [(⟨B, i⟩ : SupObj.{uB, uI} I)])))).1 X)
+                (FreeCoprodCompDisc.Hom.comp O t
+                  (interpMor I O (mk I O (Sum.inr (Sum.inr B)) d)
+                    (mplus.{uA, uB, uI} I L
+                      (FreeCoprodCompDisc.plus.{uI, uB, max uA uB} I ⟨B, i⟩ X))
+                    (mplus.{uA, uB, uI} I L X)
+                    (mplusMorMap.{uA, uB, uI} I L
+                      (FreeCoprodCompDisc.plus.{uI, uB, max uA uB} I ⟨B, i⟩ X) X
+                      (FreeCoprodCompDisc.Hom.comp I
+                        (plusLiftBridgeInvHom I B i X)
+                        (FreeCoprodCompDisc.coprodPairDesc I e
+                          (FreeCoprodCompDisc.Hom.id I X)))))))
+              (mprecompIso_snoc_hom_comp I O L (⟨B, i⟩ : SupObj.{uB, uI} I)
+                (mk I O (Sum.inr (Sum.inr B)) d) X)).trans
+            ((congrArg
+                (fun t ↦ FreeCoprodCompDisc.Hom.comp O
+                  ((interpHom I O (d (ULift.up i))
+                    (mprecomp I O (L ++ [(⟨B, i⟩ : SupObj.{uB, uI} I)])
+                      (mk I O (Sum.inr (Sum.inr B)) d))
+                    (deltaNav I O (d (ULift.up i)) B i B
+                      (fun i' ↦ d (ULift.up i')) _root_.id L
+                      (preUnitStack I O (d (ULift.up i))
+                        (L ++ [(⟨B, i⟩ : SupObj.{uB, uI} I)])))).1 X)
+                  (FreeCoprodCompDisc.Hom.comp O
+                    (FreeCoprodCompDisc.Iso.hom O
+                      (mprecompIso.{uA, uB, uI, uO} I O
+                        (L ++ [(⟨B, i⟩ : SupObj.{uB, uI} I)])
+                        (mk I O (Sum.inr (Sum.inr B)) d) X))
+                    t))
+                (interpMor_isoOfEq_dom I O (mk I O (Sum.inr (Sum.inr B)) d)
+                  (mplus.{uA, uB, uI} I
+                    (L ++ [(⟨B, i⟩ : SupObj.{uB, uI} I)]) X)
+                  (mplus.{uA, uB, uI} I L X)
+                  (mplus.{uA, uB, uI} I L
+                    (FreeCoprodCompDisc.plus.{uI, uB, max uA uB} I ⟨B, i⟩ X))
+                  (mplus_snoc.{uA, uB, uI} I L
+                    (⟨B, i⟩ : SupObj.{uB, uI} I) X)
+                  (mplusMorMap.{uA, uB, uI} I L
+                    (FreeCoprodCompDisc.plus.{uI, uB, max uA uB} I ⟨B, i⟩ X) X
+                    (FreeCoprodCompDisc.Hom.comp I
+                      (plusLiftBridgeInvHom I B i X)
+                      (FreeCoprodCompDisc.coprodPairDesc I e
+                        (FreeCoprodCompDisc.Hom.id I X)))))).trans
+              (interpHomPreUnit_deltaWeightRight I O B d ih L X i e))))))
+
+/-- The per-summand identity-image equation at a `δ`-domain: the
+navigated subcode pre-unit's transported interpretation is the summand
+inclusion followed by the semantic pre-unit component. -/
+theorem interpHomPreUnit_deltaSummand (B : Type uB)
+    (d : Direction I O (Sum.inr (Sum.inr B) : Shape.{max uA uB, uB, uO} O) →
+      IR.{max uA uB, uB, uI, uO} I O)
+    (ih : (x : Direction I O (Sum.inr (Sum.inr B) : Shape.{max uA uB, uB, uO} O)) →
+      InterpHomPreUnitMotive I O (d x))
+    (L : List (SupObj.{uB, uI} I)) (X : FreeCoprodCompDisc.{max uA uB, uI} I)
+    (i : B → I) :
+    (interpHomDeltaSummand I O B (fun j ↦ d (ULift.up j))
+        (mprecomp I O L (mk I O (Sum.inr (Sum.inr B)) d)) i
+        (preUnitDeltaData I O B d L i)).1 X =
+      FreeCoprodCompDisc.Hom.comp O
+        (deltaInto I O B (fun j ↦ d (ULift.up j)) i X)
+        (preUnitComponent I O (mk I O (Sum.inr (Sum.inr B)) d) L X) :=
+  (congrArg
+      (FreeCoprodCompDisc.coprodDesc O
+        (FreeCoprodCompDisc.Hom I
+          (FreeCoprodCompDisc.lift.{uB, uI, max uA uB} I ⟨B, i⟩) X)
+        (fun _ ↦ interpObj I O (d (ULift.up i)) X)
+        (interpObj I O (mprecomp I O L (mk I O (Sum.inr (Sum.inr B)) d)) X))
+      (funext (fun e ↦
+        interpHomPreUnit_deltaWeight I O B d ih L X i e))).trans
+    (FreeCoprodCompDisc.coprodDesc_eta O
+      (FreeCoprodCompDisc.Hom I
+        (FreeCoprodCompDisc.lift.{uB, uI, max uA uB} I ⟨B, i⟩) X)
+      (fun _ ↦ interpObj I O (d (ULift.up i)) X)
+      (interpObj I O (mprecomp I O L (mk I O (Sum.inr (Sum.inr B)) d)) X)
+      (FreeCoprodCompDisc.Hom.comp O
+        (deltaInto I O B (fun j ↦ d (ULift.up j)) i X)
+        (preUnitComponent I O (mk I O (Sum.inr (Sum.inr B)) d) L X)))
+
+/-- The `δ`-domain case of the identity-image equation. -/
+theorem interpHomPreUnit_mk_delta (B : Type uB)
+    (d : Direction I O (Sum.inr (Sum.inr B) : Shape.{max uA uB, uB, uO} O) →
+      IR.{max uA uB, uB, uI, uO} I O)
+    (ih : (x : Direction I O (Sum.inr (Sum.inr B) : Shape.{max uA uB, uB, uO} O)) →
+      InterpHomPreUnitMotive I O (d x)) :
+    InterpHomPreUnitMotive I O (mk I O (Sum.inr (Sum.inr B)) d) :=
+  fun L X ↦
+    (congrArg
+        (fun t ↦ (interpHom I O (mk I O (Sum.inr (Sum.inr B)) d)
+          (mprecomp I O L (mk I O (Sum.inr (Sum.inr B)) d)) t).1 X)
+        (funext (fun i ↦ preUnitStack_mk_delta I O B d L i))).trans
+      ((interpHom_delta I O B (fun j ↦ d (ULift.up j))
+          (mprecomp I O L (mk I O (Sum.inr (Sum.inr B)) d))
+          (preUnitDeltaData I O B d L) X).trans
+        ((congrArg
+            (deltaDesc I O B (fun j ↦ d (ULift.up j)) X
+              (interpObj I O (mprecomp I O L (mk I O (Sum.inr (Sum.inr B)) d)) X))
+            (funext (fun i ↦
+              interpHomPreUnit_deltaSummand I O B d ih L X i))).trans
+          (deltaDesc_eta I O B (fun j ↦ d (ULift.up j)) X
+            (interpObj I O (mprecomp I O L (mk I O (Sum.inr (Sum.inr B)) d)) X)
+            (preUnitComponent I O (mk I O (Sum.inr (Sum.inr B)) d) L X))))
+
+/-- The identity-image equation at an `ι`-domain, with the codomain
+code and the target morphism generalized: at the reflexive instance the
+codomain interpretation is the singleton object, so any two morphisms
+into it agree. -/
+theorem interpHomPreUnit_iotaGen (o : O)
+    (d : Direction I O (Sum.inl o : Shape.{max uA uB, uB, uO} O) →
+      IR.{max uA uB, uB, uI, uO} I O)
+    (X : FreeCoprodCompDisc.{max uA uB, uI} I) :
+    ∀ (γ'' : IR.{max uA uB, uB, uI, uO} I O)
+      (hh : iota.{max uA uB, uB, uI, uO} I O o = γ'')
+      (t : FreeCoprodCompDisc.Hom O
+        (interpObj I O (mk I O (Sum.inl o) d) X) (interpObj I O γ'' X)),
+      (interpHom I O (mk I O (Sum.inl o) d) γ''
+        (cast (congrArg (Hom I O (mk I O (Sum.inl o) d)) hh)
+          (ULift.up (PLift.up rfl) :
+            Hom.{uA, uB, uI, uO} I O (mk I O (Sum.inl o) d)
+              (iota.{max uA uB, uB, uI, uO} I O o)))).1 X = t :=
+  fun _ hh ↦
+    Eq.rec (motive := fun (γ'' : IR.{max uA uB, uB, uI, uO} I O)
+        (hh' : iota.{max uA uB, uB, uI, uO} I O o = γ'') ↦
+        ∀ t : FreeCoprodCompDisc.Hom O
+          (interpObj I O (mk I O (Sum.inl o) d) X) (interpObj I O γ'' X),
+          (interpHom I O (mk I O (Sum.inl o) d) γ''
+            (cast (congrArg (Hom I O (mk I O (Sum.inl o) d)) hh')
+              (ULift.up (PLift.up rfl) :
+                Hom.{uA, uB, uI, uO} I O (mk I O (Sum.inl o) d)
+                  (iota.{max uA uB, uB, uI, uO} I O o)))).1 X = t)
+      (fun _ ↦ Subtype.ext (funext (fun _ ↦ congrArg ULift.up rfl))) hh
+
+/-- The `ι`-domain case of the identity-image equation. -/
+theorem interpHomPreUnit_mk_iota (o : O)
+    (d : Direction I O (Sum.inl o : Shape.{max uA uB, uB, uO} O) →
+      IR.{max uA uB, uB, uI, uO} I O) :
+    InterpHomPreUnitMotive I O (mk I O (Sum.inl o) d) :=
+  fun L X ↦
+    (congrArg
+        (fun t ↦ (interpHom I O (mk I O (Sum.inl o) d)
+          (mprecomp I O L (mk I O (Sum.inl o) d)) t).1 X)
+        (preUnitStack_mk_iota I O o d L)).trans
+      (interpHomPreUnit_iotaGen I O o d X
+        (mprecomp I O L (mk I O (Sum.inl o) d))
+        (mprecomp_iota_mk I O L o d).symm
+        (preUnitComponent I O (mk I O (Sum.inl o) d) L X))
+
+/-- The per-summand identity-image equation at a `σ`-domain: the stack
+`σ`-push of the subcode's pre-unit is the semantic `σ`-injection
+followed by the pre-unit component. -/
+theorem interpHomPreUnit_sigmaSummand (A : Type (max uA uB))
+    (d : Direction I O (Sum.inr (Sum.inl A) : Shape.{max uA uB, uB, uO} O) →
+      IR.{max uA uB, uB, uI, uO} I O)
+    (ih : (x : Direction I O (Sum.inr (Sum.inl A) : Shape.{max uA uB, uB, uO} O)) →
+      InterpHomPreUnitMotive I O (d x))
+    (L : List (SupObj.{uB, uI} I)) (X : FreeCoprodCompDisc.{max uA uB, uI} I)
+    (a : A) :
+    (interpHom I O (d (ULift.up a))
+        (mprecomp I O L (mk I O (Sum.inr (Sum.inl A)) d))
+        (msigmaPush I O (d (ULift.up a)) A (fun a' ↦ d (ULift.up a')) a L
+          (preUnitStack I O (d (ULift.up a)) L))).1 X =
+      FreeCoprodCompDisc.Hom.comp O
+        (FreeCoprodCompDisc.coprodInj O A
+          (fun a' ↦ interpObj I O (d (ULift.up a')) X) a)
+        (preUnitComponent I O (mk I O (Sum.inr (Sum.inl A)) d) L X) :=
+  (interpHom_msigmaPush I O (d (ULift.up a)) A (fun a' ↦ d (ULift.up a')) a L
+      (preUnitStack I O (d (ULift.up a)) L) X).trans
+    ((congrArg
+        (fun t ↦ FreeCoprodCompDisc.Hom.comp O t
+          (FreeCoprodCompDisc.Hom.comp O
+            (FreeCoprodCompDisc.Hom.comp O
+              (FreeCoprodCompDisc.Iso.hom O
+                (mprecompIso.{uA, uB, uI, uO} I O L (d (ULift.up a)) X))
+              (FreeCoprodCompDisc.coprodInj O A
+                (fun a' ↦ interpObj I O (d (ULift.up a'))
+                  (mplus.{uA, uB, uI} I L X)) a))
+            (FreeCoprodCompDisc.Iso.invHom O
+              (mprecompIso.{uA, uB, uI, uO} I O L
+                (mk I O (Sum.inr (Sum.inl A)) d) X))))
+        (ih (ULift.up a) L X)).trans
+      ((congrArg
+          (fun t ↦ FreeCoprodCompDisc.Hom.comp O
+            (interpMor I O (d (ULift.up a)) X (mplus.{uA, uB, uI} I L X)
+              (mplusInj.{uA, uB, uI} I L X))
+            (FreeCoprodCompDisc.Hom.comp O t
+              (FreeCoprodCompDisc.Hom.comp O
+                (FreeCoprodCompDisc.coprodInj O A
+                  (fun a' ↦ interpObj I O (d (ULift.up a'))
+                    (mplus.{uA, uB, uI} I L X)) a)
+                (FreeCoprodCompDisc.Iso.invHom O
+                  (mprecompIso.{uA, uB, uI, uO} I O L
+                    (mk I O (Sum.inr (Sum.inl A)) d) X)))))
+          (FreeCoprodCompDisc.Iso.invHom_hom O
+            (mprecompIso.{uA, uB, uI, uO} I O L (d (ULift.up a)) X))).trans
+        (congrArg
+          (fun t ↦ FreeCoprodCompDisc.Hom.comp O t
+            (FreeCoprodCompDisc.Iso.invHom O
+              (mprecompIso.{uA, uB, uI, uO} I O L
+                (mk I O (Sum.inr (Sum.inl A)) d) X)))
+          (interpMor_sigma_inj I O A (fun a' ↦ d (ULift.up a')) a X
+            (mplus.{uA, uB, uI} I L X) (mplusInj.{uA, uB, uI} I L X)).symm)))
+
+/-- The `σ`-domain case of the identity-image equation. -/
+theorem interpHomPreUnit_mk_sigma (A : Type (max uA uB))
+    (d : Direction I O (Sum.inr (Sum.inl A) : Shape.{max uA uB, uB, uO} O) →
+      IR.{max uA uB, uB, uI, uO} I O)
+    (ih : (x : Direction I O (Sum.inr (Sum.inl A) : Shape.{max uA uB, uB, uO} O)) →
+      InterpHomPreUnitMotive I O (d x)) :
+    InterpHomPreUnitMotive I O (mk I O (Sum.inr (Sum.inl A)) d) :=
+  fun L X ↦
+    (congrArg
+        (fun t ↦ (interpHom I O (mk I O (Sum.inr (Sum.inl A)) d)
+          (mprecomp I O L (mk I O (Sum.inr (Sum.inl A)) d)) t).1 X)
+        (funext (fun a ↦ preUnitStack_mk_sigma I O A d L a))).trans
+      ((interpHom_sigma I O A (fun a ↦ d (ULift.up a))
+          (mprecomp I O L (mk I O (Sum.inr (Sum.inl A)) d))
+          (fun a ↦ msigmaPush I O (d (ULift.up a)) A
+            (fun a' ↦ d (ULift.up a')) a L
+            (preUnitStack I O (d (ULift.up a)) L)) X).trans
+        ((congrArg
+            (FreeCoprodCompDisc.coprodDesc O A
+              (fun a ↦ interpObj I O (d (ULift.up a)) X)
+              (interpObj I O
+                (mprecomp I O L (mk I O (Sum.inr (Sum.inl A)) d)) X))
+            (funext (fun a ↦
+              interpHomPreUnit_sigmaSummand I O A d ih L X a))).trans
+          (FreeCoprodCompDisc.coprodDesc_eta O A
+            (fun a ↦ interpObj I O (d (ULift.up a)) X)
+            (interpObj I O (mprecomp I O L (mk I O (Sum.inr (Sum.inl A)) d)) X)
+            (preUnitComponent I O (mk I O (Sum.inr (Sum.inl A)) d) L X))))
+
+/-- `IR.interpHom` sends `IR.preUnitStack` to the semantic pre-unit
+component, by `IR.induction`. -/
+theorem interpHom_preUnitStack (γ : IR.{max uA uB, uB, uI, uO} I O) :
+    InterpHomPreUnitMotive I O γ :=
+  induction I O (InterpHomPreUnitMotive I O)
+    (fun s ↦ match s with
+      | Sum.inl o => fun d _ ↦ interpHomPreUnit_mk_iota I O o d
+      | Sum.inr (Sum.inl A) => fun d ih ↦ interpHomPreUnit_mk_sigma I O A d ih
+      | Sum.inr (Sum.inr B) => fun d ih ↦ interpHomPreUnit_mk_delta I O B d ih)
+    γ
+
+/-! ### Composition and the category laws -/
+
+/-- Composition of IR-code morphisms (Corollary 2 of
+[HancockMcBrideGhaniMalatestaAltenkirch2013]): the image under
+fullness of the vertical composite of the interpreted
+transformations. -/
+def comp (γ γ' γ'' : IR.{max uA uB, uB, uI, uO} I O)
+    (f : Hom.{uA, uB, uI, uO} I O γ γ')
+    (g : Hom.{uA, uB, uI, uO} I O γ' γ'') :
+    Hom.{uA, uB, uI, uO} I O γ γ'' :=
+  natToHom I O γ γ''
+    (FreeCoprodCompDisc.NatTrans.vcomp (interpHom I O γ γ' f)
+      (interpHom I O γ' γ'' g))
+
+/-- `IR.interpHom` sends `IR.comp` to the vertical composite: the
+interpretation is functorial on morphisms. -/
+theorem interpHom_comp (γ γ' γ'' : IR.{max uA uB, uB, uI, uO} I O)
+    (f : Hom.{uA, uB, uI, uO} I O γ γ')
+    (g : Hom.{uA, uB, uI, uO} I O γ' γ'') :
+    interpHom I O γ γ'' (comp I O γ γ' γ'' f g) =
+      FreeCoprodCompDisc.NatTrans.vcomp (interpHom I O γ γ' f)
+        (interpHom I O γ' γ'' g) :=
+  interpHom_natToHom I O γ γ''
+    (FreeCoprodCompDisc.NatTrans.vcomp (interpHom I O γ γ' f)
+      (interpHom I O γ' γ'' g))
+
+/-- Associativity of `IR.comp`, by conjugation through the Theorem 3
+equivalence and associativity of vertical composition. -/
+theorem comp_assoc (γ γ' γ'' γ''' : IR.{max uA uB, uB, uI, uO} I O)
+    (f : Hom.{uA, uB, uI, uO} I O γ γ')
+    (g : Hom.{uA, uB, uI, uO} I O γ' γ'')
+    (h : Hom.{uA, uB, uI, uO} I O γ'' γ''') :
+    comp I O γ γ'' γ''' (comp I O γ γ' γ'' f g) h =
+      comp I O γ γ' γ''' f (comp I O γ' γ'' γ''' g h) :=
+  (congrArg (fun t ↦ natToHom I O γ γ'''
+      (FreeCoprodCompDisc.NatTrans.vcomp t (interpHom I O γ'' γ''' h)))
+    (interpHom_comp I O γ γ' γ'' f g)).trans
+    ((congrArg (natToHom I O γ γ''')
+        (FreeCoprodCompDisc.NatTrans.vcomp_assoc (interpHom I O γ γ' f)
+          (interpHom I O γ' γ'' g) (interpHom I O γ'' γ''' h))).trans
+      (congrArg (fun t ↦ natToHom I O γ γ'''
+          (FreeCoprodCompDisc.NatTrans.vcomp (interpHom I O γ γ' f) t))
+        (interpHom_comp I O γ' γ'' γ''' g h)).symm)
+
+/-- `IR.interpHom` sends `IR.id` to the identity transformation: the
+identity-image equation at the empty stack. -/
+theorem interpHom_id (γ : IR.{max uA uB, uB, uI, uO} I O) :
+    interpHom I O γ γ (IR.id I O γ) =
+      FreeCoprodCompDisc.NatTrans.id (interpObj I O γ) (interpMor I O γ) :=
+  Subtype.ext (funext (fun X ↦
+    (interpHom_preUnitStack I O γ [] X).trans (preUnitComponent_nil I O γ X)))
+
+/-- `IR.id` is a left identity for `IR.comp`, by conjugation through the
+Theorem 3 equivalence and the left identity of vertical composition. -/
+theorem id_comp (γ γ' : IR.{max uA uB, uB, uI, uO} I O)
+    (f : Hom.{uA, uB, uI, uO} I O γ γ') :
+    comp I O γ γ γ' (IR.id I O γ) f = f :=
+  (congrArg
+      (fun t ↦ natToHom I O γ γ'
+        (FreeCoprodCompDisc.NatTrans.vcomp t (interpHom I O γ γ' f)))
+      (interpHom_id I O γ)).trans
+    ((congrArg (natToHom I O γ γ')
+        (FreeCoprodCompDisc.NatTrans.id_vcomp
+          (interpHom I O γ γ' f))).trans
+      (natToHom_interpHom I O γ γ' f))
+
+/-- `IR.id` is a right identity for `IR.comp`, by conjugation through the
+Theorem 3 equivalence and the right identity of vertical composition. -/
+theorem comp_id (γ γ' : IR.{max uA uB, uB, uI, uO} I O)
+    (f : Hom.{uA, uB, uI, uO} I O γ γ') :
+    comp I O γ γ' γ' f (IR.id I O γ') = f :=
+  (congrArg
+      (fun t ↦ natToHom I O γ γ'
+        (FreeCoprodCompDisc.NatTrans.vcomp (interpHom I O γ γ' f) t))
+      (interpHom_id I O γ')).trans
+    ((congrArg (natToHom I O γ γ')
+        (FreeCoprodCompDisc.NatTrans.vcomp_id
+          (interpHom I O γ γ' f))).trans
+      (natToHom_interpHom I O γ γ' f))
+
+end IR
+
+end IndRec

--- a/geb-lean/vendor/geb-mathlib/Geb/Mathlib/Data/PFunctor/IndRec/Hom.lean
+++ b/geb-lean/vendor/geb-mathlib/Geb/Mathlib/Data/PFunctor/IndRec/Hom.lean
@@ -42,6 +42,12 @@ iterated-precomposition tower recorded by `IR.mprecomp`.
 * `IR.preUnitStack` — the list-generalized pre-unit `Hom γ (γ ^^ L)`.
 * `IR.id` — the identity morphism of an IR code, as `IR.preUnitStack`
   at the empty stack.
+* `IR.SigmaPushMotive`, `IR.sigmaPushStep`,
+  `IR.DeltaEmptyPushMotive`, `IR.deltaEmptyPushStep`,
+  `IR.PreUnitStackMotive`, `IR.preUnitStackStep` — the named
+  motives and recursor steps of the three `IR.rec`-built
+  operations, at which `IR.rec_mk` applies.
+* `IR.preUnitDeltaData` — the `δ`-domain pre-unit's summand datum.
 
 ## Main statements
 
@@ -49,6 +55,12 @@ iterated-precomposition tower recorded by `IR.mprecomp`.
   one outer `IR.precomp`.
 * `IR.mprecomp_iota`, `IR.mprecomp_iota_mk` — `IR.mprecomp` fixes the
   constant (`iota`) code, including any `IR.mk`-form of one.
+* `IR.sigmaPush_mk_iota`, `IR.sigmaPush_mk_sigma`,
+  `IR.sigmaPush_mk_delta`, `IR.deltaEmptyPush_mk_iota`,
+  `IR.deltaEmptyPush_mk_sigma`, `IR.deltaEmptyPush_mk_delta`,
+  `IR.preUnitStack_mk_iota`, `IR.preUnitStack_mk_sigma`,
+  `IR.preUnitStack_mk_delta` — the computation equations of the
+  three operations at an `IR.mk`-built domain code.
 
 ## Implementation notes
 
@@ -115,6 +127,23 @@ def Hom : IR.{max uA uB, uB, uI, uO} I O → IR.{max uA uB, uB, uI, uO} I O
     ⟨fun o => InnerHom I O o, fun _ dir => fun g' => ∀ a, dir a g',
      fun B dir => fun g' => ∀ i : B → I, dir i (precomp I O B i g')⟩
 
+/-- The motive of `IR.sigmaPush` (named so `IR.rec_mk` applies). -/
+def SigmaPushMotive (γ : IR.{max uA uB, uB, uI, uO} I O) :
+    Type (max (max uA uB + 1) uI uO) :=
+  ∀ (A' : Type (max uA uB)) (K' : A' → IR.{max uA uB, uB, uI, uO} I O)
+    (a' : A'), Hom I O γ (K' a') → Hom I O γ (sigma I O A' K')
+
+/-- The step of `IR.sigmaPush` (named so `IR.rec_mk` applies). -/
+def sigmaPushStep :
+    RecStep.{max uA uB, uB, uI, uO, max (max uA uB + 1) uI uO} I O
+      (SigmaPushMotive I O) :=
+  fun s _c m => match s with
+  | Sum.inl _ => fun _ _ a' f => ⟨a', f⟩
+  | Sum.inr (Sum.inl _) => fun A' K' a' f b => m (ULift.up b) A' K' a' (f b)
+  | Sum.inr (Sum.inr B) => fun A' K' a' f i =>
+      m (ULift.up i) (ULift.{uB} A')
+        (fun x => precomp I O B i (K' x.down)) (ULift.up a') (f i)
+
 /-- Postcomposition with the `σ`-injection into the `a'`-th summand:
 identity at a `σ`-code is a product of these injections. By `IR.rec` on
 the domain with the target `(A', K', a')` generalized; the `δ`-domain
@@ -123,16 +152,75 @@ keeps `(σ A' K')^i` a `σ`-code). -/
 def sigmaPush : (γ : IR.{max uA uB, uB, uI, uO} I O) →
       ∀ (A' : Type (max uA uB)) (K' : A' → IR.{max uA uB, uB, uI, uO} I O) (a' : A'),
         Hom I O γ (K' a') → Hom I O γ (sigma I O A' K') :=
-  rec I O
-    (motive := fun γ => ∀ (A' : Type (max uA uB))
-        (K' : A' → IR.{max uA uB, uB, uI, uO} I O) (a' : A'),
-      Hom I O γ (K' a') → Hom I O γ (sigma I O A' K'))
-    (fun s _c m => match s with
-      | Sum.inl _ => fun _ _ a' f => ⟨a', f⟩
-      | Sum.inr (Sum.inl _) => fun A' K' a' f b => m (ULift.up b) A' K' a' (f b)
-      | Sum.inr (Sum.inr B) => fun A' K' a' f i =>
-          m (ULift.up i) (ULift.{uB} A')
-            (fun x => precomp I O B i (K' x.down)) (ULift.up a') (f i))
+  rec I O (sigmaPushStep I O)
+
+/-- The characterizing equation of `IR.sigmaPush` at an `ι`-shaped
+`IR.mk`: the target data pairs with the argument. -/
+theorem sigmaPush_mk_iota (o : O)
+    (d : Direction I O (Sum.inl o : Shape.{max uA uB, uB, uO} O) →
+      IR.{max uA uB, uB, uI, uO} I O)
+    (A' : Type (max uA uB)) (K' : A' → IR.{max uA uB, uB, uI, uO} I O)
+    (a' : A') (f : Hom.{uA, uB, uI, uO} I O (mk I O (Sum.inl o) d) (K' a')) :
+    sigmaPush I O (mk I O (Sum.inl o) d) A' K' a' f = ⟨a', f⟩ :=
+  congrFun (congrFun (congrFun (congrFun
+    (rec_mk I O (sigmaPushStep I O) (Sum.inl o) d) A') K') a') f
+
+/-- The characterizing equation of `IR.sigmaPush` at a `σ`-shaped
+`IR.mk`: componentwise recursion. -/
+theorem sigmaPush_mk_sigma (A : Type (max uA uB))
+    (d : Direction I O (Sum.inr (Sum.inl A) : Shape.{max uA uB, uB, uO} O) →
+      IR.{max uA uB, uB, uI, uO} I O)
+    (A' : Type (max uA uB)) (K' : A' → IR.{max uA uB, uB, uI, uO} I O)
+    (a' : A')
+    (f : Hom.{uA, uB, uI, uO} I O (mk I O (Sum.inr (Sum.inl A)) d) (K' a')) :
+    sigmaPush I O (mk I O (Sum.inr (Sum.inl A)) d) A' K' a' f =
+      fun b => sigmaPush I O (d (ULift.up b)) A' K' a' (f b) :=
+  congrFun (congrFun (congrFun (congrFun
+    (rec_mk I O (sigmaPushStep I O) (Sum.inr (Sum.inl A)) d) A') K') a') f
+
+/-- The characterizing equation of `IR.sigmaPush` at a `δ`-shaped
+`IR.mk`: recursion at the precomposed target. -/
+theorem sigmaPush_mk_delta (B : Type uB)
+    (d : Direction I O (Sum.inr (Sum.inr B) : Shape.{max uA uB, uB, uO} O) →
+      IR.{max uA uB, uB, uI, uO} I O)
+    (A' : Type (max uA uB)) (K' : A' → IR.{max uA uB, uB, uI, uO} I O)
+    (a' : A')
+    (f : Hom.{uA, uB, uI, uO} I O (mk I O (Sum.inr (Sum.inr B)) d) (K' a')) :
+    sigmaPush I O (mk I O (Sum.inr (Sum.inr B)) d) A' K' a' f =
+      fun i => sigmaPush I O (d (ULift.up i)) (ULift.{uB} A')
+        (fun x => precomp I O B i (K' x.down)) (ULift.up a') (f i) :=
+  congrFun (congrFun (congrFun (congrFun
+    (rec_mk I O (sigmaPushStep I O) (Sum.inr (Sum.inr B)) d) A') K') a') f
+
+/-- The motive of `IR.deltaEmptyPush` (named so `IR.rec_mk` applies). -/
+def DeltaEmptyPushMotive (γ : IR.{max uA uB, uB, uI, uO} I O) :
+    Type (max (max uA uB + 1) uI uO) :=
+  ∀ (E : Type uB) (e : E → PEmpty.{1})
+    (M : (E → I) → IR.{max uA uB, uB, uI, uO} I O),
+    Hom I O γ (M (fun x => (e x).elim)) → Hom I O γ (delta I O E M)
+
+/-- The step of `IR.deltaEmptyPush` (named so `IR.rec_mk` applies). -/
+def deltaEmptyPushStep :
+    RecStep.{max uA uB, uB, uI, uO, max (max uA uB + 1) uI uO} I O
+      (DeltaEmptyPushMotive I O) :=
+  fun s c m => match s with
+  | Sum.inl _ => fun _ e _ f => ⟨e, f⟩
+  | Sum.inr (Sum.inl _) => fun E e M f b => m (ULift.up b) E e M (f b)
+  | Sum.inr (Sum.inr B) => fun E e M f i =>
+      sigmaPush I O (c (ULift.up i)) (ULift.{max uA uB} (E → B ⊕ PUnit.{uB + 1}))
+        (fun cl => delta I O {z : E // cl.down z = Sum.inr PUnit.unit}
+          (fun j => precomp I O B i (M (precompMerge I B i cl.down j))))
+        (ULift.up (fun x => (e x).elim))
+        (m (ULift.up i) {z : E // (fun x => (e x).elim) z = Sum.inr PUnit.unit}
+          (fun z => (e z.1).elim)
+          (fun j => precomp I O B i (M (precompMerge I B i (fun x => (e x).elim) j)))
+          (cast (congrArg
+            (fun a => Hom I O (c (ULift.up i)) (precomp I O B i (M a)))
+            (funext (fun x => (e x).elim) :
+              (fun x => (e x).elim) = precompMerge I B i (fun x => (e x).elim)
+                    (fun z : {z : E // (fun x => (e x).elim) z = Sum.inr PUnit.unit}
+                      => ((e z.1).elim : PEmpty.{1}).elim)))
+            (f i)))
 
 /-- Postcomposition with the `δ`-injection at an empty direction witness
 (`e : E → PEmpty`): by `IR.rec` on the domain with `(E, e, M)`
@@ -141,28 +229,64 @@ all-resolved classifier summand of the precomposed `δ`-code. -/
 def deltaEmptyPush : (γ : IR.{max uA uB, uB, uI, uO} I O) →
       ∀ (E : Type uB) (e : E → PEmpty.{1}) (M : (E → I) → IR.{max uA uB, uB, uI, uO} I O),
         Hom I O γ (M (fun x => (e x).elim)) → Hom I O γ (delta I O E M) :=
-  rec I O
-    (motive := fun γ => ∀ (E : Type uB) (e : E → PEmpty.{1})
-        (M : (E → I) → IR.{max uA uB, uB, uI, uO} I O),
-      Hom I O γ (M (fun x => (e x).elim)) → Hom I O γ (delta I O E M))
-    (fun s c m => match s with
-      | Sum.inl _ => fun _ e _ f => ⟨e, f⟩
-      | Sum.inr (Sum.inl _) => fun E e M f b => m (ULift.up b) E e M (f b)
-      | Sum.inr (Sum.inr B) => fun E e M f i =>
-          sigmaPush I O (c (ULift.up i)) (ULift.{max uA uB} (E → B ⊕ PUnit.{uB + 1}))
-            (fun cl => delta I O {z : E // cl.down z = Sum.inr PUnit.unit}
-              (fun j => precomp I O B i (M (precompMerge I B i cl.down j))))
-            (ULift.up (fun x => (e x).elim))
-            (m (ULift.up i) {z : E // (fun x => (e x).elim) z = Sum.inr PUnit.unit}
-              (fun z => (e z.1).elim)
-              (fun j => precomp I O B i (M (precompMerge I B i (fun x => (e x).elim) j)))
-              (cast (congrArg
-                (fun a => Hom I O (c (ULift.up i)) (precomp I O B i (M a)))
-                (funext (fun x => (e x).elim) :
-                  (fun x => (e x).elim) = precompMerge I B i (fun x => (e x).elim)
-                        (fun z : {z : E // (fun x => (e x).elim) z = Sum.inr PUnit.unit}
-                          => ((e z.1).elim : PEmpty.{1}).elim)))
-                (f i))))
+  rec I O (deltaEmptyPushStep I O)
+
+/-- The characterizing equation of `IR.deltaEmptyPush` at an `ι`-shaped
+`IR.mk`: the empty witness pairs with the argument. -/
+theorem deltaEmptyPush_mk_iota (o : O)
+    (d : Direction I O (Sum.inl o : Shape.{max uA uB, uB, uO} O) →
+      IR.{max uA uB, uB, uI, uO} I O)
+    (E : Type uB) (e : E → PEmpty.{1})
+    (M : (E → I) → IR.{max uA uB, uB, uI, uO} I O)
+    (f : Hom.{uA, uB, uI, uO} I O (mk I O (Sum.inl o) d)
+      (M (fun x => (e x).elim))) :
+    deltaEmptyPush I O (mk I O (Sum.inl o) d) E e M f = ⟨e, f⟩ :=
+  congrFun (congrFun (congrFun (congrFun
+    (rec_mk I O (deltaEmptyPushStep I O) (Sum.inl o) d) E) e) M) f
+
+/-- The characterizing equation of `IR.deltaEmptyPush` at a `σ`-shaped
+`IR.mk`: componentwise recursion. -/
+theorem deltaEmptyPush_mk_sigma (A : Type (max uA uB))
+    (d : Direction I O (Sum.inr (Sum.inl A) : Shape.{max uA uB, uB, uO} O) →
+      IR.{max uA uB, uB, uI, uO} I O)
+    (E : Type uB) (e : E → PEmpty.{1})
+    (M : (E → I) → IR.{max uA uB, uB, uI, uO} I O)
+    (f : Hom.{uA, uB, uI, uO} I O (mk I O (Sum.inr (Sum.inl A)) d)
+      (M (fun x => (e x).elim))) :
+    deltaEmptyPush I O (mk I O (Sum.inr (Sum.inl A)) d) E e M f =
+      fun b => deltaEmptyPush I O (d (ULift.up b)) E e M (f b) :=
+  congrFun (congrFun (congrFun (congrFun
+    (rec_mk I O (deltaEmptyPushStep I O) (Sum.inr (Sum.inl A)) d) E) e) M) f
+
+/-- The characterizing equation of `IR.deltaEmptyPush` at a `δ`-shaped
+`IR.mk`: injection through the all-resolved classifier summand of the
+precomposed `δ`-code, recursing at the unresolved subtype. -/
+theorem deltaEmptyPush_mk_delta (B : Type uB)
+    (d : Direction I O (Sum.inr (Sum.inr B) : Shape.{max uA uB, uB, uO} O) →
+      IR.{max uA uB, uB, uI, uO} I O)
+    (E : Type uB) (e : E → PEmpty.{1})
+    (M : (E → I) → IR.{max uA uB, uB, uI, uO} I O)
+    (f : Hom.{uA, uB, uI, uO} I O (mk I O (Sum.inr (Sum.inr B)) d)
+      (M (fun x => (e x).elim))) :
+    deltaEmptyPush I O (mk I O (Sum.inr (Sum.inr B)) d) E e M f =
+      fun i => sigmaPush I O (d (ULift.up i))
+        (ULift.{max uA uB} (E → B ⊕ PUnit.{uB + 1}))
+        (fun cl => delta I O {z : E // cl.down z = Sum.inr PUnit.unit}
+          (fun j => precomp I O B i (M (precompMerge I B i cl.down j))))
+        (ULift.up (fun x => (e x).elim))
+        (deltaEmptyPush I O (d (ULift.up i))
+          {z : E // (fun x => (e x).elim) z = Sum.inr PUnit.unit}
+          (fun z => (e z.1).elim)
+          (fun j => precomp I O B i (M (precompMerge I B i (fun x => (e x).elim) j)))
+          (cast (congrArg
+            (fun a => Hom I O (d (ULift.up i)) (precomp I O B i (M a)))
+            (funext (fun x => (e x).elim) :
+              (fun x => (e x).elim) = precompMerge I B i (fun x => (e x).elim)
+                    (fun z : {z : E // (fun x => (e x).elim) z = Sum.inr PUnit.unit}
+                      => ((e z.1).elim : PEmpty.{1}).elim)))
+            (f i))) :=
+  congrFun (congrFun (congrFun (congrFun
+    (rec_mk I O (deltaEmptyPushStep I O) (Sum.inr (Sum.inr B)) d) E) e) M) f
 
 /-- Superscript objects: index types with an `I`-valued assignment
 (definitionally `FreeCoprodCompDisc.{uB, uI} I`, the free-coproduct-
@@ -262,6 +386,29 @@ def deltaNav (D : IR.{max uA uB, uB, uI, uO} I O) (Bout : Type uB) (iout : Bout 
           (fun z => g z.1) f))
     Bin K g f
 
+/-- The motive of `IR.preUnitStack` (named so `IR.rec_mk` applies). -/
+def PreUnitStackMotive (γ : IR.{max uA uB, uB, uI, uO} I O) :
+    Type (max uA (uB + 1) uI) :=
+  ∀ L : List (SupObj.{uB, uI} I), Hom.{uA, uB, uI, uO} I O γ (mprecomp I O L γ)
+
+/-- The step of `IR.preUnitStack` (named so `IR.rec_mk` applies). -/
+def preUnitStackStep :
+    RecStep.{max uA uB, uB, uI, uO, max uA (uB + 1) uI} I O
+      (PreUnitStackMotive I O) :=
+  fun s c m => match s with
+  | Sum.inl o => fun L =>
+      cast (congrArg (InnerHom.{uA, uB, uI, uO} I O o)
+          (mprecomp_iota_mk I O L o c).symm)
+        (ULift.up (PLift.up rfl) : InnerHom.{uA, uB, uI, uO} I O o (iota I O o))
+  | Sum.inr (Sum.inl A) => fun L a =>
+      msigmaPush I O (c (ULift.up a)) A (fun a' => c (ULift.up a')) a L
+        (m (ULift.up a) L)
+  | Sum.inr (Sum.inr B) => fun L i =>
+      cast (congrArg (Hom I O (c (ULift.up i)))
+             (mprecomp_snoc I O L ⟨B, i⟩ (mk I O (Sum.inr (Sum.inr B)) c)))
+        (deltaNav I O (c (ULift.up i)) B i B (fun i' => c (ULift.up i')) _root_.id L
+          (m (ULift.up i) (L ++ [⟨B, i⟩])))
+
 /-- The list-generalized pre-unit `Hom γ (γ ^^ L)`: by `IR.rec` on `γ`
 with the stack `L` generalized. The `δ`-case appends the mapped direction
 to `L`, so the subcode induction hypothesis lands at the precomposition
@@ -269,18 +416,56 @@ depth clause 3 demands, and `deltaNav` navigates the superscripted
 `δ`-tower. -/
 def preUnitStack : (γ : IR.{max uA uB, uB, uI, uO} I O) →
       ∀ (L : List (SupObj.{uB, uI} I)), Hom I O γ (mprecomp I O L γ) :=
-  rec I O (motive := fun γ => ∀ L, Hom I O γ (mprecomp I O L γ))
-    (fun s c m => match s with
-      | Sum.inl o => fun L =>
-          cast (congrArg (InnerHom.{uA, uB, uI, uO} I O o) (mprecomp_iota_mk I O L o c).symm)
-            (ULift.up (PLift.up rfl) : InnerHom.{uA, uB, uI, uO} I O o (iota I O o))
-      | Sum.inr (Sum.inl A) => fun L a =>
-          msigmaPush I O (c (ULift.up a)) A (fun a' => c (ULift.up a')) a L (m (ULift.up a) L)
-      | Sum.inr (Sum.inr B) => fun L i =>
-          cast (congrArg (Hom I O (c (ULift.up i)))
-                 (mprecomp_snoc I O L ⟨B, i⟩ (mk I O (Sum.inr (Sum.inr B)) c)))
-            (deltaNav I O (c (ULift.up i)) B i B (fun i' => c (ULift.up i')) _root_.id L
-              (m (ULift.up i) (L ++ [⟨B, i⟩]))))
+  rec I O (preUnitStackStep I O)
+
+/-- The characterizing equation of `IR.preUnitStack` at an `ι`-shaped
+`IR.mk`: the transported reflexivity witness. -/
+theorem preUnitStack_mk_iota (o : O)
+    (d : Direction I O (Sum.inl o : Shape.{max uA uB, uB, uO} O) →
+      IR.{max uA uB, uB, uI, uO} I O)
+    (L : List (SupObj.{uB, uI} I)) :
+    preUnitStack I O (mk I O (Sum.inl o) d) L =
+      cast (congrArg (InnerHom.{uA, uB, uI, uO} I O o)
+          (mprecomp_iota_mk I O L o d).symm)
+        (ULift.up (PLift.up rfl) : InnerHom.{uA, uB, uI, uO} I O o (iota I O o)) :=
+  congrFun (rec_mk I O (preUnitStackStep I O) (Sum.inl o) d) L
+
+/-- The characterizing equation of `IR.preUnitStack` at a `σ`-shaped
+`IR.mk`: the subcode's pre-unit pushed along the stack `σ`-injection. -/
+theorem preUnitStack_mk_sigma (A : Type (max uA uB))
+    (d : Direction I O (Sum.inr (Sum.inl A) : Shape.{max uA uB, uB, uO} O) →
+      IR.{max uA uB, uB, uI, uO} I O)
+    (L : List (SupObj.{uB, uI} I)) (a : A) :
+    preUnitStack I O (mk I O (Sum.inr (Sum.inl A)) d) L a =
+      msigmaPush I O (d (ULift.up a)) A (fun a' => d (ULift.up a')) a L
+        (preUnitStack I O (d (ULift.up a)) L) :=
+  congrFun (congrFun
+    (rec_mk I O (preUnitStackStep I O) (Sum.inr (Sum.inl A)) d) L) a
+
+/-- The `δ`-domain pre-unit's summand datum: the subcode's pre-unit at
+the extended stack, navigated up the tower and transported by
+`IR.mprecomp_snoc`. -/
+def preUnitDeltaData (B : Type uB)
+    (d : Direction I O (Sum.inr (Sum.inr B) : Shape.{max uA uB, uB, uO} O) →
+      IR.{max uA uB, uB, uI, uO} I O)
+    (L : List (SupObj.{uB, uI} I)) (i : B → I) :
+    Hom.{uA, uB, uI, uO} I O (d (ULift.up i))
+      (precomp I O B i (mprecomp I O L (mk I O (Sum.inr (Sum.inr B)) d))) :=
+  cast (congrArg (Hom I O (d (ULift.up i)))
+      (mprecomp_snoc I O L ⟨B, i⟩ (mk I O (Sum.inr (Sum.inr B)) d)))
+    (deltaNav I O (d (ULift.up i)) B i B (fun i' => d (ULift.up i')) _root_.id L
+      (preUnitStack I O (d (ULift.up i)) (L ++ [⟨B, i⟩])))
+
+/-- The characterizing equation of `IR.preUnitStack` at a `δ`-shaped
+`IR.mk`: the summand datum `IR.preUnitDeltaData` at every assignment. -/
+theorem preUnitStack_mk_delta (B : Type uB)
+    (d : Direction I O (Sum.inr (Sum.inr B) : Shape.{max uA uB, uB, uO} O) →
+      IR.{max uA uB, uB, uI, uO} I O)
+    (L : List (SupObj.{uB, uI} I)) (i : B → I) :
+    preUnitStack I O (mk I O (Sum.inr (Sum.inr B)) d) L i =
+      preUnitDeltaData I O B d L i :=
+  congrFun (congrFun
+    (rec_mk I O (preUnitStackStep I O) (Sum.inr (Sum.inr B)) d) L) i
 
 /-- The identity morphism of an IR code (the paper gives no explicit
 identity; this is a construction), as the pre-unit at the empty stack. -/

--- a/geb-lean/vendor/geb-mathlib/Geb/Mathlib/Data/PFunctor/IndRec/Naturality.lean
+++ b/geb-lean/vendor/geb-mathlib/Geb/Mathlib/Data/PFunctor/IndRec/Naturality.lean
@@ -1,0 +1,1200 @@
+/-
+Copyright (c) 2026 Terence Rokop. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Terence Rokop
+-/
+module
+
+public import Geb.Mathlib.CategoryTheory.FreeCoprodCompDisc.NatTrans
+public import Geb.Mathlib.Data.PFunctor.IndRec.Functor
+public import Geb.Mathlib.Data.PFunctor.IndRec.Hom
+
+/-!
+# Naturality of the IR interpretation and Theorem 3
+
+Theorem 3 of [HancockMcBrideGhaniMalatestaAltenkirch2013]: the
+homset between two `IR` codes is equivalent to the space of
+natural transformations between their interpretations
+(`IR.interpHomEquiv`), by `IR.rec` on the domain code. The
+supporting development comprises the per-summand decomposition at
+a `delta` code (the naturality upgrade of the paper's Lemma 3),
+the naturality upgrade of Lemma 4, the ∅-evaluation and `InnerHom`
+fiber equivalences of the `ι`-case, and the plus-lift bridge.
+
+## Main definitions
+
+* `IR.deltaInto`, `IR.deltaDesc` — the natural inclusions of the
+  copower summands into the `delta` interpretation and their
+  cotuple ([HancockMcBrideGhaniMalatestaAltenkirch2013], Lemma 3,
+  upgraded to per-summand natural form).
+* `IR.natDeltaEquiv` — the per-summand decomposition of
+  transformation spaces at a `delta` code.
+* `IR.natIotaEquiv` — the ∅-evaluation equivalence at an `ι`
+  domain: transformations out of `⟦ι o⟧` correspond to their
+  components at the initial object.
+* `IR.innerHomEquiv` — the homset from an `ι`-code as the fiber,
+  over the index, of the decoding of the codomain's interpretation
+  at the initial object
+  ([HancockMcBrideGhaniMalatestaAltenkirch2013], Definition 8's
+  `ι`-clauses, in the form Theorem 3's `ι`-case consumes).
+* `IR.plusLiftBridgeNat`, `IR.plusLiftBridgeNatInv` — the inverse
+  pair of transformations bridging the `plus`-precomposed
+  interpretation at the lifted summand and the Lemma 4 right-hand
+  map.
+* `IR.interpHomEquiv` — Theorem 3 of
+  [HancockMcBrideGhaniMalatestaAltenkirch2013]: `Hom γ γ'` is
+  equivalent to the transformation space between the
+  interpretations, with the directions `IR.interpHom` and
+  `IR.natToHom`.
+
+## Main statements
+
+* `IR.deltaInto_desc`, `IR.deltaDesc_eta`, `IR.deltaHom_ext` — the
+  computation and uniqueness laws of the cotuple, and joint
+  epicness of the inclusions.
+* `IR.deltaInto_natural` — naturality of the inclusions in the
+  interpreted object.
+* `IR.interpPrecompIso_natural` — naturality of the Lemma 4
+  isomorphism family
+  ([HancockMcBrideGhaniMalatestaAltenkirch2013], Lemma 4, upgraded
+  from the pointwise statement), with the characterizing equation
+  `IR.interpPrecompIso_mk`.
+* `IR.interpHom_natToHom`, `IR.natToHom_interpHom` — the
+  round-trip laws of `IR.interpHomEquiv` (fullness and
+  faithfulness of the interpretation on morphisms).
+
+## Implementation notes
+
+The total coproduct of Lemma 3 has an index type exceeding the
+uniform index universe, so it never appears as a
+`FreeCoprodCompDisc.Map`; the decomposition is per summand. The
+`delta`-side morphism map is rewritten by `IR.interpMor_delta`,
+and transports of names along equalities of direction assignments
+are eliminated by the cast lemmas `IR.interpObj_snd_cast` and
+`IR.interpMor_cast`, with `Eq.rec` motives at projection-reduced
+types and dependent `rfl`-proofs quantified inside the motive.
+The Lemma 4 upgrade rewrites the isomorphism family to step form
+before eliminating the morphism's commutation equality and
+splitting on the shape; the precomposed code is a stuck match
+until the shape is known, after which the per-constructor
+`IR.interpMor` equations apply to it.
+
+## References
+
+* [HancockMcBrideGhaniMalatestaAltenkirch2013]
+
+## Tags
+
+inductive-recursive, interpretation, natural transformation
+-/
+
+@[expose] public section
+
+universe uA uB uI uO
+
+namespace IndRec
+
+open CategoryTheory
+
+variable (I : Type uI) (O : Type uO)
+
+namespace IR
+
+/-- Decoding of interpretation names commutes with transport along an
+equality of direction assignments. -/
+theorem interpObj_snd_cast (B : Type uB)
+    (c : (B → I) → IR.{max uA uB, uB, uI, uO} I O)
+    (X : FreeCoprodCompDisc.{max uA uB, uI} I) {i j : B → I}
+    (e : i = j) (n : (interpObj I O (c i) X).1) :
+    (interpObj I O (c j) X).2
+        (cast (congrArg (fun t ↦ (interpObj I O (c t) X).1) e) n) =
+      (interpObj I O (c i) X).2 n :=
+  Eq.rec (motive := fun j' e' ↦
+      (interpObj I O (c j') X).2
+          (cast (congrArg (fun t ↦ (interpObj I O (c t) X).1) e') n) =
+        (interpObj I O (c i) X).2 n)
+    rfl e
+
+/-- The injection of the `i`-th copower summand into the `delta`
+interpretation: a copower name `⟨e, n⟩` maps to the delta name whose
+direction is `e.1` restricted along `ULift.up`, with `n` transported
+along the induced equality of direction assignments. -/
+def deltaInto (B : Type uB)
+    (c : (B → I) → IR.{max uA uB, uB, uI, uO} I O)
+    (i : B → I) (X : FreeCoprodCompDisc.{max uA uB, uI} I) :
+    FreeCoprodCompDisc.Hom O
+      (FreeCoprodCompDisc.copowerHomMap
+        (FreeCoprodCompDisc.lift.{uB, uI, max uA uB} I ⟨B, i⟩)
+        (interpObj I O (c i)) X)
+      (interpObj I O (delta I O B c) X) :=
+  ⟨fun p ↦ ⟨p.1.1 ∘ ULift.up,
+      cast (congrArg (fun t ↦ (interpObj I O (c t) X).1)
+        (congrArg (· ∘ ULift.up) p.1.2).symm) p.2⟩,
+    funext (fun p ↦
+      interpObj_snd_cast I O B c X
+        (congrArg (· ∘ ULift.up) p.1.2).symm p.2)⟩
+
+/-- The cotuple out of the `delta` interpretation: a delta name
+`⟨g, n⟩` is dispatched to the component of `m` at the direction
+assignment `X.2 ∘ g`, at the copower name pairing the lifted
+direction with `n`. -/
+def deltaDesc (B : Type uB)
+    (c : (B → I) → IR.{max uA uB, uB, uI, uO} I O)
+    (X : FreeCoprodCompDisc.{max uA uB, uI} I)
+    (Z : FreeCoprodCompDisc.{max uA uB, uO} O)
+    (m : (i : B → I) → FreeCoprodCompDisc.Hom O
+      (FreeCoprodCompDisc.copowerHomMap
+        (FreeCoprodCompDisc.lift.{uB, uI, max uA uB} I ⟨B, i⟩)
+        (interpObj I O (c i)) X) Z) :
+    FreeCoprodCompDisc.Hom O (interpObj I O (delta I O B c) X) Z :=
+  ⟨fun q ↦ (m (X.2 ∘ q.1)).1 ⟨⟨q.1 ∘ ULift.down, rfl⟩, q.2⟩,
+    funext (fun q ↦
+      congrFun (m (X.2 ∘ q.1)).2 ⟨⟨q.1 ∘ ULift.down, rfl⟩, q.2⟩)⟩
+
+/-- The transport-elimination step of `IR.deltaInto_desc`: the target
+direction assignment is generalized together with the transport
+equality and the inner commutation proof, so the base case is
+definitional. -/
+theorem deltaInto_desc_aux (B : Type uB)
+    (c : (B → I) → IR.{max uA uB, uB, uI, uO} I O) (i : B → I)
+    (X : FreeCoprodCompDisc.{max uA uB, uI} I)
+    (Z : FreeCoprodCompDisc.{max uA uB, uO} O)
+    (m : (i' : B → I) → FreeCoprodCompDisc.Hom O
+      (FreeCoprodCompDisc.copowerHomMap
+        (FreeCoprodCompDisc.lift.{uB, uI, max uA uB} I ⟨B, i'⟩)
+        (interpObj I O (c i')) X) Z)
+    (e : FreeCoprodCompDisc.Hom I
+      (FreeCoprodCompDisc.lift.{uB, uI, max uA uB} I ⟨B, i⟩) X)
+    (n : (interpObj I O (c i) X).1) (j : B → I) (h : i = j)
+    (pf : X.2 ∘ ((e.1 ∘ ULift.up) ∘ ULift.down) =
+      (FreeCoprodCompDisc.lift.{uB, uI, max uA uB} I ⟨B, j⟩).2) :
+    (m j).1 ⟨⟨(e.1 ∘ ULift.up) ∘ ULift.down, pf⟩,
+        cast (congrArg (fun t ↦ (interpObj I O (c t) X).1) h) n⟩ =
+      (m i).1 ⟨e, n⟩ :=
+  Eq.rec (motive := fun j' h' ↦
+      ∀ pf' : X.2 ∘ ((e.1 ∘ ULift.up) ∘ ULift.down) =
+        (FreeCoprodCompDisc.lift.{uB, uI, max uA uB} I ⟨B, j'⟩).2,
+      (m j').1 ⟨⟨(e.1 ∘ ULift.up) ∘ ULift.down, pf'⟩,
+          cast (congrArg (fun t ↦ (interpObj I O (c t) X).1) h') n⟩ =
+        (m i).1 ⟨e, n⟩)
+    (fun _ ↦ rfl) h pf
+
+/-- Restricting the delta cotuple along the `i`-th injection recovers
+the component. -/
+theorem deltaInto_desc (B : Type uB)
+    (c : (B → I) → IR.{max uA uB, uB, uI, uO} I O) (i : B → I)
+    (X : FreeCoprodCompDisc.{max uA uB, uI} I)
+    (Z : FreeCoprodCompDisc.{max uA uB, uO} O)
+    (m : (i' : B → I) → FreeCoprodCompDisc.Hom O
+      (FreeCoprodCompDisc.copowerHomMap
+        (FreeCoprodCompDisc.lift.{uB, uI, max uA uB} I ⟨B, i'⟩)
+        (interpObj I O (c i')) X) Z) :
+    FreeCoprodCompDisc.Hom.comp O (deltaInto I O B c i X)
+      (deltaDesc I O B c X Z m) = m i :=
+  Subtype.ext (funext (fun p ↦
+    deltaInto_desc_aux I O B c i X Z m p.1 p.2
+      (X.2 ∘ (p.1.1 ∘ ULift.up))
+      ((congrArg (· ∘ ULift.up) p.1.2).symm) rfl))
+
+/-- Every morphism out of the delta interpretation is the cotuple of
+its restrictions along the injections. -/
+theorem deltaDesc_eta (B : Type uB)
+    (c : (B → I) → IR.{max uA uB, uB, uI, uO} I O)
+    (X : FreeCoprodCompDisc.{max uA uB, uI} I)
+    (Z : FreeCoprodCompDisc.{max uA uB, uO} O)
+    (h : FreeCoprodCompDisc.Hom O (interpObj I O (delta I O B c) X) Z) :
+    deltaDesc I O B c X Z
+        (fun i ↦ FreeCoprodCompDisc.Hom.comp O (deltaInto I O B c i X) h) =
+      h :=
+  Subtype.ext (funext (fun _ ↦ rfl))
+
+/-- The `IR.deltaInto` family is jointly epic: two morphisms out of
+the delta interpretation agree when their restrictions along every
+injection agree. -/
+theorem deltaHom_ext (B : Type uB)
+    (c : (B → I) → IR.{max uA uB, uB, uI, uO} I O)
+    (X : FreeCoprodCompDisc.{max uA uB, uI} I)
+    (Z : FreeCoprodCompDisc.{max uA uB, uO} O)
+    (f g : FreeCoprodCompDisc.Hom O (interpObj I O (delta I O B c) X) Z)
+    (hfg : ∀ i : B → I,
+      FreeCoprodCompDisc.Hom.comp O (deltaInto I O B c i X) f =
+        FreeCoprodCompDisc.Hom.comp O (deltaInto I O B c i X) g) :
+    f = g :=
+  (deltaDesc_eta I O B c X Z f).symm.trans
+    ((congrArg (deltaDesc I O B c X Z) (funext hfg)).trans
+      (deltaDesc_eta I O B c X Z g))
+
+/-- `IR.interpMor` commutes with transport of names along an equality
+of direction assignments. -/
+theorem interpMor_cast (B : Type uB)
+    (c : (B → I) → IR.{max uA uB, uB, uI, uO} I O)
+    (X Y : FreeCoprodCompDisc.{max uA uB, uI} I)
+    (h : FreeCoprodCompDisc.Hom I X Y) {i j : B → I} (e : i = j)
+    (n : (interpObj I O (c i) X).1) :
+    cast (congrArg (fun t ↦ (interpObj I O (c t) Y).1) e)
+        ((interpMor I O (c i) X Y h).1 n) =
+      (interpMor I O (c j) X Y h).1
+        (cast (congrArg (fun t ↦ (interpObj I O (c t) X).1) e) n) :=
+  Eq.rec (motive := fun j' e' ↦
+      cast (congrArg (fun t ↦ (interpObj I O (c t) Y).1) e')
+          ((interpMor I O (c i) X Y h).1 n) =
+        (interpMor I O (c j') X Y h).1
+          (cast (congrArg (fun t ↦ (interpObj I O (c t) X).1) e') n))
+    rfl e
+
+/-- The motive of the commutation-equality elimination in
+`IR.deltaInto_natural`: the domain decoding is generalized together
+with the morphism's commutation proof, and the delta-side morphism
+map appears in its `IR.interpMorDelta` form. -/
+def DeltaIntoNaturalMotive (B : Type uB)
+    (c : (B → I) → IR.{max uA uB, uB, uI, uO} I O) (i : B → I)
+    (X1 : Type (max uA uB)) (Y : FreeCoprodCompDisc.{max uA uB, uI} I)
+    (h1 : X1 → Y.1) (x2 : X1 → I) (hcomm : Y.2 ∘ h1 = x2) : Prop :=
+  FreeCoprodCompDisc.Hom.comp O
+      (FreeCoprodCompDisc.copowerHomMapMor
+        (FreeCoprodCompDisc.lift.{uB, uI, max uA uB} I ⟨B, i⟩)
+        (interpMor I O (c i)) ⟨X1, x2⟩ Y ⟨h1, hcomm⟩)
+      (deltaInto I O B c i Y) =
+    FreeCoprodCompDisc.Hom.comp O (deltaInto I O B c i ⟨X1, x2⟩)
+      (interpMorDelta I O B (fun f ↦ interpObj I O (c f))
+        (fun f ↦ interpMor I O (c f)) ⟨X1, x2⟩ Y ⟨h1, hcomm⟩)
+
+/-- The base case of `IR.deltaInto_natural`: at a factored domain
+decoding with reflexive commutation proof, the `homOfEq` transport in
+`IR.interpMorDelta` reduces definitionally and the square reduces to
+`IR.interpMor_cast` componentwise. -/
+theorem deltaInto_natural_base (B : Type uB)
+    (c : (B → I) → IR.{max uA uB, uB, uI, uO} I O) (i : B → I)
+    (X1 : Type (max uA uB)) (Y : FreeCoprodCompDisc.{max uA uB, uI} I)
+    (h1 : X1 → Y.1) :
+    DeltaIntoNaturalMotive I O B c i X1 Y h1 (Y.2 ∘ h1) rfl :=
+  Subtype.ext (funext (fun p ↦
+    congrArg
+      (fun t ↦ (⟨h1 ∘ (p.1.1 ∘ ULift.up), t⟩ :
+        Σ g : B → Y.1, (interpObj I O (c (Y.2 ∘ g)) Y).1))
+      (interpMor_cast I O B c ⟨X1, Y.2 ∘ h1⟩ Y ⟨h1, rfl⟩
+        ((congrArg (· ∘ ULift.up) p.1.2).symm) p.2)))
+
+/-- Naturality of `IR.deltaInto` in the object. -/
+theorem deltaInto_natural (B : Type uB)
+    (c : (B → I) → IR.{max uA uB, uB, uI, uO} I O) (i : B → I) :
+    FreeCoprodCompDisc.IsNatTrans I O
+      (FreeCoprodCompDisc.copowerHomMap
+        (FreeCoprodCompDisc.lift.{uB, uI, max uA uB} I ⟨B, i⟩)
+        (interpObj I O (c i)))
+      (interpObj I O (delta I O B c))
+      (FreeCoprodCompDisc.copowerHomMapMor
+        (FreeCoprodCompDisc.lift.{uB, uI, max uA uB} I ⟨B, i⟩)
+        (interpMor I O (c i)))
+      (interpMor I O (delta I O B c))
+      (deltaInto I O B c i) :=
+  fun X Y h ↦
+    match X, h with
+    | ⟨X1, x2⟩, ⟨h1, hcomm⟩ =>
+      (Eq.rec (motive := fun x2' hcomm' ↦
+          DeltaIntoNaturalMotive I O B c i X1 Y h1 x2' hcomm')
+        (deltaInto_natural_base I O B c i X1 Y h1) hcomm).trans
+        (congrArg
+          (fun t ↦ FreeCoprodCompDisc.Hom.comp O
+            (deltaInto I O B c i ⟨X1, x2⟩) (t ⟨X1, x2⟩ Y ⟨h1, hcomm⟩))
+          (interpMor_delta I O B c).symm)
+
+/-- The per-summand decomposition of transformation spaces at a
+`delta` code: transformations out of the `delta` interpretation
+correspond to families, over the direction assignments, of
+transformations out of the copower summands. -/
+def natDeltaEquiv (B : Type uB)
+    (c : (B → I) → IR.{max uA uB, uB, uI, uO} I O)
+    {G : FreeCoprodCompDisc.Map.{max uA uB, uI, uO} I O}
+    (mG : FreeCoprodCompDisc.MapMor I O G) :
+    FreeCoprodCompDisc.NatTrans I O (interpObj I O (delta I O B c)) G
+        (interpMor I O (delta I O B c)) mG ≃
+      ((i : B → I) → FreeCoprodCompDisc.NatTrans I O
+        (FreeCoprodCompDisc.copowerHomMap
+          (FreeCoprodCompDisc.lift.{uB, uI, max uA uB} I ⟨B, i⟩)
+          (interpObj I O (c i))) G
+        (FreeCoprodCompDisc.copowerHomMapMor
+          (FreeCoprodCompDisc.lift.{uB, uI, max uA uB} I ⟨B, i⟩)
+          (interpMor I O (c i))) mG) :=
+  { toFun := fun η i ↦
+      ⟨fun X ↦
+        FreeCoprodCompDisc.Hom.comp O (deltaInto I O B c i X) (η.1 X),
+        fun X Y h ↦
+          (congrArg
+              (fun t ↦ FreeCoprodCompDisc.Hom.comp O t (η.1 Y))
+              (deltaInto_natural I O B c i X Y h)).trans
+            (congrArg
+              (FreeCoprodCompDisc.Hom.comp O (deltaInto I O B c i X))
+              (η.2 X Y h))⟩,
+    invFun := fun θ ↦
+      ⟨fun X ↦ deltaDesc I O B c X (G X) (fun i ↦ (θ i).1 X),
+        fun X Y h ↦
+          deltaHom_ext I O B c X (G Y) _ _ (fun i ↦
+            (((congrArg
+                  (fun t ↦ FreeCoprodCompDisc.Hom.comp O t
+                    (deltaDesc I O B c Y (G Y) (fun i' ↦ (θ i').1 Y)))
+                  (deltaInto_natural I O B c i X Y h)).symm.trans
+              ((congrArg
+                  (FreeCoprodCompDisc.Hom.comp O
+                    (FreeCoprodCompDisc.copowerHomMapMor
+                      (FreeCoprodCompDisc.lift.{uB, uI, max uA uB}
+                        I ⟨B, i⟩)
+                      (interpMor I O (c i)) X Y h))
+                  (deltaInto_desc I O B c i Y (G Y)
+                    (fun i' ↦ (θ i').1 Y))).trans
+                ((θ i).2 X Y h))).trans
+            (congrArg
+              (fun t ↦ FreeCoprodCompDisc.Hom.comp O t (mG X Y h))
+              (deltaInto_desc I O B c i X (G X)
+                (fun i' ↦ (θ i').1 X)).symm)))⟩,
+    left_inv := fun η ↦ Subtype.ext (funext (fun X ↦
+      deltaDesc_eta I O B c X (G X) (η.1 X))),
+    right_inv := fun θ ↦ funext (fun i ↦ Subtype.ext (funext (fun X ↦
+      deltaInto_desc I O B c i X (G X) (fun i' ↦ (θ i').1 X)))) }
+
+/-- The right-hand object map of the Lemma 4 naturality square: the
+direct interpretation of `γ` at the coproduct of `⟨Q, i⟩` with the
+argument object. -/
+def precompRhsMap (Q : Type uB) (i : Q → I)
+    (γ : IR.{max uA uB, uB, uI, uO} I O) :
+    FreeCoprodCompDisc.Map.{max uA uB, uI, uO} I O :=
+  fun k ↦ interpObj I O γ (FreeCoprodCompDisc.plus.{uI, uB, max uA uB} I ⟨Q, i⟩ k)
+
+/-- The morphism-map component of `IR.precompRhsMap`: the direct
+interpretation's morphism map at the coproduct of the identity on
+`⟨Q, i⟩` with the argument morphism. -/
+def precompRhsMapMor (Q : Type uB) (i : Q → I)
+    (γ : IR.{max uA uB, uB, uI, uO} I O) :
+    FreeCoprodCompDisc.MapMor I O (precompRhsMap I O Q i γ) :=
+  fun X Y h ↦ interpMor I O γ
+    (FreeCoprodCompDisc.plus I ⟨Q, i⟩ X) (FreeCoprodCompDisc.plus I ⟨Q, i⟩ Y)
+    (FreeCoprodCompDisc.coprodPairMor I (FreeCoprodCompDisc.Hom.id I ⟨Q, i⟩) h)
+
+/-- The characterizing equation of `IR.interpPrecompIso` at `IR.mk`:
+the isomorphism family computes by one step of
+`IR.interpPrecompIsoStep`. -/
+theorem interpPrecompIso_mk (s : Shape.{max uA uB, uB, uO} O)
+    (d : Direction I O s → IR.{max uA uB, uB, uI, uO} I O) :
+    interpPrecompIso I O (mk I O s d) =
+      interpPrecompIsoStep I O s d (fun x ↦ interpPrecompIso I O (d x)) :=
+  rec_mk I O (interpPrecompIsoStep I O) s d
+
+/-- Postcomposing the values of a merged assignment commutes with the
+merge, pointwise: case analysis on the classifier at each element. -/
+theorem arrowSumMerge_map {B : Type uB} {X : Type uB}
+    {Y Z : Type (max uA uB)} (c : ArrowSumClassifier.{uB, uB, uB} B X)
+    (j : ArrowSumUnresolved c → Y) (h : Y → Z) (b : B) :
+    Sum.map _root_.id h (arrowSumMerge c j b) = arrowSumMerge c (h ∘ j) b :=
+  Sum.casesOn (motive := fun t ↦ c b = t →
+      Sum.map _root_.id h (arrowSumMerge c j b) = arrowSumMerge c (h ∘ j) b)
+    (c b)
+    (fun x hx ↦
+      (congrArg (Sum.map _root_.id h) (arrowSumMerge_eq c j b (Sum.inl x) hx)).trans
+        (arrowSumMerge_eq c (h ∘ j) b (Sum.inl x) hx).symm)
+    (fun u hu ↦
+      (congrArg (Sum.map _root_.id h) (arrowSumMerge_eq c j b (Sum.inr u) hu)).trans
+        (arrowSumMerge_eq c (h ∘ j) b (Sum.inr u) hu).symm)
+    rfl
+
+/-- `IR.interpMor` commutes with `FreeCoprodCompDisc.isoOfEq`
+transport of names along an equality of direction assignments (the
+`IR.interpMor_cast` companion at object-equality transports). -/
+theorem interpMor_isoOfEq (B : Type uB)
+    (c : (B → I) → IR.{max uA uB, uB, uI, uO} I O)
+    (V W : FreeCoprodCompDisc.{max uA uB, uI} I)
+    (pm : FreeCoprodCompDisc.Hom I V W) {m₀ m₁ : B → I} (e : m₀ = m₁)
+    (u : (interpObj I O (c m₀) V).1) :
+    (FreeCoprodCompDisc.isoOfEq O
+        (congrArg (fun m ↦ interpObj I O (c m) W) e)).1
+        ((interpMor I O (c m₀) V W pm).1 u) =
+      (interpMor I O (c m₁) V W pm).1
+        ((FreeCoprodCompDisc.isoOfEq O
+          (congrArg (fun m ↦ interpObj I O (c m) V) e)).1 u) :=
+  Eq.rec (motive := fun m' e' ↦
+      (FreeCoprodCompDisc.isoOfEq O
+          (congrArg (fun m ↦ interpObj I O (c m) W) e')).1
+          ((interpMor I O (c m₀) V W pm).1 u) =
+        (interpMor I O (c m') V W pm).1
+          ((FreeCoprodCompDisc.isoOfEq O
+            (congrArg (fun m ↦ interpObj I O (c m) V) e')).1 u))
+    rfl e
+
+/-- The motive of the commutation-proof elimination in
+`IR.precompNatDeltaPair`: the domain decoding of the coproduct
+morphism is generalized together with its commutation proof, and the
+assignment equalities (whose types depend on it) are quantified
+inside. -/
+def PrecompNatDeltaPairMotive (B : Type uB)
+    (c : (B → I) → IR.{max uA uB, uB, uI, uO} I O)
+    (V1 : Type (max uA uB)) (W : FreeCoprodCompDisc.{max uA uB, uI} I)
+    (p1 : V1 → W.1) (gx : B → V1) (m₀ : B → I)
+    (v2 : V1 → I) (p2 : W.2 ∘ p1 = v2) : Prop :=
+  ∀ (gy : B → W.1), p1 ∘ gx = gy →
+    ∀ (eX : m₀ = v2 ∘ gx) (eY : m₀ = W.2 ∘ gy)
+      (u : (interpObj I O (c m₀) ⟨V1, v2⟩).1),
+    (⟨gy, (FreeCoprodCompDisc.isoOfEq O
+        (congrArg (fun m ↦ interpObj I O (c m) W) eY)).1
+        ((interpMor I O (c m₀) ⟨V1, v2⟩ W ⟨p1, p2⟩).1 u)⟩ :
+      (interpObj I O (delta I O B c) W).1) =
+    ⟨p1 ∘ gx,
+      (FreeCoprodCompDisc.homOfEq O
+          (congrArg (fun t ↦ interpObj I O (c (t ∘ gx)) W) p2.symm)
+          (interpMor I O (c (v2 ∘ gx)) ⟨V1, v2⟩ W ⟨p1, p2⟩)).1
+        ((FreeCoprodCompDisc.isoOfEq O
+          (congrArg (fun m ↦ interpObj I O (c m) ⟨V1, v2⟩) eX)).1 u)⟩
+
+/-- The motive of the reassembled-assignment elimination inside the
+base case of `IR.precompNatDeltaPair`: the codomain-side assignment is
+generalized together with its factoring through the coproduct
+morphism, at the already-factored domain decoding (where the
+`homOfEq` transport has reduced definitionally). -/
+def PrecompNatDeltaPairInnerMotive (B : Type uB)
+    (c : (B → I) → IR.{max uA uB, uB, uI, uO} I O)
+    (V1 : Type (max uA uB)) (W : FreeCoprodCompDisc.{max uA uB, uI} I)
+    (p1 : V1 → W.1) (gx : B → V1) (m₀ : B → I) (gy : B → W.1) : Prop :=
+  ∀ (eX : m₀ = (W.2 ∘ p1) ∘ gx) (eY : m₀ = W.2 ∘ gy)
+    (u : (interpObj I O (c m₀) ⟨V1, W.2 ∘ p1⟩).1),
+  (⟨gy, (FreeCoprodCompDisc.isoOfEq O
+      (congrArg (fun m ↦ interpObj I O (c m) W) eY)).1
+      ((interpMor I O (c m₀) ⟨V1, W.2 ∘ p1⟩ W ⟨p1, rfl⟩).1 u)⟩ :
+    (interpObj I O (delta I O B c) W).1) =
+  ⟨p1 ∘ gx,
+    (interpMor I O (c ((W.2 ∘ p1) ∘ gx)) ⟨V1, W.2 ∘ p1⟩ W ⟨p1, rfl⟩).1
+      ((FreeCoprodCompDisc.isoOfEq O
+        (congrArg (fun m ↦ interpObj I O (c m) ⟨V1, W.2 ∘ p1⟩) eX)).1 u)⟩
+
+/-- The base case of both eliminations in `IR.precompNatDeltaPair`:
+at the factored assignment `p1 ∘ gx`, the two assignment-equality
+transports commute with the morphism map by `IR.interpMor_isoOfEq`
+under the common first component. -/
+theorem precompNatDeltaPair_inner (B : Type uB)
+    (c : (B → I) → IR.{max uA uB, uB, uI, uO} I O)
+    (V1 : Type (max uA uB)) (W : FreeCoprodCompDisc.{max uA uB, uI} I)
+    (p1 : V1 → W.1) (gx : B → V1) (m₀ : B → I) :
+    PrecompNatDeltaPairInnerMotive I O B c V1 W p1 gx m₀ (p1 ∘ gx) :=
+  fun eX _ u ↦
+    congrArg (fun t ↦ (⟨p1 ∘ gx, t⟩ : (interpObj I O (delta I O B c) W).1))
+      (interpMor_isoOfEq I O B c ⟨V1, W.2 ∘ p1⟩ W ⟨p1, rfl⟩ eX u)
+
+/-- The transport-commutation square of the `delta` case of the
+naturality upgrade: relabeling a merged assignment on both sides of
+the morphism map (by `FreeCoprodCompDisc.isoOfEq` at the domain and
+codomain objects) agrees with the `homOfEq`-transported component of
+`IR.interpMorDelta`, as elements of the direct `delta` interpretation
+at the codomain. -/
+theorem precompNatDeltaPair (B : Type uB)
+    (c : (B → I) → IR.{max uA uB, uB, uI, uO} I O)
+    (V1 : Type (max uA uB)) (W : FreeCoprodCompDisc.{max uA uB, uI} I)
+    (p1 : V1 → W.1) (gx : B → V1) (m₀ : B → I)
+    (v2 : V1 → I) (p2 : W.2 ∘ p1 = v2) :
+    PrecompNatDeltaPairMotive I O B c V1 W p1 gx m₀ v2 p2 :=
+  Eq.rec (motive := fun v2' p2' ↦
+      PrecompNatDeltaPairMotive I O B c V1 W p1 gx m₀ v2' p2')
+    (fun _gy e1 ↦
+      Eq.rec (motive := fun gy' _ ↦
+          PrecompNatDeltaPairInnerMotive I O B c V1 W p1 gx m₀ gy')
+        (precompNatDeltaPair_inner I O B c V1 W p1 gx m₀) e1)
+    p2
+
+/-- The motive of the naturality upgrade of Lemma 4
+([HancockMcBrideGhaniMalatestaAltenkirch2013]): for each code, at
+every precomposition datum, the `IR.interpPrecompIso` family is
+natural between the precomposed interpretation and the direct
+interpretation at the coproduct object. -/
+def PrecompNatMotive (γ : IR.{max uA uB, uB, uI, uO} I O) : Prop :=
+  ∀ (Q : Type uB) (i : Q → I),
+    FreeCoprodCompDisc.IsNatTrans I O
+      (interpObj I O (precomp I O Q i γ)) (precompRhsMap I O Q i γ)
+      (interpMor I O (precomp I O Q i γ)) (precompRhsMapMor I O Q i γ)
+      (fun k ↦ FreeCoprodCompDisc.Iso.hom O (interpPrecompIso I O γ Q i k))
+
+/-- The motive of the commutation-equality elimination in the
+inductive step of the naturality upgrade: the domain decoding is
+generalized together with the morphism's commutation proof, at the
+`IR.interpPrecompIsoStep` form of the isomorphism family. -/
+def PrecompNatMkMotive (s : Shape.{max uA uB, uB, uO} O)
+    (d : Direction I O s → IR.{max uA uB, uB, uI, uO} I O)
+    (Q : Type uB) (i : Q → I) (X1 : Type (max uA uB))
+    (Y : FreeCoprodCompDisc.{max uA uB, uI} I) (h1 : X1 → Y.1)
+    (x2 : X1 → I) (hcomm : Y.2 ∘ h1 = x2) : Prop :=
+  FreeCoprodCompDisc.Hom.comp O
+      (interpMor I O (precomp I O Q i (mk I O s d)) ⟨X1, x2⟩ Y ⟨h1, hcomm⟩)
+      (FreeCoprodCompDisc.Iso.hom O
+        (interpPrecompIsoStep I O s d
+          (fun x ↦ interpPrecompIso I O (d x)) Q i Y)) =
+    FreeCoprodCompDisc.Hom.comp O
+      (FreeCoprodCompDisc.Iso.hom O
+        (interpPrecompIsoStep I O s d
+          (fun x ↦ interpPrecompIso I O (d x)) Q i ⟨X1, x2⟩))
+      (interpMor I O (mk I O s d)
+        (FreeCoprodCompDisc.plus I ⟨Q, i⟩ ⟨X1, x2⟩)
+        (FreeCoprodCompDisc.plus I ⟨Q, i⟩ Y)
+        (FreeCoprodCompDisc.coprodPairMor I
+          (FreeCoprodCompDisc.Hom.id I ⟨Q, i⟩) ⟨h1, hcomm⟩))
+
+/-- The `iota` case of the naturality upgrade: after the
+characterizing equations, both legs of the square are identities on
+the constant singleton interpretation. -/
+theorem precompNat_mk_iota (o : O)
+    (d : Direction I O (Sum.inl o : Shape.{max uA uB, uB, uO} O) →
+      IR.{max uA uB, uB, uI, uO} I O)
+    (Q : Type uB) (i : Q → I) (X1 : Type (max uA uB))
+    (Y : FreeCoprodCompDisc.{max uA uB, uI} I) (h1 : X1 → Y.1) :
+    PrecompNatMkMotive I O (Sum.inl o) d Q i X1 Y h1 (Y.2 ∘ h1) rfl :=
+  (congrArg
+      (fun (t : MorMapSig I O (iota I O o)) ↦
+        FreeCoprodCompDisc.Hom.comp O (t ⟨X1, Y.2 ∘ h1⟩ Y ⟨h1, rfl⟩)
+          (FreeCoprodCompDisc.Iso.hom O
+            (interpPrecompIsoStep I O (Sum.inl o) d
+              (fun x ↦ interpPrecompIso I O (d x)) Q i Y)))
+      (interpMor_iota I O o)).trans
+    (congrArg
+      (fun (t : MorMapSig I O (mk I O (Sum.inl o) d)) ↦
+        FreeCoprodCompDisc.Hom.comp O
+          (FreeCoprodCompDisc.Iso.hom O
+            (interpPrecompIsoStep I O (Sum.inl o) d
+              (fun x ↦ interpPrecompIso I O (d x)) Q i ⟨X1, Y.2 ∘ h1⟩))
+          (t (FreeCoprodCompDisc.plus I ⟨Q, i⟩ ⟨X1, Y.2 ∘ h1⟩)
+            (FreeCoprodCompDisc.plus I ⟨Q, i⟩ Y)
+            (FreeCoprodCompDisc.coprodPairMor I
+              (FreeCoprodCompDisc.Hom.id I ⟨Q, i⟩) ⟨h1, rfl⟩)))
+      (interpMor_mk I O (Sum.inl o) d).symm)
+
+/-- The `sigma` case of the naturality upgrade: after the
+characterizing equations, both paths around the square compute
+componentwise, and each summand's square is the inductive hypothesis
+at the summand's subcode. -/
+theorem precompNat_mk_sigma (A : Type (max uA uB))
+    (d : Direction I O (Sum.inr (Sum.inl A) : Shape.{max uA uB, uB, uO} O) →
+      IR.{max uA uB, uB, uI, uO} I O)
+    (ih : (x : Direction I O (Sum.inr (Sum.inl A) : Shape.{max uA uB, uB, uO} O)) →
+      PrecompNatMotive I O (d x))
+    (Q : Type uB) (i : Q → I) (X1 : Type (max uA uB))
+    (Y : FreeCoprodCompDisc.{max uA uB, uI} I) (h1 : X1 → Y.1) :
+    PrecompNatMkMotive I O (Sum.inr (Sum.inl A)) d Q i X1 Y h1 (Y.2 ∘ h1) rfl :=
+  Subtype.ext (funext (fun p ↦
+    ((congrArg
+        (FreeCoprodCompDisc.Iso.hom O
+          (interpPrecompIsoStep I O (Sum.inr (Sum.inl A)) d
+            (fun x ↦ interpPrecompIso I O (d x)) Q i Y)).1
+        (congrFun (congrArg Subtype.val
+            (congrFun (congrFun (congrFun
+              (interpMor_sigma I O (ULift.{uB} A)
+                (fun a ↦ precomp I O Q i (d (ULift.up a.down))))
+              ⟨X1, Y.2 ∘ h1⟩) Y) ⟨h1, rfl⟩))
+          p)).trans
+      (congrArg
+        (fun t ↦ (⟨p.1.down, t⟩ :
+          (interpObj I O (mk I O (Sum.inr (Sum.inl A)) d)
+            (FreeCoprodCompDisc.plus I ⟨Q, i⟩ Y)).1))
+        (congrFun (congrArg Subtype.val
+            (ih (ULift.up p.1.down) Q i ⟨X1, Y.2 ∘ h1⟩ Y ⟨h1, rfl⟩))
+          p.2))).trans
+    (congrFun (congrArg Subtype.val
+        (congrFun (congrFun (congrFun
+          (interpMor_mk I O (Sum.inr (Sum.inl A)) d)
+          (FreeCoprodCompDisc.plus I ⟨Q, i⟩ ⟨X1, Y.2 ∘ h1⟩))
+          (FreeCoprodCompDisc.plus I ⟨Q, i⟩ Y))
+          (FreeCoprodCompDisc.coprodPairMor I
+            (FreeCoprodCompDisc.Hom.id I ⟨Q, i⟩) ⟨h1, rfl⟩)))
+      ((FreeCoprodCompDisc.Iso.hom O
+        (interpPrecompIsoStep I O (Sum.inr (Sum.inl A)) d
+          (fun x ↦ interpPrecompIso I O (d x)) Q i ⟨X1, Y.2 ∘ h1⟩)).1 p)).symm))
+
+/-- The `delta` case of the naturality upgrade: after the
+characterizing equations, a name of the precomposed `delta`
+interpretation is chased componentwise through both paths of the
+square — the classifier component is preserved, the summand's square
+is the inductive hypothesis at the merged assignment, and the
+remaining transports commute by `IR.precompNatDeltaPair`. -/
+theorem precompNat_mk_delta (B : Type uB)
+    (d : Direction I O (Sum.inr (Sum.inr B) : Shape.{max uA uB, uB, uO} O) →
+      IR.{max uA uB, uB, uI, uO} I O)
+    (ih : (x : Direction I O (Sum.inr (Sum.inr B) : Shape.{max uA uB, uB, uO} O)) →
+      PrecompNatMotive I O (d x))
+    (Q : Type uB) (i : Q → I) (X1 : Type (max uA uB))
+    (Y : FreeCoprodCompDisc.{max uA uB, uI} I) (h1 : X1 → Y.1) :
+    PrecompNatMkMotive I O (Sum.inr (Sum.inr B)) d Q i X1 Y h1 (Y.2 ∘ h1) rfl :=
+  Subtype.ext (funext (fun p ↦
+    ((congrArg
+        (FreeCoprodCompDisc.Iso.hom O
+          (interpPrecompIsoStep I O (Sum.inr (Sum.inr B)) d
+            (fun x ↦ interpPrecompIso I O (d x)) Q i Y)).1
+        (congrFun (congrArg Subtype.val
+            (congrFun (congrFun (congrFun
+              (interpMor_sigma I O
+                (ULift.{max uA uB} (ArrowSumClassifier.{uB, uB, uB} B Q))
+                (fun cl ↦ delta I O (ArrowSumUnresolved cl.down)
+                  (fun j ↦ precomp I O Q i
+                    (d (ULift.up (precompMerge I Q i cl.down j))))))
+              ⟨X1, Y.2 ∘ h1⟩) Y) ⟨h1, rfl⟩))
+          p)).trans
+      ((congrArg
+          (fun t ↦ (FreeCoprodCompDisc.Iso.hom O
+            (interpPrecompIsoStep I O (Sum.inr (Sum.inr B)) d
+              (fun x ↦ interpPrecompIso I O (d x)) Q i Y)).1
+            (⟨p.1, t⟩ :
+              (interpObj I O
+                (precomp I O Q i (mk I O (Sum.inr (Sum.inr B)) d)) Y).1))
+          (congrFun (congrArg Subtype.val
+              (congrFun (congrFun (congrFun
+                (interpMor_delta I O (ArrowSumUnresolved p.1.down)
+                  (fun j ↦ precomp I O Q i
+                    (d (ULift.up (precompMerge I Q i p.1.down j)))))
+                ⟨X1, Y.2 ∘ h1⟩) Y) ⟨h1, rfl⟩))
+            p.2)).trans
+        ((congrArg
+            (fun t ↦ (⟨arrowSumMerge p.1.down (h1 ∘ p.2.1),
+              (FreeCoprodCompDisc.isoOfEq O
+                (congrArg
+                  (fun m ↦ interpObj I O (d (ULift.up m))
+                    (FreeCoprodCompDisc.plus I ⟨Q, i⟩ Y))
+                  (precompMerge_elim I Q i Y B p.1.down (h1 ∘ p.2.1)))).1 t⟩ :
+              (interpObj I O (mk I O (Sum.inr (Sum.inr B)) d)
+                (FreeCoprodCompDisc.plus I ⟨Q, i⟩ Y)).1))
+            (congrFun (congrArg Subtype.val
+                (ih (ULift.up
+                    (precompMerge I Q i p.1.down ((Y.2 ∘ h1) ∘ p.2.1))) Q i
+                  ⟨X1, Y.2 ∘ h1⟩ Y ⟨h1, rfl⟩))
+              p.2.2)).trans
+          (precompNatDeltaPair I O B (fun m ↦ d (ULift.up m)) (Q ⊕ X1)
+            (FreeCoprodCompDisc.plus I ⟨Q, i⟩ Y) (Sum.map _root_.id h1)
+            (arrowSumMerge p.1.down p.2.1)
+            (precompMerge I Q i p.1.down ((Y.2 ∘ h1) ∘ p.2.1))
+            (Sum.elim i (Y.2 ∘ h1))
+            (FreeCoprodCompDisc.coprodPairMor I
+              (FreeCoprodCompDisc.Hom.id I ⟨Q, i⟩)
+              (⟨h1, rfl⟩ :
+                FreeCoprodCompDisc.Hom I ⟨X1, Y.2 ∘ h1⟩ Y)).2
+            (arrowSumMerge p.1.down (h1 ∘ p.2.1))
+            (funext (fun b ↦ arrowSumMerge_map p.1.down p.2.1 h1 b))
+            (precompMerge_elim I Q i ⟨X1, Y.2 ∘ h1⟩ B p.1.down p.2.1)
+            (precompMerge_elim I Q i Y B p.1.down (h1 ∘ p.2.1))
+            ((FreeCoprodCompDisc.Iso.hom O
+              (interpPrecompIso I O
+                (d (ULift.up
+                  (precompMerge I Q i p.1.down ((Y.2 ∘ h1) ∘ p.2.1)))) Q i
+                ⟨X1, Y.2 ∘ h1⟩)).1 p.2.2))))).trans
+    (congrFun (congrArg Subtype.val
+        (congrFun (congrFun (congrFun
+          (interpMor_mk I O (Sum.inr (Sum.inr B)) d)
+          (FreeCoprodCompDisc.plus I ⟨Q, i⟩ ⟨X1, Y.2 ∘ h1⟩))
+          (FreeCoprodCompDisc.plus I ⟨Q, i⟩ Y))
+          (FreeCoprodCompDisc.coprodPairMor I
+            (FreeCoprodCompDisc.Hom.id I ⟨Q, i⟩) ⟨h1, rfl⟩)))
+      ((FreeCoprodCompDisc.Iso.hom O
+        (interpPrecompIsoStep I O (Sum.inr (Sum.inr B)) d
+          (fun x ↦ interpPrecompIso I O (d x)) Q i ⟨X1, Y.2 ∘ h1⟩)).1 p)).symm))
+
+/-- The per-shape dispatch of the naturality upgrade's base case. -/
+theorem precompNat_mk_base (s : Shape.{max uA uB, uB, uO} O)
+    (d : Direction I O s → IR.{max uA uB, uB, uI, uO} I O)
+    (ih : (x : Direction I O s) → PrecompNatMotive I O (d x))
+    (Q : Type uB) (i : Q → I) (X1 : Type (max uA uB))
+    (Y : FreeCoprodCompDisc.{max uA uB, uI} I) (h1 : X1 → Y.1) :
+    PrecompNatMkMotive I O s d Q i X1 Y h1 (Y.2 ∘ h1) rfl :=
+  match s, d, ih with
+  | Sum.inl o, d, _ => precompNat_mk_iota I O o d Q i X1 Y h1
+  | Sum.inr (Sum.inl A), d, ih => precompNat_mk_sigma I O A d ih Q i X1 Y h1
+  | Sum.inr (Sum.inr B), d, ih => precompNat_mk_delta I O B d ih Q i X1 Y h1
+
+/-- The inductive step of the naturality upgrade: rewrite the
+isomorphism family by its characterizing equation
+`IR.interpPrecompIso_mk`, eliminate the morphism's commutation
+equality, and dispatch on the shape. -/
+theorem interpPrecompIso_natural_step :
+    InductionStep.{max uA uB, uB, uI, uO} I O (PrecompNatMotive I O) :=
+  fun s d ih Q i X Y h ↦
+    match X, h with
+    | ⟨X1, x2⟩, ⟨h1, hcomm⟩ =>
+      Eq.mpr
+        (congrArg
+          (fun t ↦ FreeCoprodCompDisc.Hom.comp O
+              (interpMor I O (precomp I O Q i (mk I O s d)) ⟨X1, x2⟩ Y
+                ⟨h1, hcomm⟩)
+              (FreeCoprodCompDisc.Iso.hom O (t Q i Y)) =
+            FreeCoprodCompDisc.Hom.comp O
+              (FreeCoprodCompDisc.Iso.hom O (t Q i ⟨X1, x2⟩))
+              (precompRhsMapMor I O Q i (mk I O s d) ⟨X1, x2⟩ Y ⟨h1, hcomm⟩))
+          (interpPrecompIso_mk I O s d))
+        (Eq.rec (motive := fun x2' hcomm' ↦
+            PrecompNatMkMotive I O s d Q i X1 Y h1 x2' hcomm')
+          (precompNat_mk_base I O s d ih Q i X1 Y h1) hcomm)
+
+/-- Naturality of the Lemma 4 isomorphism family
+([HancockMcBrideGhaniMalatestaAltenkirch2013]): at every code and
+every precomposition datum, `IR.interpPrecompIso` is natural in the
+interpreted object, between the precomposed interpretation and the
+direct interpretation at the coproduct object. -/
+theorem interpPrecompIso_natural (γ : IR.{max uA uB, uB, uI, uO} I O)
+    (Q : Type uB) (i : Q → I) :
+    FreeCoprodCompDisc.IsNatTrans I O
+      (interpObj I O (precomp I O Q i γ)) (precompRhsMap I O Q i γ)
+      (interpMor I O (precomp I O Q i γ)) (precompRhsMapMor I O Q i γ)
+      (fun k ↦ FreeCoprodCompDisc.Iso.hom O (interpPrecompIso I O γ Q i k)) :=
+  induction I O (PrecompNatMotive I O) (interpPrecompIso_natural_step I O)
+    γ Q i
+
+/-- The interpretation's cocone over the initial object: the image of
+the unique morphism out of `∅` followed by the image of any morphism
+is the image of the unique morphism. -/
+theorem interpMor_emptyDesc_comp (γ' : IR.{max uA uB, uB, uI, uO} I O)
+    (X Y : FreeCoprodCompDisc.{max uA uB, uI} I)
+    (h : FreeCoprodCompDisc.Hom I X Y) :
+    FreeCoprodCompDisc.Hom.comp O
+        (interpMor I O γ' (FreeCoprodCompDisc.emptyObj I) X
+          (FreeCoprodCompDisc.emptyDesc I X))
+        (interpMor I O γ' X Y h) =
+      interpMor I O γ' (FreeCoprodCompDisc.emptyObj I) Y
+        (FreeCoprodCompDisc.emptyDesc I Y) :=
+  (interpMor_comp I O γ' (FreeCoprodCompDisc.emptyObj I) X Y
+      (FreeCoprodCompDisc.emptyDesc I X) h).symm.trans
+    (congrArg (interpMor I O γ' (FreeCoprodCompDisc.emptyObj I) Y)
+      (FreeCoprodCompDisc.emptyDesc_unique I Y
+        (FreeCoprodCompDisc.Hom.comp I (FreeCoprodCompDisc.emptyDesc I X) h)))
+
+/-- The backward direction of `IR.natIotaEquiv`: extend a morphism at
+the initial object to a transformation by composing with the images of
+the unique morphisms out of `∅`. -/
+def natIotaInvFun (o : O) (γ' : IR.{max uA uB, uB, uI, uO} I O)
+    (f : FreeCoprodCompDisc.Hom O
+      (interpObj I O (iota.{max uA uB, uB, uI, uO} I O o) (FreeCoprodCompDisc.emptyObj I))
+      (interpObj I O γ' (FreeCoprodCompDisc.emptyObj I))) :
+    FreeCoprodCompDisc.NatTrans I O (interpObj I O (iota.{max uA uB, uB, uI, uO} I O o))
+      (interpObj I O γ') (interpMor I O (iota.{max uA uB, uB, uI, uO} I O o)) (interpMor I O γ') :=
+  ⟨fun X ↦ FreeCoprodCompDisc.Hom.comp O f
+      (interpMor I O γ' (FreeCoprodCompDisc.emptyObj I) X
+        (FreeCoprodCompDisc.emptyDesc I X)),
+    fun X Y h ↦
+      (congrArg
+          (fun (t : MorMapSig I O (iota.{max uA uB, uB, uI, uO} I O o)) ↦
+            FreeCoprodCompDisc.Hom.comp O (t X Y h)
+              (FreeCoprodCompDisc.Hom.comp O f
+                (interpMor I O γ' (FreeCoprodCompDisc.emptyObj I) Y
+                  (FreeCoprodCompDisc.emptyDesc I Y))))
+          (interpMor_iota.{max uA uB, uB, uI, uO} I O o)).trans
+        ((congrArg (FreeCoprodCompDisc.Hom.comp O f)
+            (interpMor_emptyDesc_comp I O γ' X Y h).symm).trans
+          (FreeCoprodCompDisc.Hom.comp_assoc O f
+            (interpMor I O γ' (FreeCoprodCompDisc.emptyObj I) X
+              (FreeCoprodCompDisc.emptyDesc I X))
+            (interpMor I O γ' X Y h)).symm)⟩
+
+/-- The ∅-evaluation equivalence at an `iota` domain: transformations
+out of the interpretation of `iota o` correspond to their components
+at the initial object. -/
+def natIotaEquiv (o : O) (γ' : IR.{max uA uB, uB, uI, uO} I O) :
+    FreeCoprodCompDisc.NatTrans I O (interpObj I O (iota.{max uA uB, uB, uI, uO} I O o))
+        (interpObj I O γ') (interpMor I O (iota.{max uA uB, uB, uI, uO} I O o)) (interpMor I O γ') ≃
+      FreeCoprodCompDisc.Hom O
+        (interpObj I O (iota.{max uA uB, uB, uI, uO} I O o) (FreeCoprodCompDisc.emptyObj I))
+        (interpObj I O γ' (FreeCoprodCompDisc.emptyObj I)) :=
+  { toFun := fun η ↦ η.1 (FreeCoprodCompDisc.emptyObj I),
+    invFun := natIotaInvFun I O o γ',
+    left_inv := fun η ↦ Subtype.ext (funext (fun X ↦
+      (η.2 (FreeCoprodCompDisc.emptyObj I) X
+          (FreeCoprodCompDisc.emptyDesc I X)).symm.trans
+        (congrArg
+          (fun (t : MorMapSig I O (iota.{max uA uB, uB, uI, uO} I O o)) ↦
+            FreeCoprodCompDisc.Hom.comp O
+              (t (FreeCoprodCompDisc.emptyObj I) X
+                (FreeCoprodCompDisc.emptyDesc I X))
+              (η.1 X))
+          (interpMor_iota.{max uA uB, uB, uI, uO} I O o)))),
+    right_inv := fun f ↦
+      (congrArg
+          (fun t ↦ FreeCoprodCompDisc.Hom.comp O f
+            (interpMor I O γ' (FreeCoprodCompDisc.emptyObj I)
+              (FreeCoprodCompDisc.emptyObj I) t))
+          (FreeCoprodCompDisc.emptyDesc_unique I
+            (FreeCoprodCompDisc.emptyObj I)
+            (FreeCoprodCompDisc.Hom.id I
+              (FreeCoprodCompDisc.emptyObj I))).symm).trans
+        ((congrArg (FreeCoprodCompDisc.Hom.comp O f)
+            (interpMor_id I O γ' (FreeCoprodCompDisc.emptyObj I))).trans
+          (FreeCoprodCompDisc.Hom.comp_id O f)) }
+
+/-- The motive of `IR.innerHomEquiv`: the homset from an `ι`-code to a
+code is the fiber, over the index, of the decoding of the code's
+interpretation at the initial object. -/
+def InnerHomEquivMotive (o : O) (γ' : IR.{max uA uB, uB, uI, uO} I O) :
+    Type (max uA uB uI) :=
+  InnerHom.{uA, uB, uI, uO} I O o γ' ≃
+    {z : (interpObj I O γ' (FreeCoprodCompDisc.emptyObj I)).1 //
+      (interpObj I O γ' (FreeCoprodCompDisc.emptyObj I)).2 z = o}
+
+/-- Transport the fiber equivalence of a `δ`-subcode along an equality
+of direction assignments, keeping the equivalence's source at the
+original assignment. -/
+def innerHomEquivCast (o : O) (B : Type uB)
+    (c : ULift.{max uA uB} (B → I) → IR.{max uA uB, uB, uI, uO} I O)
+    (m : (x : ULift.{max uA uB} (B → I)) → InnerHomEquivMotive I O o (c x))
+    (i j : B → I) (e : i = j) :
+    InnerHom.{uA, uB, uI, uO} I O o (c (ULift.up i)) ≃
+      {n : (interpObj I O (c (ULift.up j)) (FreeCoprodCompDisc.emptyObj I)).1 //
+        (interpObj I O (c (ULift.up j)) (FreeCoprodCompDisc.emptyObj I)).2 n = o} :=
+  Eq.rec (motive := fun j' _ ↦
+      InnerHom.{uA, uB, uI, uO} I O o (c (ULift.up i)) ≃
+        {n : (interpObj I O (c (ULift.up j'))
+            (FreeCoprodCompDisc.emptyObj I)).1 //
+          (interpObj I O (c (ULift.up j'))
+            (FreeCoprodCompDisc.emptyObj I)).2 n = o})
+    (m (ULift.up i)) e
+
+/-- The step of `IR.innerHomEquiv`: per shape, the homset clause and
+the ∅-fiber of the interpretation are matched componentwise, with the
+inductive hypotheses supplying the subcode equivalences. -/
+def innerHomEquivStep (o : O) :
+    RecStep.{max uA uB, uB, uI, uO, max uA uB uI} I O
+      (InnerHomEquivMotive I O o) :=
+  fun s c m ↦ match s, c, m with
+  | Sum.inl _, _, _ =>
+      { toFun := fun h ↦ ⟨ULift.up Unit.unit, h.down.down.symm⟩,
+        invFun := fun z ↦ ULift.up (PLift.up z.2.symm),
+        left_inv := fun _ ↦ rfl,
+        right_inv := fun _ ↦ rfl }
+  | Sum.inr (Sum.inl _), c, m =>
+      (sigmaCongrRight' (fun a ↦ m (ULift.up a))).trans
+        (sigmaSubtypeEquiv
+          (fun a ↦
+            (interpObj I O (c (ULift.up a))
+              (FreeCoprodCompDisc.emptyObj I)).1)
+          (fun a n ↦
+            (interpObj I O (c (ULift.up a))
+              (FreeCoprodCompDisc.emptyObj I)).2 n = o))
+  | Sum.inr (Sum.inr B), c, m =>
+      (sigmaCongrRight' (fun (e : B → PEmpty.{1}) ↦
+          innerHomEquivCast I O o B c m (fun b ↦ (e b).elim)
+            ((FreeCoprodCompDisc.emptyObj I).2 ∘ (fun b ↦ (e b).elim))
+            (funext (fun b ↦ (e b).elim)))).trans
+        ((Equiv.sigmaCongrLeft
+            (β := fun g ↦
+              {n : (interpObj I O
+                  (c (ULift.up ((FreeCoprodCompDisc.emptyObj I).2 ∘ g)))
+                  (FreeCoprodCompDisc.emptyObj I)).1 //
+                (interpObj I O
+                  (c (ULift.up ((FreeCoprodCompDisc.emptyObj I).2 ∘ g)))
+                  (FreeCoprodCompDisc.emptyObj I)).2 n = o})
+            (arrowPEmptyEquiv.{0, max uA uB, uB} B)).trans
+          (sigmaSubtypeEquiv
+            (fun g ↦
+              (interpObj I O
+                (c (ULift.up ((FreeCoprodCompDisc.emptyObj I).2 ∘ g)))
+                (FreeCoprodCompDisc.emptyObj I)).1)
+            (fun g n ↦
+              (interpObj I O
+                (c (ULift.up ((FreeCoprodCompDisc.emptyObj I).2 ∘ g)))
+                (FreeCoprodCompDisc.emptyObj I)).2 n = o)))
+
+/-- The homset from an `ι`-code to a code is the fiber, over the
+index, of the decoding of the code's interpretation at the initial
+object, by `IR.rec` on the code. -/
+def innerHomEquiv (o : O) (γ' : IR.{max uA uB, uB, uI, uO} I O) :
+    InnerHom.{uA, uB, uI, uO} I O o γ' ≃
+      {z : (interpObj I O γ' (FreeCoprodCompDisc.emptyObj I)).1 //
+        (interpObj I O γ' (FreeCoprodCompDisc.emptyObj I)).2 z = o} :=
+  rec I O (motive := InnerHomEquivMotive I O o) (innerHomEquivStep I O o) γ'
+
+/-- The bridge from the lifted-summand binary coproduct to the direct
+one: lower the left names, keep the right names. -/
+def plusLiftBridgeHom (Q : Type uB) (i : Q → I)
+    (X : FreeCoprodCompDisc.{max uA uB, uI} I) :
+    FreeCoprodCompDisc.Hom I
+      (FreeCoprodCompDisc.plus I
+        (FreeCoprodCompDisc.lift.{uB, uI, max uA uB} I ⟨Q, i⟩) X)
+      (FreeCoprodCompDisc.plus I ⟨Q, i⟩ X) :=
+  ⟨Sum.map ULift.down _root_.id,
+    funext (fun s ↦ Sum.casesOn s (fun _ ↦ rfl) (fun _ ↦ rfl))⟩
+
+/-- The bridge from the direct binary coproduct to the lifted-summand
+one: raise the left names, keep the right names. -/
+def plusLiftBridgeInvHom (Q : Type uB) (i : Q → I)
+    (X : FreeCoprodCompDisc.{max uA uB, uI} I) :
+    FreeCoprodCompDisc.Hom I (FreeCoprodCompDisc.plus I ⟨Q, i⟩ X)
+      (FreeCoprodCompDisc.plus I
+        (FreeCoprodCompDisc.lift.{uB, uI, max uA uB} I ⟨Q, i⟩) X) :=
+  ⟨Sum.map ULift.up _root_.id,
+    funext (fun s ↦ Sum.casesOn s (fun _ ↦ rfl) (fun _ ↦ rfl))⟩
+
+/-- The forward bridge followed by the backward bridge is the
+identity. -/
+theorem plusLiftBridge_hom_invHom (Q : Type uB) (i : Q → I)
+    (X : FreeCoprodCompDisc.{max uA uB, uI} I) :
+    FreeCoprodCompDisc.Hom.comp I (plusLiftBridgeHom I Q i X)
+        (plusLiftBridgeInvHom I Q i X) =
+      FreeCoprodCompDisc.Hom.id I
+        (FreeCoprodCompDisc.plus I
+          (FreeCoprodCompDisc.lift.{uB, uI, max uA uB} I ⟨Q, i⟩) X) :=
+  Subtype.ext (funext (fun s ↦ Sum.casesOn s (fun _ ↦ rfl) (fun _ ↦ rfl)))
+
+/-- The backward bridge followed by the forward bridge is the
+identity. -/
+theorem plusLiftBridge_invHom_hom (Q : Type uB) (i : Q → I)
+    (X : FreeCoprodCompDisc.{max uA uB, uI} I) :
+    FreeCoprodCompDisc.Hom.comp I (plusLiftBridgeInvHom I Q i X)
+        (plusLiftBridgeHom I Q i X) =
+      FreeCoprodCompDisc.Hom.id I (FreeCoprodCompDisc.plus I ⟨Q, i⟩ X) :=
+  Subtype.ext (funext (fun s ↦ Sum.casesOn s (fun _ ↦ rfl) (fun _ ↦ rfl)))
+
+/-- The forward bridge is natural in the right summand. -/
+theorem plusLiftBridge_square (Q : Type uB) (i : Q → I)
+    (X Y : FreeCoprodCompDisc.{max uA uB, uI} I)
+    (h : FreeCoprodCompDisc.Hom I X Y) :
+    FreeCoprodCompDisc.Hom.comp I
+        (FreeCoprodCompDisc.coprodPairMor I
+          (FreeCoprodCompDisc.Hom.id I
+            (FreeCoprodCompDisc.lift.{uB, uI, max uA uB} I ⟨Q, i⟩)) h)
+        (plusLiftBridgeHom I Q i Y) =
+      FreeCoprodCompDisc.Hom.comp I (plusLiftBridgeHom I Q i X)
+        (FreeCoprodCompDisc.coprodPairMor I
+          (FreeCoprodCompDisc.Hom.id I ⟨Q, i⟩) h) :=
+  Subtype.ext (funext (fun s ↦ Sum.casesOn s (fun _ ↦ rfl) (fun _ ↦ rfl)))
+
+/-- The backward bridge is natural in the right summand. -/
+theorem plusLiftBridge_square_inv (Q : Type uB) (i : Q → I)
+    (X Y : FreeCoprodCompDisc.{max uA uB, uI} I)
+    (h : FreeCoprodCompDisc.Hom I X Y) :
+    FreeCoprodCompDisc.Hom.comp I
+        (FreeCoprodCompDisc.coprodPairMor I
+          (FreeCoprodCompDisc.Hom.id I ⟨Q, i⟩) h)
+        (plusLiftBridgeInvHom I Q i Y) =
+      FreeCoprodCompDisc.Hom.comp I (plusLiftBridgeInvHom I Q i X)
+        (FreeCoprodCompDisc.coprodPairMor I
+          (FreeCoprodCompDisc.Hom.id I
+            (FreeCoprodCompDisc.lift.{uB, uI, max uA uB} I ⟨Q, i⟩)) h) :=
+  Subtype.ext (funext (fun s ↦ Sum.casesOn s (fun _ ↦ rfl) (fun _ ↦ rfl)))
+
+/-- The interpretation's image of the forward bridge, as a natural
+transformation from the `plus`-precomposed interpretation at the
+lifted summand to the Lemma 4 right-hand map. -/
+def plusLiftBridgeNat (Q : Type uB) (i : Q → I)
+    (γ' : IR.{max uA uB, uB, uI, uO} I O) :
+    FreeCoprodCompDisc.NatTrans I O
+      (FreeCoprodCompDisc.mapComp
+        (FreeCoprodCompDisc.plusMap
+          (FreeCoprodCompDisc.lift.{uB, uI, max uA uB} I ⟨Q, i⟩))
+        (interpObj I O γ'))
+      (precompRhsMap I O Q i γ')
+      (FreeCoprodCompDisc.mapMorComp
+        (FreeCoprodCompDisc.plusMapMor
+          (FreeCoprodCompDisc.lift.{uB, uI, max uA uB} I ⟨Q, i⟩))
+        (interpMor I O γ'))
+      (precompRhsMapMor I O Q i γ') :=
+  ⟨fun X ↦ interpMor I O γ'
+      (FreeCoprodCompDisc.plus I
+        (FreeCoprodCompDisc.lift.{uB, uI, max uA uB} I ⟨Q, i⟩) X)
+      (FreeCoprodCompDisc.plus I ⟨Q, i⟩ X)
+      (plusLiftBridgeHom I Q i X),
+    fun X Y h ↦
+      (interpMor_comp I O γ'
+          (FreeCoprodCompDisc.plus I
+            (FreeCoprodCompDisc.lift.{uB, uI, max uA uB} I ⟨Q, i⟩) X)
+          (FreeCoprodCompDisc.plus I
+            (FreeCoprodCompDisc.lift.{uB, uI, max uA uB} I ⟨Q, i⟩) Y)
+          (FreeCoprodCompDisc.plus I ⟨Q, i⟩ Y)
+          (FreeCoprodCompDisc.coprodPairMor I
+            (FreeCoprodCompDisc.Hom.id I
+              (FreeCoprodCompDisc.lift.{uB, uI, max uA uB} I ⟨Q, i⟩)) h)
+          (plusLiftBridgeHom I Q i Y)).symm.trans
+        ((congrArg
+            (interpMor I O γ'
+              (FreeCoprodCompDisc.plus I
+                (FreeCoprodCompDisc.lift.{uB, uI, max uA uB} I ⟨Q, i⟩) X)
+              (FreeCoprodCompDisc.plus I ⟨Q, i⟩ Y))
+            (plusLiftBridge_square I Q i X Y h)).trans
+          (interpMor_comp I O γ'
+            (FreeCoprodCompDisc.plus I
+              (FreeCoprodCompDisc.lift.{uB, uI, max uA uB} I ⟨Q, i⟩) X)
+            (FreeCoprodCompDisc.plus I ⟨Q, i⟩ X)
+            (FreeCoprodCompDisc.plus I ⟨Q, i⟩ Y)
+            (plusLiftBridgeHom I Q i X)
+            (FreeCoprodCompDisc.coprodPairMor I
+              (FreeCoprodCompDisc.Hom.id I ⟨Q, i⟩) h)))⟩
+
+/-- The interpretation's image of the backward bridge, as a natural
+transformation from the Lemma 4 right-hand map to the
+`plus`-precomposed interpretation at the lifted summand. -/
+def plusLiftBridgeNatInv (Q : Type uB) (i : Q → I)
+    (γ' : IR.{max uA uB, uB, uI, uO} I O) :
+    FreeCoprodCompDisc.NatTrans I O (precompRhsMap I O Q i γ')
+      (FreeCoprodCompDisc.mapComp
+        (FreeCoprodCompDisc.plusMap
+          (FreeCoprodCompDisc.lift.{uB, uI, max uA uB} I ⟨Q, i⟩))
+        (interpObj I O γ'))
+      (precompRhsMapMor I O Q i γ')
+      (FreeCoprodCompDisc.mapMorComp
+        (FreeCoprodCompDisc.plusMapMor
+          (FreeCoprodCompDisc.lift.{uB, uI, max uA uB} I ⟨Q, i⟩))
+        (interpMor I O γ')) :=
+  ⟨fun X ↦ interpMor I O γ' (FreeCoprodCompDisc.plus I ⟨Q, i⟩ X)
+      (FreeCoprodCompDisc.plus I
+        (FreeCoprodCompDisc.lift.{uB, uI, max uA uB} I ⟨Q, i⟩) X)
+      (plusLiftBridgeInvHom I Q i X),
+    fun X Y h ↦
+      (interpMor_comp I O γ' (FreeCoprodCompDisc.plus I ⟨Q, i⟩ X)
+          (FreeCoprodCompDisc.plus I ⟨Q, i⟩ Y)
+          (FreeCoprodCompDisc.plus I
+            (FreeCoprodCompDisc.lift.{uB, uI, max uA uB} I ⟨Q, i⟩) Y)
+          (FreeCoprodCompDisc.coprodPairMor I
+            (FreeCoprodCompDisc.Hom.id I ⟨Q, i⟩) h)
+          (plusLiftBridgeInvHom I Q i Y)).symm.trans
+        ((congrArg
+            (interpMor I O γ' (FreeCoprodCompDisc.plus I ⟨Q, i⟩ X)
+              (FreeCoprodCompDisc.plus I
+                (FreeCoprodCompDisc.lift.{uB, uI, max uA uB} I ⟨Q, i⟩) Y))
+            (plusLiftBridge_square_inv I Q i X Y h)).trans
+          (interpMor_comp I O γ' (FreeCoprodCompDisc.plus I ⟨Q, i⟩ X)
+            (FreeCoprodCompDisc.plus I
+              (FreeCoprodCompDisc.lift.{uB, uI, max uA uB} I ⟨Q, i⟩) X)
+            (FreeCoprodCompDisc.plus I
+              (FreeCoprodCompDisc.lift.{uB, uI, max uA uB} I ⟨Q, i⟩) Y)
+            (plusLiftBridgeInvHom I Q i X)
+            (FreeCoprodCompDisc.coprodPairMor I
+              (FreeCoprodCompDisc.Hom.id I
+                (FreeCoprodCompDisc.lift.{uB, uI, max uA uB} I ⟨Q, i⟩))
+              h)))⟩
+
+/-- The two bridge transformations are inverse. -/
+theorem plusLiftBridgeNat_isInverse (Q : Type uB) (i : Q → I)
+    (γ' : IR.{max uA uB, uB, uI, uO} I O) :
+    FreeCoprodCompDisc.NatTrans.IsInverse (plusLiftBridgeNat I O Q i γ')
+      (plusLiftBridgeNatInv I O Q i γ') :=
+  ⟨Subtype.ext (funext (fun X ↦
+      (interpMor_comp I O γ'
+          (FreeCoprodCompDisc.plus I
+            (FreeCoprodCompDisc.lift.{uB, uI, max uA uB} I ⟨Q, i⟩) X)
+          (FreeCoprodCompDisc.plus I ⟨Q, i⟩ X)
+          (FreeCoprodCompDisc.plus I
+            (FreeCoprodCompDisc.lift.{uB, uI, max uA uB} I ⟨Q, i⟩) X)
+          (plusLiftBridgeHom I Q i X)
+          (plusLiftBridgeInvHom I Q i X)).symm.trans
+        ((congrArg
+            (interpMor I O γ'
+              (FreeCoprodCompDisc.plus I
+                (FreeCoprodCompDisc.lift.{uB, uI, max uA uB} I ⟨Q, i⟩) X)
+              (FreeCoprodCompDisc.plus I
+                (FreeCoprodCompDisc.lift.{uB, uI, max uA uB} I ⟨Q, i⟩) X))
+            (plusLiftBridge_hom_invHom I Q i X)).trans
+          (interpMor_id I O γ'
+            (FreeCoprodCompDisc.plus I
+              (FreeCoprodCompDisc.lift.{uB, uI, max uA uB} I ⟨Q, i⟩) X))))),
+    Subtype.ext (funext (fun X ↦
+      (interpMor_comp I O γ' (FreeCoprodCompDisc.plus I ⟨Q, i⟩ X)
+          (FreeCoprodCompDisc.plus I
+            (FreeCoprodCompDisc.lift.{uB, uI, max uA uB} I ⟨Q, i⟩) X)
+          (FreeCoprodCompDisc.plus I ⟨Q, i⟩ X)
+          (plusLiftBridgeInvHom I Q i X)
+          (plusLiftBridgeHom I Q i X)).symm.trans
+        ((congrArg
+            (interpMor I O γ' (FreeCoprodCompDisc.plus I ⟨Q, i⟩ X)
+              (FreeCoprodCompDisc.plus I ⟨Q, i⟩ X))
+            (plusLiftBridge_invHom_hom I Q i X)).trans
+          (interpMor_id I O γ'
+            (FreeCoprodCompDisc.plus I ⟨Q, i⟩ X)))))⟩
+
+/-- The motive of `IR.interpHomEquiv`: for each code, the homset to
+every codomain code is equivalent to the space of natural
+transformations between the interpretations. -/
+def InterpHomEquivMotive (γ : IR.{max uA uB, uB, uI, uO} I O) :
+    Type (max (max uA uB + 1) uI uO) :=
+  (γ' : IR.{max uA uB, uB, uI, uO} I O) →
+    Hom.{uA, uB, uI, uO} I O γ γ' ≃
+      FreeCoprodCompDisc.NatTrans I O (interpObj I O γ) (interpObj I O γ')
+        (interpMor I O γ) (interpMor I O γ')
+
+/-- The step of `IR.interpHomEquiv`: per shape, the homset clause and
+the transformation space are matched by the corresponding
+decomposition equivalence, with the inductive hypotheses supplying the
+subcode equivalences. -/
+def interpHomEquivStep :
+    RecStep.{max uA uB, uB, uI, uO, max (max uA uB + 1) uI uO} I O
+      (InterpHomEquivMotive I O) :=
+  fun s c m ↦ match s, c, m with
+  | Sum.inl o, c, _ => fun γ' ↦
+      Eq.rec (motive := fun ir _ ↦
+          InnerHom.{uA, uB, uI, uO} I O o γ' ≃
+            FreeCoprodCompDisc.NatTrans I O (interpObj I O ir)
+              (interpObj I O γ') (interpMor I O ir) (interpMor I O γ'))
+        ((innerHomEquiv I O o γ').trans
+          ((FreeCoprodCompDisc.homSingletonEquiv O o
+              (interpObj I O γ' (FreeCoprodCompDisc.emptyObj I))).symm.trans
+            (natIotaEquiv I O o γ').symm))
+        (mk_congr I O (Sum.inl o) (funext (fun x ↦ nomatch x)) :
+          mk I O (Sum.inl o) c = iota.{max uA uB, uB, uI, uO} I O o).symm
+  | Sum.inr (Sum.inl A), c, m => fun γ' ↦
+      (Equiv.piCongrRight (fun a ↦ m (ULift.up a) γ')).trans
+        ((FreeCoprodCompDisc.natCoprodEquiv A
+            (fun a ↦ interpObj I O (c (ULift.up a)))
+            (fun a ↦ interpMor I O (c (ULift.up a)))
+            (interpObj I O γ') (interpMor I O γ')).symm.trans
+          (FreeCoprodCompDisc.NatTrans.congrSource
+            (interpMor_sigma I O A (fun a ↦ c (ULift.up a)))
+            (interpMor I O γ')).symm)
+  | Sum.inr (Sum.inr Q), c, m => fun γ' ↦
+      (Equiv.piCongrRight (fun i ↦
+          (((m (ULift.up i) (precomp I O Q i γ')).trans
+            (FreeCoprodCompDisc.NatTrans.equivOfInverseTarget
+              (FreeCoprodCompDisc.NatTrans.ofIsoFamily
+                (fun k ↦ interpPrecompIso I O γ' Q i k)
+                (interpPrecompIso_natural I O γ' Q i))
+              (FreeCoprodCompDisc.NatTrans.invOfIsoFamily
+                (fun k ↦ interpPrecompIso I O γ' Q i k)
+                (interpPrecompIso_natural I O γ' Q i))
+              (FreeCoprodCompDisc.NatTrans.ofIsoFamily_isInverse
+                (fun k ↦ interpPrecompIso I O γ' Q i k)
+                (interpPrecompIso_natural I O γ' Q i)))).trans
+            (FreeCoprodCompDisc.NatTrans.equivOfInverseTarget
+              (plusLiftBridgeNatInv I O Q i γ')
+              (plusLiftBridgeNat I O Q i γ')
+              ⟨(plusLiftBridgeNat_isInverse I O Q i γ').2,
+                (plusLiftBridgeNat_isInverse I O Q i γ').1⟩)).trans
+            (FreeCoprodCompDisc.natCopowerPlusEquiv
+              (FreeCoprodCompDisc.lift.{uB, uI, max uA uB} I ⟨Q, i⟩)
+              (interpMor I O (c (ULift.up i))) (interpMor I O γ')
+              (interpMor_id I O (c (ULift.up i)))
+              (interpMor_comp I O (c (ULift.up i)))
+              (interpMor_id I O γ') (interpMor_comp I O γ')).symm)).trans
+        (natDeltaEquiv I O Q (fun i ↦ c (ULift.up i)) (interpMor I O γ')).symm
+
+/-- Theorem 3 of [HancockMcBrideGhaniMalatestaAltenkirch2013]: the
+homset between two codes is equivalent to the space of natural
+transformations between their interpretations, by `IR.rec` on the
+domain code. -/
+def interpHomEquiv (γ γ' : IR.{max uA uB, uB, uI, uO} I O) :
+    Hom.{uA, uB, uI, uO} I O γ γ' ≃
+      FreeCoprodCompDisc.NatTrans I O (interpObj I O γ) (interpObj I O γ')
+        (interpMor I O γ) (interpMor I O γ') :=
+  rec I O (interpHomEquivStep I O) γ γ'
+
+/-- The interpretation of a code morphism as a natural transformation
+(the forward direction of `IR.interpHomEquiv`). -/
+def interpHom (γ γ' : IR.{max uA uB, uB, uI, uO} I O)
+    (f : Hom.{uA, uB, uI, uO} I O γ γ') :
+    FreeCoprodCompDisc.NatTrans I O (interpObj I O γ) (interpObj I O γ')
+      (interpMor I O γ) (interpMor I O γ') :=
+  interpHomEquiv I O γ γ' f
+
+/-- The code morphism carried by a natural transformation between
+interpretations (the backward direction of `IR.interpHomEquiv`). -/
+def natToHom (γ γ' : IR.{max uA uB, uB, uI, uO} I O)
+    (η : FreeCoprodCompDisc.NatTrans I O (interpObj I O γ)
+      (interpObj I O γ') (interpMor I O γ) (interpMor I O γ')) :
+    Hom.{uA, uB, uI, uO} I O γ γ' :=
+  (interpHomEquiv I O γ γ').symm η
+
+/-- `IR.interpHom` inverts `IR.natToHom`. -/
+theorem interpHom_natToHom (γ γ' : IR.{max uA uB, uB, uI, uO} I O)
+    (η : FreeCoprodCompDisc.NatTrans I O (interpObj I O γ)
+      (interpObj I O γ') (interpMor I O γ) (interpMor I O γ')) :
+    interpHom I O γ γ' (natToHom I O γ γ' η) = η :=
+  Equiv.apply_symm_apply (interpHomEquiv I O γ γ') η
+
+/-- `IR.natToHom` inverts `IR.interpHom`. -/
+theorem natToHom_interpHom (γ γ' : IR.{max uA uB, uB, uI, uO} I O)
+    (f : Hom.{uA, uB, uI, uO} I O γ γ') :
+    natToHom I O γ γ' (interpHom I O γ γ' f) = f :=
+  Equiv.symm_apply_apply (interpHomEquiv I O γ γ') f
+
+end IR
+
+end IndRec

--- a/geb-lean/vendor/geb-mathlib/Geb/Mathlib/Logic/Equiv/Basic.lean
+++ b/geb-lean/vendor/geb-mathlib/Geb/Mathlib/Logic/Equiv/Basic.lean
@@ -26,6 +26,9 @@ unresolved elements.
   the two families at independent universes.
 * `sigmaCompEquivSigmaFiber` — group a sigma over a composite family by
   the fibers of the inner function.
+* `sigmaSubtypeEquiv` — commute a sigma with a fiberwise subtype.
+* `arrowPEmptyEquiv` — the empty-valued function types across
+  universes are equivalent.
 * `arrowSumEquivSigma` — a function into a sum type is a classifier
   into `X ⊕ PUnit` together with an assignment on the classifier's
   unresolved (right-classified) elements.
@@ -87,6 +90,25 @@ def sigmaCompEquivSigmaFiber.{w} {X : Type u} {B : Type v}
   right_inv q :=
     match q with
     | ⟨_, ⟨_, rfl⟩, _⟩ => rfl
+
+/-- Commute a sigma with a fiberwise subtype: a dependent pair whose
+second component is constrained is a constrained dependent pair. -/
+def sigmaSubtypeEquiv.{p, q} {A : Type p} (N : A → Type q)
+    (P : (a : A) → N a → Prop) :
+    (Σ a, {n : N a // P a n}) ≃ {z : Σ a, N a // P z.1 z.2} :=
+  { toFun := fun x ↦ ⟨⟨x.1, x.2.1⟩, x.2.2⟩,
+    invFun := fun z ↦ ⟨z.1.1, ⟨z.1.2, z.2⟩⟩,
+    left_inv := fun _ ↦ rfl,
+    right_inv := fun _ ↦ rfl }
+
+/-- The equivalence of empty-valued function types across universes:
+each direction composes with the elimination out of `PEmpty`. -/
+def arrowPEmptyEquiv.{p, q, r} (B : Type r) :
+    (B → PEmpty.{p + 1}) ≃ (B → PEmpty.{q + 1}) :=
+  { toFun := fun e b ↦ (e b).elim,
+    invFun := fun g b ↦ (g b).elim,
+    left_inv := fun e ↦ funext (fun b ↦ (e b).elim),
+    right_inv := fun g ↦ funext (fun g' ↦ (g g').elim) }
 
 /-- The type of classifiers of `B` over `X`: functions
 `B → X ⊕ PUnit` marking each element of `B` as resolved (carrying a

--- a/geb-lean/vendor/geb-mathlib/PROVENANCE.md
+++ b/geb-lean/vendor/geb-mathlib/PROVENANCE.md
@@ -1,6 +1,6 @@
 # Vendored geb-mathlib provenance
 
 - Source: https://github.com/rokopt/geb-mathlib.git
-- Source commit: 279c920189276b4407ec62d9f5650d3201fe76f0
-- Back-port patch: scripts/geb-mathlib-backport.patch (sha256 cdfaacb60dd0bc2126dc6802905b44641570c07ceb1d317edde8310fd0d285fb)
+- Source commit: 89f18d05cd4234d4e31518415d5295868af87f17
+- Back-port patch: scripts/geb-mathlib-backport.patch (sha256 65c9ad11d1323ebf10c28b1ac1f0862d1031d1f8f49f03eff0aba5253a725c1e)
 - The files under `Geb/` are an unmodified mirror of the source commit except where the back-port patch changes them; modified files carry a change notice in their header comment.


### PR DESCRIPTION
Update the vendored mirror to upstream 89f18d05, which adds `IndRec/Category.lean`, `IndRec/Naturality.lean`, and `FreeCoprodCompDisc/NatTrans.lean`.

Extend the back-port patch with a category-2 hunk for `IndRec/Category.lean`: the new module suppresses the `checkUnivs` universe linter on `IR.comp_isoOfEq_hom` and
`IR.isoOfEq_symm_hom_comp` with `set_option linter.checkUnivs false in`, an option absent in v4.29.0-rc6. Replace each with the `@[nolint checkUnivs]` attribute, reword the module docstring to describe the attribute, and add the modification notice to the file header. Re-anchor the remaining hunks against the new upstream.