### PR TITLE
chore(deps): re-anchor geb-mathlib back-port patch

### DIFF
--- a/geb-lean/docs/geb-mathlib-backport-notes.md
+++ b/geb-lean/docs/geb-mathlib-backport-notes.md
@@ -54,12 +54,9 @@ genuinely new (decide the adaptation, add a category here).
   in `Presheaf/Basic.lean`. The affected definitions in
   `IndRec/Basic.lean` are `IR.Shape`, `IR.pFunctor`, `IR.Obj`,
   `IR.ObjFst`, `IR.Dest`, `IR.Alg`, the top-level `IR`, and
-  `IR.interpObjIota`. The affected theorems in `IndRec/Category.lean`
-  are `IR.comp_isoOfEq_hom` and `IR.isoOfEq_symm_hom_comp`; there the
-  attribute goes between the docstring and the `theorem` keyword.
-- Prose adaptation: the module docstrings of `Presheaf/Basic.lean`,
-  `IndRec/Basic.lean`, and `IndRec/Category.lean` describe the
-  suppression as
+  `IR.interpObjIota`.
+- Prose adaptation: the module docstrings of `Presheaf/Basic.lean` and
+  `IndRec/Basic.lean` describe the suppression as
   "The `linter.checkUnivs false` option suppresses the ...". Because
   the option line is deleted and the attribute inserted, reword to
   "The `@[nolint checkUnivs]` attribute suppresses the ..." so the

--- a/geb-lean/scripts/geb-mathlib-backport.patch
+++ b/geb-lean/scripts/geb-mathlib-backport.patch
@@ -99,50 +99,6 @@ index 44ebba7..b6df37e 100644
  def interpObjIota (o : O) : FreeCoprodCompDisc.Map.{max uA uB, uI, uO} I O :=
    fun _ ↦ ⟨ULift Unit, fun _ ↦ o⟩
  
-diff --git a/vendor/geb-mathlib/Geb/Mathlib/Data/PFunctor/IndRec/Category.lean b/vendor/geb-mathlib/Geb/Mathlib/Data/PFunctor/IndRec/Category.lean
-index a162a0c..92535e6 100644
---- a/vendor/geb-mathlib/Geb/Mathlib/Data/PFunctor/IndRec/Category.lean
-+++ b/vendor/geb-mathlib/Geb/Mathlib/Data/PFunctor/IndRec/Category.lean
-@@ -3,6 +3,7 @@ Copyright (c) 2026 Terence Rokop. All rights reserved.
- Released under Apache 2.0 license as described in the file LICENSE.
- Authors: Terence Rokop
- -/
-+-- Modified from geb-mathlib by scripts/geb-mathlib-backport.patch.
- module
- 
- public import Geb.Mathlib.Data.PFunctor.IndRec.Naturality
-@@ -86,7 +87,7 @@ are carried as `FreeCoprodCompDisc.isoOfEq` transports and commuted
- across the Lemma 4 isomorphism by elimination of the generalized
- equality.
- 
--The `linter.checkUnivs false` option on `IR.comp_isoOfEq_hom` and
-+The `@[nolint checkUnivs]` attribute on `IR.comp_isoOfEq_hom` and
- `IR.isoOfEq_symm_hom_comp` suppresses the `checkUnivs` warning on
- the separated arity universes `uA`/`uB`: in those two declarations'
- types the pair appears only together under `max`, so the linter
-@@ -4125,10 +4126,10 @@ theorem interpHom_cast_cod (D : IR.{max uA uB, uB, uI, uO} I O)
-       (fun f ↦ (FreeCoprodCompDisc.Hom.comp_id O
-         ((interpHom I O D γ₀ f).1 X)).symm)
-       h
--set_option linter.checkUnivs false in
- /-- Postcomposition with an object-equality transport is the transport
- of the morphism's codomain, by elimination of the generalized
- equality. -/
-+@[nolint checkUnivs]
- theorem comp_isoOfEq_hom (Z W : FreeCoprodCompDisc.{max uA uB, uI} I) :
-     ∀ (V : FreeCoprodCompDisc.{max uA uB, uI} I) (q : W = V)
-       (f : FreeCoprodCompDisc.Hom I Z W),
-@@ -4143,9 +4144,9 @@ theorem comp_isoOfEq_hom (Z W : FreeCoprodCompDisc.{max uA uB, uI} I) :
-                 (FreeCoprodCompDisc.isoOfEq I q')) =
-             cast (congrArg (FreeCoprodCompDisc.Hom I Z) q') f)
-       (fun f ↦ FreeCoprodCompDisc.Hom.comp_id I f) q
--set_option linter.checkUnivs false in
- /-- An object-equality transport followed by its inverse is the
- identity, by elimination of the generalized equality. -/
-+@[nolint checkUnivs]
- theorem isoOfEq_symm_hom_comp (Z : FreeCoprodCompDisc.{max uA uB, uO} O) :
-     ∀ (W : FreeCoprodCompDisc.{max uA uB, uO} O) (q : Z = W),
-       FreeCoprodCompDisc.Hom.comp O
 diff --git a/vendor/geb-mathlib/Geb/Mathlib/Data/PFunctor/Presheaf/Basic.lean b/vendor/geb-mathlib/Geb/Mathlib/Data/PFunctor/Presheaf/Basic.lean
 index 004265e..fc173cb 100644
 --- a/vendor/geb-mathlib/Geb/Mathlib/Data/PFunctor/Presheaf/Basic.lean

--- a/geb-lean/vendor/geb-mathlib/Geb/Mathlib/Data/PFunctor/IndRec/Category.lean
+++ b/geb-lean/vendor/geb-mathlib/Geb/Mathlib/Data/PFunctor/IndRec/Category.lean
@@ -3,7 +3,6 @@ Copyright (c) 2026 Terence Rokop. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Terence Rokop
 -/
--- Modified from geb-mathlib by scripts/geb-mathlib-backport.patch.
 module
 
 public import Geb.Mathlib.Data.PFunctor.IndRec.Naturality
@@ -87,14 +86,6 @@ are carried as `FreeCoprodCompDisc.isoOfEq` transports and commuted
 across the Lemma 4 isomorphism by elimination of the generalized
 equality.
 
-The `@[nolint checkUnivs]` attribute on `IR.comp_isoOfEq_hom` and
-`IR.isoOfEq_symm_hom_comp` suppresses the `checkUnivs` warning on
-the separated arity universes `uA`/`uB`: in those two declarations'
-types the pair appears only together under `max`, so the linter
-reports it as unifiable; keeping the two distinct is the point of
-the separation. `IndRec.Basic` carries the same suppression, for
-the same reason.
-
 ## References
 
 * [HancockMcBrideGhaniMalatestaAltenkirch2013]
@@ -106,7 +97,7 @@ inductive-recursive, morphism, category
 
 @[expose] public section
 
-universe uA uB uI uO
+universe u uA uB uI uO
 
 namespace IndRec
 
@@ -4129,9 +4120,8 @@ theorem interpHom_cast_cod (D : IR.{max uA uB, uB, uI, uO} I O)
 /-- Postcomposition with an object-equality transport is the transport
 of the morphism's codomain, by elimination of the generalized
 equality. -/
-@[nolint checkUnivs]
-theorem comp_isoOfEq_hom (Z W : FreeCoprodCompDisc.{max uA uB, uI} I) :
-    ∀ (V : FreeCoprodCompDisc.{max uA uB, uI} I) (q : W = V)
+theorem comp_isoOfEq_hom (Z W : FreeCoprodCompDisc.{u, uI} I) :
+    ∀ (V : FreeCoprodCompDisc.{u, uI} I) (q : W = V)
       (f : FreeCoprodCompDisc.Hom I Z W),
       FreeCoprodCompDisc.Hom.comp I f
           (FreeCoprodCompDisc.Iso.hom I (FreeCoprodCompDisc.isoOfEq I q)) =
@@ -4146,9 +4136,8 @@ theorem comp_isoOfEq_hom (Z W : FreeCoprodCompDisc.{max uA uB, uI} I) :
       (fun f ↦ FreeCoprodCompDisc.Hom.comp_id I f) q
 /-- An object-equality transport followed by its inverse is the
 identity, by elimination of the generalized equality. -/
-@[nolint checkUnivs]
-theorem isoOfEq_symm_hom_comp (Z : FreeCoprodCompDisc.{max uA uB, uO} O) :
-    ∀ (W : FreeCoprodCompDisc.{max uA uB, uO} O) (q : Z = W),
+theorem isoOfEq_symm_hom_comp (Z : FreeCoprodCompDisc.{u, uO} O) :
+    ∀ (W : FreeCoprodCompDisc.{u, uO} O) (q : Z = W),
       FreeCoprodCompDisc.Hom.comp O
           (FreeCoprodCompDisc.Iso.hom O (FreeCoprodCompDisc.isoOfEq O q.symm))
           (FreeCoprodCompDisc.Iso.hom O (FreeCoprodCompDisc.isoOfEq O q)) =
@@ -4360,7 +4349,7 @@ theorem mprecompIso_snoc_hom_comp (L : List (SupObj.{uB, uI} I))
                 (FreeCoprodCompDisc.Iso.hom O
                   (mprecompIso.{uA, uB, uI, uO} I O L γ
                     (FreeCoprodCompDisc.plus.{uI, uB, max uA uB} I b X))))
-              (isoOfEq_symm_hom_comp.{uA, uB, uO} O
+              (isoOfEq_symm_hom_comp.{max uA uB, uO} O
                 (interpObj I O γ (mplus.{uA, uB, uI} I (L ++ [b]) X))
                 (interpObj I O γ (mplus.{uA, uB, uI} I L
                   (FreeCoprodCompDisc.plus.{uI, uB, max uA uB} I b X)))
@@ -4415,7 +4404,7 @@ theorem mplusInj_navBridge (B : Type uB) (i : B → I)
             (FreeCoprodCompDisc.Hom.comp I (plusLiftBridgeInvHom I B i X)
               (FreeCoprodCompDisc.coprodPairDesc I e
                 (FreeCoprodCompDisc.Hom.id I X)))))
-        ((comp_isoOfEq_hom.{uA, uB, uI} I X
+        ((comp_isoOfEq_hom.{max uA uB, uI} I X
             (mplus.{uA, uB, uI} I (L ++ [(⟨B, i⟩ : SupObj.{uB, uI} I)]) X)
             (mplus.{uA, uB, uI} I L
               (FreeCoprodCompDisc.plus.{uI, uB, max uA uB} I ⟨B, i⟩ X))
@@ -4491,7 +4480,7 @@ theorem navWeight_navBridge (B : Type uB) (i : B → I)
             (FreeCoprodCompDisc.Hom.comp I (plusLiftBridgeInvHom I B i X)
               (FreeCoprodCompDisc.coprodPairDesc I e
                 (FreeCoprodCompDisc.Hom.id I X)))))
-        ((comp_isoOfEq_hom.{uA, uB, uI} I
+        ((comp_isoOfEq_hom.{max uA uB, uI} I
             (FreeCoprodCompDisc.lift.{uB, uI, max uA uB} I ⟨B, i⟩)
             (mplus.{uA, uB, uI} I (L ++ [(⟨B, i⟩ : SupObj.{uB, uI} I)]) X)
             (mplus.{uA, uB, uI} I L
@@ -4638,7 +4627,7 @@ theorem preUnitComponent_comp_hom (γ : IR.{max uA uB, uB, uI, uO} I O)
 /-- The reduced form of the per-weight identity-image equation: after
 the tower isomorphisms cancel, both routes are the interpreted tower
 injection followed by the reindexed weighted summand inclusion. -/
-theorem interpHomPreUnit_deltaWeightRight (B : Type uB)
+theorem interpHom_preUnitStack_deltaWeightRight (B : Type uB)
     (d : Direction I O (Sum.inr (Sum.inr B) : Shape.{max uA uB, uB, uO} O) →
       IR.{max uA uB, uB, uI, uO} I O)
     (ih : (x : Direction I O (Sum.inr (Sum.inr B) : Shape.{max uA uB, uB, uO} O)) →
@@ -4797,7 +4786,7 @@ theorem interpHomPreUnit_deltaWeightRight (B : Type uB)
 weight out of the lifted arity, the copower-adjunction transport of the
 navigated subcode pre-unit is the weight's injection followed by the
 summand inclusion and the semantic pre-unit component. -/
-theorem interpHomPreUnit_deltaWeight (B : Type uB)
+theorem interpHom_preUnitStack_deltaWeight (B : Type uB)
     (d : Direction I O (Sum.inr (Sum.inr B) : Shape.{max uA uB, uB, uO} O) →
       IR.{max uA uB, uB, uI, uO} I O)
     (ih : (x : Direction I O (Sum.inr (Sum.inr B) : Shape.{max uA uB, uB, uO} O)) →
@@ -4981,12 +4970,12 @@ theorem interpHomPreUnit_deltaWeight (B : Type uB)
                       (plusLiftBridgeInvHom I B i X)
                       (FreeCoprodCompDisc.coprodPairDesc I e
                         (FreeCoprodCompDisc.Hom.id I X)))))).trans
-              (interpHomPreUnit_deltaWeightRight I O B d ih L X i e))))))
+              (interpHom_preUnitStack_deltaWeightRight I O B d ih L X i e))))))
 
 /-- The per-summand identity-image equation at a `δ`-domain: the
 navigated subcode pre-unit's transported interpretation is the summand
 inclusion followed by the semantic pre-unit component. -/
-theorem interpHomPreUnit_deltaSummand (B : Type uB)
+theorem interpHom_preUnitStack_deltaSummand (B : Type uB)
     (d : Direction I O (Sum.inr (Sum.inr B) : Shape.{max uA uB, uB, uO} O) →
       IR.{max uA uB, uB, uI, uO} I O)
     (ih : (x : Direction I O (Sum.inr (Sum.inr B) : Shape.{max uA uB, uB, uO} O)) →
@@ -5006,7 +4995,7 @@ theorem interpHomPreUnit_deltaSummand (B : Type uB)
         (fun _ ↦ interpObj I O (d (ULift.up i)) X)
         (interpObj I O (mprecomp I O L (mk I O (Sum.inr (Sum.inr B)) d)) X))
       (funext (fun e ↦
-        interpHomPreUnit_deltaWeight I O B d ih L X i e))).trans
+        interpHom_preUnitStack_deltaWeight I O B d ih L X i e))).trans
     (FreeCoprodCompDisc.coprodDesc_eta O
       (FreeCoprodCompDisc.Hom I
         (FreeCoprodCompDisc.lift.{uB, uI, max uA uB} I ⟨B, i⟩) X)
@@ -5017,7 +5006,7 @@ theorem interpHomPreUnit_deltaSummand (B : Type uB)
         (preUnitComponent I O (mk I O (Sum.inr (Sum.inr B)) d) L X)))
 
 /-- The `δ`-domain case of the identity-image equation. -/
-theorem interpHomPreUnit_mk_delta (B : Type uB)
+theorem interpHom_preUnitStack_mk_delta (B : Type uB)
     (d : Direction I O (Sum.inr (Sum.inr B) : Shape.{max uA uB, uB, uO} O) →
       IR.{max uA uB, uB, uI, uO} I O)
     (ih : (x : Direction I O (Sum.inr (Sum.inr B) : Shape.{max uA uB, uB, uO} O)) →
@@ -5035,7 +5024,7 @@ theorem interpHomPreUnit_mk_delta (B : Type uB)
             (deltaDesc I O B (fun j ↦ d (ULift.up j)) X
               (interpObj I O (mprecomp I O L (mk I O (Sum.inr (Sum.inr B)) d)) X))
             (funext (fun i ↦
-              interpHomPreUnit_deltaSummand I O B d ih L X i))).trans
+              interpHom_preUnitStack_deltaSummand I O B d ih L X i))).trans
           (deltaDesc_eta I O B (fun j ↦ d (ULift.up j)) X
             (interpObj I O (mprecomp I O L (mk I O (Sum.inr (Sum.inr B)) d)) X)
             (preUnitComponent I O (mk I O (Sum.inr (Sum.inr B)) d) L X))))
@@ -5044,7 +5033,7 @@ theorem interpHomPreUnit_mk_delta (B : Type uB)
 code and the target morphism generalized: at the reflexive instance the
 codomain interpretation is the singleton object, so any two morphisms
 into it agree. -/
-theorem interpHomPreUnit_iotaGen (o : O)
+theorem interpHom_preUnitStack_iotaGen (o : O)
     (d : Direction I O (Sum.inl o : Shape.{max uA uB, uB, uO} O) →
       IR.{max uA uB, uB, uI, uO} I O)
     (X : FreeCoprodCompDisc.{max uA uB, uI} I) :
@@ -5070,7 +5059,7 @@ theorem interpHomPreUnit_iotaGen (o : O)
       (fun _ ↦ Subtype.ext (funext (fun _ ↦ congrArg ULift.up rfl))) hh
 
 /-- The `ι`-domain case of the identity-image equation. -/
-theorem interpHomPreUnit_mk_iota (o : O)
+theorem interpHom_preUnitStack_mk_iota (o : O)
     (d : Direction I O (Sum.inl o : Shape.{max uA uB, uB, uO} O) →
       IR.{max uA uB, uB, uI, uO} I O) :
     InterpHomPreUnitMotive I O (mk I O (Sum.inl o) d) :=
@@ -5079,7 +5068,7 @@ theorem interpHomPreUnit_mk_iota (o : O)
         (fun t ↦ (interpHom I O (mk I O (Sum.inl o) d)
           (mprecomp I O L (mk I O (Sum.inl o) d)) t).1 X)
         (preUnitStack_mk_iota I O o d L)).trans
-      (interpHomPreUnit_iotaGen I O o d X
+      (interpHom_preUnitStack_iotaGen I O o d X
         (mprecomp I O L (mk I O (Sum.inl o) d))
         (mprecomp_iota_mk I O L o d).symm
         (preUnitComponent I O (mk I O (Sum.inl o) d) L X))
@@ -5087,7 +5076,7 @@ theorem interpHomPreUnit_mk_iota (o : O)
 /-- The per-summand identity-image equation at a `σ`-domain: the stack
 `σ`-push of the subcode's pre-unit is the semantic `σ`-injection
 followed by the pre-unit component. -/
-theorem interpHomPreUnit_sigmaSummand (A : Type (max uA uB))
+theorem interpHom_preUnitStack_sigmaSummand (A : Type (max uA uB))
     (d : Direction I O (Sum.inr (Sum.inl A) : Shape.{max uA uB, uB, uO} O) →
       IR.{max uA uB, uB, uI, uO} I O)
     (ih : (x : Direction I O (Sum.inr (Sum.inl A) : Shape.{max uA uB, uB, uO} O)) →
@@ -5140,7 +5129,7 @@ theorem interpHomPreUnit_sigmaSummand (A : Type (max uA uB))
             (mplus.{uA, uB, uI} I L X) (mplusInj.{uA, uB, uI} I L X)).symm)))
 
 /-- The `σ`-domain case of the identity-image equation. -/
-theorem interpHomPreUnit_mk_sigma (A : Type (max uA uB))
+theorem interpHom_preUnitStack_mk_sigma (A : Type (max uA uB))
     (d : Direction I O (Sum.inr (Sum.inl A) : Shape.{max uA uB, uB, uO} O) →
       IR.{max uA uB, uB, uI, uO} I O)
     (ih : (x : Direction I O (Sum.inr (Sum.inl A) : Shape.{max uA uB, uB, uO} O)) →
@@ -5162,7 +5151,7 @@ theorem interpHomPreUnit_mk_sigma (A : Type (max uA uB))
               (interpObj I O
                 (mprecomp I O L (mk I O (Sum.inr (Sum.inl A)) d)) X))
             (funext (fun a ↦
-              interpHomPreUnit_sigmaSummand I O A d ih L X a))).trans
+              interpHom_preUnitStack_sigmaSummand I O A d ih L X a))).trans
           (FreeCoprodCompDisc.coprodDesc_eta O A
             (fun a ↦ interpObj I O (d (ULift.up a)) X)
             (interpObj I O (mprecomp I O L (mk I O (Sum.inr (Sum.inl A)) d)) X)
@@ -5174,9 +5163,9 @@ theorem interpHom_preUnitStack (γ : IR.{max uA uB, uB, uI, uO} I O) :
     InterpHomPreUnitMotive I O γ :=
   induction I O (InterpHomPreUnitMotive I O)
     (fun s ↦ match s with
-      | Sum.inl o => fun d _ ↦ interpHomPreUnit_mk_iota I O o d
-      | Sum.inr (Sum.inl A) => fun d ih ↦ interpHomPreUnit_mk_sigma I O A d ih
-      | Sum.inr (Sum.inr B) => fun d ih ↦ interpHomPreUnit_mk_delta I O B d ih)
+      | Sum.inl o => fun d _ ↦ interpHom_preUnitStack_mk_iota I O o d
+      | Sum.inr (Sum.inl A) => fun d ih ↦ interpHom_preUnitStack_mk_sigma I O A d ih
+      | Sum.inr (Sum.inr B) => fun d ih ↦ interpHom_preUnitStack_mk_delta I O B d ih)
     γ
 
 /-! ### Composition and the category laws -/

--- a/geb-lean/vendor/geb-mathlib/Geb/Mathlib/Data/PFunctor/IndRec/Hom.lean
+++ b/geb-lean/vendor/geb-mathlib/Geb/Mathlib/Data/PFunctor/IndRec/Hom.lean
@@ -113,8 +113,8 @@ codomain: propositional equality of indices, a dependent sum over the
 `σ`-arity, and an empty-witness sum over the `δ`-arity. -/
 def InnerHom (o : O) : IR.{max uA uB, uB, uI, uO} I O → Type (max uA uB uI) :=
   elimAlg I O (Type (max uA uB uI))
-    ⟨fun o' => ULift.{max uA uB uI} (PLift (o = o')), fun _ dir => Σ a, dir a,
-     fun B dir => Σ e : B → PEmpty.{1}, dir (fun b => (e b).elim)⟩
+    ⟨fun o' ↦ ULift.{max uA uB uI} (PLift (o = o')), fun _ dir ↦ Σ a, dir a,
+     fun B dir ↦ Σ e : B → PEmpty.{1}, dir (fun b ↦ (e b).elim)⟩
 
 /-- The homset of IR codes (Definition 8 of
 [HancockMcBrideGhaniMalatestaAltenkirch2013]), by `IR.elimAlg` on the
@@ -124,8 +124,8 @@ codomain (clause 3's `γ'^i`). -/
 def Hom : IR.{max uA uB, uB, uI, uO} I O → IR.{max uA uB, uB, uI, uO} I O
     → Type (max uA uB uI) :=
   elimAlg I O (IR.{max uA uB, uB, uI, uO} I O → Type (max uA uB uI))
-    ⟨fun o => InnerHom I O o, fun _ dir => fun g' => ∀ a, dir a g',
-     fun B dir => fun g' => ∀ i : B → I, dir i (precomp I O B i g')⟩
+    ⟨fun o ↦ InnerHom I O o, fun _ dir ↦ fun g' ↦ ∀ a, dir a g',
+     fun B dir ↦ fun g' ↦ ∀ i : B → I, dir i (precomp I O B i g')⟩
 
 /-- The motive of `IR.sigmaPush` (named so `IR.rec_mk` applies). -/
 def SigmaPushMotive (γ : IR.{max uA uB, uB, uI, uO} I O) :
@@ -137,12 +137,12 @@ def SigmaPushMotive (γ : IR.{max uA uB, uB, uI, uO} I O) :
 def sigmaPushStep :
     RecStep.{max uA uB, uB, uI, uO, max (max uA uB + 1) uI uO} I O
       (SigmaPushMotive I O) :=
-  fun s _c m => match s with
-  | Sum.inl _ => fun _ _ a' f => ⟨a', f⟩
-  | Sum.inr (Sum.inl _) => fun A' K' a' f b => m (ULift.up b) A' K' a' (f b)
-  | Sum.inr (Sum.inr B) => fun A' K' a' f i =>
+  fun s _c m ↦ match s with
+  | Sum.inl _ => fun _ _ a' f ↦ ⟨a', f⟩
+  | Sum.inr (Sum.inl _) => fun A' K' a' f b ↦ m (ULift.up b) A' K' a' (f b)
+  | Sum.inr (Sum.inr B) => fun A' K' a' f i ↦
       m (ULift.up i) (ULift.{uB} A')
-        (fun x => precomp I O B i (K' x.down)) (ULift.up a') (f i)
+        (fun x ↦ precomp I O B i (K' x.down)) (ULift.up a') (f i)
 
 /-- Postcomposition with the `σ`-injection into the `a'`-th summand:
 identity at a `σ`-code is a product of these injections. By `IR.rec` on
@@ -174,7 +174,7 @@ theorem sigmaPush_mk_sigma (A : Type (max uA uB))
     (a' : A')
     (f : Hom.{uA, uB, uI, uO} I O (mk I O (Sum.inr (Sum.inl A)) d) (K' a')) :
     sigmaPush I O (mk I O (Sum.inr (Sum.inl A)) d) A' K' a' f =
-      fun b => sigmaPush I O (d (ULift.up b)) A' K' a' (f b) :=
+      fun b ↦ sigmaPush I O (d (ULift.up b)) A' K' a' (f b) :=
   congrFun (congrFun (congrFun (congrFun
     (rec_mk I O (sigmaPushStep I O) (Sum.inr (Sum.inl A)) d) A') K') a') f
 
@@ -187,8 +187,8 @@ theorem sigmaPush_mk_delta (B : Type uB)
     (a' : A')
     (f : Hom.{uA, uB, uI, uO} I O (mk I O (Sum.inr (Sum.inr B)) d) (K' a')) :
     sigmaPush I O (mk I O (Sum.inr (Sum.inr B)) d) A' K' a' f =
-      fun i => sigmaPush I O (d (ULift.up i)) (ULift.{uB} A')
-        (fun x => precomp I O B i (K' x.down)) (ULift.up a') (f i) :=
+      fun i ↦ sigmaPush I O (d (ULift.up i)) (ULift.{uB} A')
+        (fun x ↦ precomp I O B i (K' x.down)) (ULift.up a') (f i) :=
   congrFun (congrFun (congrFun (congrFun
     (rec_mk I O (sigmaPushStep I O) (Sum.inr (Sum.inr B)) d) A') K') a') f
 
@@ -197,29 +197,29 @@ def DeltaEmptyPushMotive (γ : IR.{max uA uB, uB, uI, uO} I O) :
     Type (max (max uA uB + 1) uI uO) :=
   ∀ (E : Type uB) (e : E → PEmpty.{1})
     (M : (E → I) → IR.{max uA uB, uB, uI, uO} I O),
-    Hom I O γ (M (fun x => (e x).elim)) → Hom I O γ (delta I O E M)
+    Hom I O γ (M (fun x ↦ (e x).elim)) → Hom I O γ (delta I O E M)
 
 /-- The step of `IR.deltaEmptyPush` (named so `IR.rec_mk` applies). -/
 def deltaEmptyPushStep :
     RecStep.{max uA uB, uB, uI, uO, max (max uA uB + 1) uI uO} I O
       (DeltaEmptyPushMotive I O) :=
-  fun s c m => match s with
-  | Sum.inl _ => fun _ e _ f => ⟨e, f⟩
-  | Sum.inr (Sum.inl _) => fun E e M f b => m (ULift.up b) E e M (f b)
-  | Sum.inr (Sum.inr B) => fun E e M f i =>
+  fun s c m ↦ match s with
+  | Sum.inl _ => fun _ e _ f ↦ ⟨e, f⟩
+  | Sum.inr (Sum.inl _) => fun E e M f b ↦ m (ULift.up b) E e M (f b)
+  | Sum.inr (Sum.inr B) => fun E e M f i ↦
       sigmaPush I O (c (ULift.up i)) (ULift.{max uA uB} (E → B ⊕ PUnit.{uB + 1}))
-        (fun cl => delta I O {z : E // cl.down z = Sum.inr PUnit.unit}
-          (fun j => precomp I O B i (M (precompMerge I B i cl.down j))))
-        (ULift.up (fun x => (e x).elim))
-        (m (ULift.up i) {z : E // (fun x => (e x).elim) z = Sum.inr PUnit.unit}
-          (fun z => (e z.1).elim)
-          (fun j => precomp I O B i (M (precompMerge I B i (fun x => (e x).elim) j)))
+        (fun cl ↦ delta I O {z : E // cl.down z = Sum.inr PUnit.unit}
+          (fun j ↦ precomp I O B i (M (precompMerge I B i cl.down j))))
+        (ULift.up (fun x ↦ (e x).elim))
+        (m (ULift.up i) {z : E // (fun x ↦ (e x).elim) z = Sum.inr PUnit.unit}
+          (fun z ↦ (e z.1).elim)
+          (fun j ↦ precomp I O B i (M (precompMerge I B i (fun x ↦ (e x).elim) j)))
           (cast (congrArg
-            (fun a => Hom I O (c (ULift.up i)) (precomp I O B i (M a)))
-            (funext (fun x => (e x).elim) :
-              (fun x => (e x).elim) = precompMerge I B i (fun x => (e x).elim)
-                    (fun z : {z : E // (fun x => (e x).elim) z = Sum.inr PUnit.unit}
-                      => ((e z.1).elim : PEmpty.{1}).elim)))
+            (fun a ↦ Hom I O (c (ULift.up i)) (precomp I O B i (M a)))
+            (funext (fun x ↦ (e x).elim) :
+              (fun x ↦ (e x).elim) = precompMerge I B i (fun x ↦ (e x).elim)
+                    (fun z : {z : E // (fun x ↦ (e x).elim) z = Sum.inr PUnit.unit}
+                      ↦ ((e z.1).elim : PEmpty.{1}).elim)))
             (f i)))
 
 /-- Postcomposition with the `δ`-injection at an empty direction witness
@@ -228,7 +228,7 @@ generalized; the `δ`-domain case injects, via `sigmaPush`, into the
 all-resolved classifier summand of the precomposed `δ`-code. -/
 def deltaEmptyPush : (γ : IR.{max uA uB, uB, uI, uO} I O) →
       ∀ (E : Type uB) (e : E → PEmpty.{1}) (M : (E → I) → IR.{max uA uB, uB, uI, uO} I O),
-        Hom I O γ (M (fun x => (e x).elim)) → Hom I O γ (delta I O E M) :=
+        Hom I O γ (M (fun x ↦ (e x).elim)) → Hom I O γ (delta I O E M) :=
   rec I O (deltaEmptyPushStep I O)
 
 /-- The characterizing equation of `IR.deltaEmptyPush` at an `ι`-shaped
@@ -239,7 +239,7 @@ theorem deltaEmptyPush_mk_iota (o : O)
     (E : Type uB) (e : E → PEmpty.{1})
     (M : (E → I) → IR.{max uA uB, uB, uI, uO} I O)
     (f : Hom.{uA, uB, uI, uO} I O (mk I O (Sum.inl o) d)
-      (M (fun x => (e x).elim))) :
+      (M (fun x ↦ (e x).elim))) :
     deltaEmptyPush I O (mk I O (Sum.inl o) d) E e M f = ⟨e, f⟩ :=
   congrFun (congrFun (congrFun (congrFun
     (rec_mk I O (deltaEmptyPushStep I O) (Sum.inl o) d) E) e) M) f
@@ -252,9 +252,9 @@ theorem deltaEmptyPush_mk_sigma (A : Type (max uA uB))
     (E : Type uB) (e : E → PEmpty.{1})
     (M : (E → I) → IR.{max uA uB, uB, uI, uO} I O)
     (f : Hom.{uA, uB, uI, uO} I O (mk I O (Sum.inr (Sum.inl A)) d)
-      (M (fun x => (e x).elim))) :
+      (M (fun x ↦ (e x).elim))) :
     deltaEmptyPush I O (mk I O (Sum.inr (Sum.inl A)) d) E e M f =
-      fun b => deltaEmptyPush I O (d (ULift.up b)) E e M (f b) :=
+      fun b ↦ deltaEmptyPush I O (d (ULift.up b)) E e M (f b) :=
   congrFun (congrFun (congrFun (congrFun
     (rec_mk I O (deltaEmptyPushStep I O) (Sum.inr (Sum.inl A)) d) E) e) M) f
 
@@ -267,23 +267,23 @@ theorem deltaEmptyPush_mk_delta (B : Type uB)
     (E : Type uB) (e : E → PEmpty.{1})
     (M : (E → I) → IR.{max uA uB, uB, uI, uO} I O)
     (f : Hom.{uA, uB, uI, uO} I O (mk I O (Sum.inr (Sum.inr B)) d)
-      (M (fun x => (e x).elim))) :
+      (M (fun x ↦ (e x).elim))) :
     deltaEmptyPush I O (mk I O (Sum.inr (Sum.inr B)) d) E e M f =
-      fun i => sigmaPush I O (d (ULift.up i))
+      fun i ↦ sigmaPush I O (d (ULift.up i))
         (ULift.{max uA uB} (E → B ⊕ PUnit.{uB + 1}))
-        (fun cl => delta I O {z : E // cl.down z = Sum.inr PUnit.unit}
-          (fun j => precomp I O B i (M (precompMerge I B i cl.down j))))
-        (ULift.up (fun x => (e x).elim))
+        (fun cl ↦ delta I O {z : E // cl.down z = Sum.inr PUnit.unit}
+          (fun j ↦ precomp I O B i (M (precompMerge I B i cl.down j))))
+        (ULift.up (fun x ↦ (e x).elim))
         (deltaEmptyPush I O (d (ULift.up i))
-          {z : E // (fun x => (e x).elim) z = Sum.inr PUnit.unit}
-          (fun z => (e z.1).elim)
-          (fun j => precomp I O B i (M (precompMerge I B i (fun x => (e x).elim) j)))
+          {z : E // (fun x ↦ (e x).elim) z = Sum.inr PUnit.unit}
+          (fun z ↦ (e z.1).elim)
+          (fun j ↦ precomp I O B i (M (precompMerge I B i (fun x ↦ (e x).elim) j)))
           (cast (congrArg
-            (fun a => Hom I O (d (ULift.up i)) (precomp I O B i (M a)))
-            (funext (fun x => (e x).elim) :
-              (fun x => (e x).elim) = precompMerge I B i (fun x => (e x).elim)
-                    (fun z : {z : E // (fun x => (e x).elim) z = Sum.inr PUnit.unit}
-                      => ((e z.1).elim : PEmpty.{1}).elim)))
+            (fun a ↦ Hom I O (d (ULift.up i)) (precomp I O B i (M a)))
+            (funext (fun x ↦ (e x).elim) :
+              (fun x ↦ (e x).elim) = precompMerge I B i (fun x ↦ (e x).elim)
+                    (fun z : {z : E // (fun x ↦ (e x).elim) z = Sum.inr PUnit.unit}
+                      ↦ ((e z.1).elim : PEmpty.{1}).elim)))
             (f i))) :=
   congrFun (congrFun (congrFun (congrFun
     (rec_mk I O (deltaEmptyPushStep I O) (Sum.inr (Sum.inr B)) d) E) e) M) f
@@ -299,25 +299,25 @@ abbrev SupObj (I : Type uI) := Σ Q : Type uB, Q → I
 objects (`γ ^^ L`). -/
 def mprecomp (L : List (SupObj.{uB, uI} I)) (γ : IR.{max uA uB, uB, uI, uO} I O) :
     IR.{max uA uB, uB, uI, uO} I O :=
-  L.foldl (fun g a => precomp I O a.1 a.2 g) γ
+  L.foldl (fun g a ↦ precomp I O a.1 a.2 g) γ
 
 /-- `mprecomp` at a right-appended superscript is one outer `precomp`. -/
 theorem mprecomp_snoc (L : List (SupObj.{uB, uI} I)) (b : SupObj.{uB, uI} I)
     (γ : IR.{max uA uB, uB, uI, uO} I O) :
     mprecomp I O (L ++ [b]) γ = precomp I O b.1 b.2 (mprecomp I O L γ) :=
-  (List.foldl_concat (fun g a => precomp I O a.1 a.2 g) γ b L) ▸ rfl
+  (List.foldl_concat (fun g a ↦ precomp I O a.1 a.2 g) γ b L) ▸ rfl
 
 /-- `mprecomp` fixes the constant (`iota`) code. -/
 theorem mprecomp_iota (L : List (SupObj.{uB, uI} I)) (o : O) :
     mprecomp I O L (iota I O o) = iota I O o :=
-  L.rec (motive := fun L => ∀ o, mprecomp I O L (iota I O o) = iota I O o)
-    (fun _ => rfl) (fun _a _L ih o => ih o) o
+  L.rec (motive := fun L ↦ ∀ o, mprecomp I O L (iota I O o) = iota I O o)
+    (fun _ ↦ rfl) (fun _a _L ih o ↦ ih o) o
 
 /-- `mprecomp` fixes any `mk`-form of an `iota` code. -/
 theorem mprecomp_iota_mk (L : List (SupObj.{uB, uI} I)) (o : O)
     (c : Direction I O (Sum.inl o) → IR.{max uA uB, uB, uI, uO} I O) :
     mprecomp I O L (mk I O (Sum.inl o) c) = iota I O o :=
-  (mk_congr I O (Sum.inl o) (funext (fun x => nomatch x)) :
+  (mk_congr I O (Sum.inl o) (funext (fun x ↦ nomatch x)) :
       mk I O (Sum.inl o) c = iota I O o) ▸ mprecomp_iota I O L o
 
 /-- Stack `σ`-push: `sigmaPush` under an iterated precomposition. By
@@ -326,12 +326,12 @@ reindexing the target family through `ULift`. -/
 def msigmaPush (D : IR.{max uA uB, uB, uI, uO} I O) (A' : Type (max uA uB))
     (K' : A' → IR.{max uA uB, uB, uI, uO} I O) (a' : A') (L : List (SupObj.{uB, uI} I))
     (f : Hom I O D (mprecomp I O L (K' a'))) : Hom I O D (mprecomp I O L (sigma I O A' K')) :=
-  L.rec (motive := fun L => ∀ (A' : Type (max uA uB))
+  L.rec (motive := fun L ↦ ∀ (A' : Type (max uA uB))
       (K' : A' → IR.{max uA uB, uB, uI, uO} I O) (a' : A'),
       Hom I O D (mprecomp I O L (K' a')) → Hom I O D (mprecomp I O L (sigma I O A' K')))
-    (fun A' K' a' f => sigmaPush I O D A' K' a' f)
-    (fun c _L ih A' K' a' f =>
-      ih (ULift.{uB} A') (fun x => precomp I O c.1 c.2 (K' x.down)) (ULift.up a') f)
+    (fun A' K' a' f ↦ sigmaPush I O D A' K' a' f)
+    (fun c _L ih A' K' a' f ↦
+      ih (ULift.{uB} A') (fun x ↦ precomp I O c.1 c.2 (K' x.down)) (ULift.up a') f)
     A' K' a' f
 
 /-- The base navigation: inject a `Hom` into `precomp Bout iout (K …)`
@@ -342,18 +342,18 @@ def deltaNavBase (D : IR.{max uA uB, uB, uI, uO} I O) (Bout : Type uB) (iout : B
     (f : Hom I O D (precomp I O Bout iout (K (iout ∘ g)))) :
     Hom I O D (precomp I O Bout iout (delta I O Bin K)) :=
   sigmaPush I O D (ULift.{max uA uB} (Bin → Bout ⊕ PUnit.{uB + 1}))
-    (fun cl => delta I O {z : Bin // cl.down z = Sum.inr PUnit.unit}
-      (fun j => precomp I O Bout iout (K (precompMerge I Bout iout cl.down j))))
-    (ULift.up (fun b => Sum.inl (g b)))
-    (deltaEmptyPush I O D {z : Bin // (fun b => Sum.inl (g b)) z = Sum.inr PUnit.unit}
-      (fun z => nomatch z.2)
-      (fun j => precomp I O Bout iout
-        (K (precompMerge I Bout iout (fun b => Sum.inl (g b)) j)))
-      (cast (congrArg (fun a => Hom I O D (precomp I O Bout iout (K a)))
-        (funext (fun _b => rfl) :
-          (iout ∘ g) = precompMerge I Bout iout (fun b => Sum.inl (g b))
-                (fun z : {z : Bin // (fun b => Sum.inl (g b)) z = Sum.inr PUnit.unit}
-                  => (nomatch z.2 : I)))) f))
+    (fun cl ↦ delta I O {z : Bin // cl.down z = Sum.inr PUnit.unit}
+      (fun j ↦ precomp I O Bout iout (K (precompMerge I Bout iout cl.down j))))
+    (ULift.up (fun b ↦ Sum.inl (g b)))
+    (deltaEmptyPush I O D {z : Bin // (fun b ↦ Sum.inl (g b)) z = Sum.inr PUnit.unit}
+      (fun z ↦ nomatch z.2)
+      (fun j ↦ precomp I O Bout iout
+        (K (precompMerge I Bout iout (fun b ↦ Sum.inl (g b)) j)))
+      (cast (congrArg (fun a ↦ Hom I O D (precomp I O Bout iout (K a)))
+        (funext (fun _b ↦ rfl) :
+          (iout ∘ g) = precompMerge I Bout iout (fun b ↦ Sum.inl (g b))
+                (fun z : {z : Bin // (fun b ↦ Sum.inl (g b)) z = Sum.inr PUnit.unit}
+                  ↦ (nomatch z.2 : I)))) f))
 
 /-- The navigation up an iterated-precomposition tower: at each stack
 layer, inject through the all-unresolved classifier (`msigmaPush`),
@@ -364,26 +364,26 @@ def deltaNav (D : IR.{max uA uB, uB, uI, uO} I O) (Bout : Type uB) (iout : Bout 
     (f : Hom I O D
       (mprecomp I O (L ++ [(⟨Bout, iout⟩ : SupObj.{uB, uI} I)]) (K (iout ∘ g)))) :
     Hom I O D (mprecomp I O (L ++ [(⟨Bout, iout⟩ : SupObj.{uB, uI} I)]) (delta I O Bin K)) :=
-  L.rec (motive := fun L => ∀ (Bin : Type uB)
+  L.rec (motive := fun L ↦ ∀ (Bin : Type uB)
       (K : (Bin → I) → IR.{max uA uB, uB, uI, uO} I O) (g : Bin → Bout),
       Hom I O D (mprecomp I O (L ++ [(⟨Bout, iout⟩ : SupObj.{uB, uI} I)]) (K (iout ∘ g))) →
       Hom I O D (mprecomp I O (L ++ [(⟨Bout, iout⟩ : SupObj.{uB, uI} I)]) (delta I O Bin K)))
-    (fun Bin K g f =>
+    (fun Bin K g f ↦
       (mprecomp_snoc I O [] (⟨Bout, iout⟩ : SupObj.{uB, uI} I) (delta I O Bin K)).symm ▸
         deltaNavBase I O D Bout iout Bin K g
           (mprecomp_snoc I O [] (⟨Bout, iout⟩ : SupObj.{uB, uI} I) (K (iout ∘ g)) ▸ f))
-    (fun a _L ih Bin K g f =>
+    (fun a _L ih Bin K g f ↦
       msigmaPush I O D (ULift.{max uA uB, uB} (Bin → a.1 ⊕ PUnit.{uB + 1}))
-        (fun cl => delta I O {z : Bin // cl.down z = Sum.inr PUnit.unit}
-          (fun m => precomp.{max uA uB, uB, uI, uO, uB} I O a.1 a.2
+        (fun cl ↦ delta I O {z : Bin // cl.down z = Sum.inr PUnit.unit}
+          (fun m ↦ precomp.{max uA uB, uB, uI, uO, uB} I O a.1 a.2
             (K (precompMerge I a.1 a.2 cl.down m))))
-        (ULift.up (fun _ => Sum.inr PUnit.unit))
+        (ULift.up (fun _ ↦ Sum.inr PUnit.unit))
         (_L ++ [(⟨Bout, iout⟩ : SupObj.{uB, uI} I)])
-        (ih {z : Bin // (fun _ : Bin => (Sum.inr PUnit.unit : a.1 ⊕ PUnit.{uB + 1})) z
+        (ih {z : Bin // (fun _ : Bin ↦ (Sum.inr PUnit.unit : a.1 ⊕ PUnit.{uB + 1})) z
               = Sum.inr PUnit.unit}
-          (fun m => precomp.{max uA uB, uB, uI, uO, uB} I O a.1 a.2
-            (K (precompMerge I a.1 a.2 (fun _ => Sum.inr PUnit.unit) m)))
-          (fun z => g z.1) f))
+          (fun m ↦ precomp.{max uA uB, uB, uI, uO, uB} I O a.1 a.2
+            (K (precompMerge I a.1 a.2 (fun _ ↦ Sum.inr PUnit.unit) m)))
+          (fun z ↦ g z.1) f))
     Bin K g f
 
 /-- The motive of `IR.preUnitStack` (named so `IR.rec_mk` applies). -/
@@ -395,18 +395,18 @@ def PreUnitStackMotive (γ : IR.{max uA uB, uB, uI, uO} I O) :
 def preUnitStackStep :
     RecStep.{max uA uB, uB, uI, uO, max uA (uB + 1) uI} I O
       (PreUnitStackMotive I O) :=
-  fun s c m => match s with
-  | Sum.inl o => fun L =>
+  fun s c m ↦ match s with
+  | Sum.inl o => fun L ↦
       cast (congrArg (InnerHom.{uA, uB, uI, uO} I O o)
           (mprecomp_iota_mk I O L o c).symm)
         (ULift.up (PLift.up rfl) : InnerHom.{uA, uB, uI, uO} I O o (iota I O o))
-  | Sum.inr (Sum.inl A) => fun L a =>
-      msigmaPush I O (c (ULift.up a)) A (fun a' => c (ULift.up a')) a L
+  | Sum.inr (Sum.inl A) => fun L a ↦
+      msigmaPush I O (c (ULift.up a)) A (fun a' ↦ c (ULift.up a')) a L
         (m (ULift.up a) L)
-  | Sum.inr (Sum.inr B) => fun L i =>
+  | Sum.inr (Sum.inr B) => fun L i ↦
       cast (congrArg (Hom I O (c (ULift.up i)))
              (mprecomp_snoc I O L ⟨B, i⟩ (mk I O (Sum.inr (Sum.inr B)) c)))
-        (deltaNav I O (c (ULift.up i)) B i B (fun i' => c (ULift.up i')) _root_.id L
+        (deltaNav I O (c (ULift.up i)) B i B (fun i' ↦ c (ULift.up i')) _root_.id L
           (m (ULift.up i) (L ++ [⟨B, i⟩])))
 
 /-- The list-generalized pre-unit `Hom γ (γ ^^ L)`: by `IR.rec` on `γ`
@@ -437,7 +437,7 @@ theorem preUnitStack_mk_sigma (A : Type (max uA uB))
       IR.{max uA uB, uB, uI, uO} I O)
     (L : List (SupObj.{uB, uI} I)) (a : A) :
     preUnitStack I O (mk I O (Sum.inr (Sum.inl A)) d) L a =
-      msigmaPush I O (d (ULift.up a)) A (fun a' => d (ULift.up a')) a L
+      msigmaPush I O (d (ULift.up a)) A (fun a' ↦ d (ULift.up a')) a L
         (preUnitStack I O (d (ULift.up a)) L) :=
   congrFun (congrFun
     (rec_mk I O (preUnitStackStep I O) (Sum.inr (Sum.inl A)) d) L) a
@@ -453,7 +453,7 @@ def preUnitDeltaData (B : Type uB)
       (precomp I O B i (mprecomp I O L (mk I O (Sum.inr (Sum.inr B)) d))) :=
   cast (congrArg (Hom I O (d (ULift.up i)))
       (mprecomp_snoc I O L ⟨B, i⟩ (mk I O (Sum.inr (Sum.inr B)) d)))
-    (deltaNav I O (d (ULift.up i)) B i B (fun i' => d (ULift.up i')) _root_.id L
+    (deltaNav I O (d (ULift.up i)) B i B (fun i' ↦ d (ULift.up i')) _root_.id L
       (preUnitStack I O (d (ULift.up i)) (L ++ [⟨B, i⟩])))
 
 /-- The characterizing equation of `IR.preUnitStack` at a `δ`-shaped

--- a/geb-lean/vendor/geb-mathlib/PROVENANCE.md
+++ b/geb-lean/vendor/geb-mathlib/PROVENANCE.md
@@ -1,6 +1,6 @@
 # Vendored geb-mathlib provenance
 
 - Source: https://github.com/rokopt/geb-mathlib.git
-- Source commit: 89f18d05cd4234d4e31518415d5295868af87f17
-- Back-port patch: scripts/geb-mathlib-backport.patch (sha256 65c9ad11d1323ebf10c28b1ac1f0862d1031d1f8f49f03eff0aba5253a725c1e)
+- Source commit: ef4c86a06cb281205e222750f4373ca7437e337e
+- Back-port patch: scripts/geb-mathlib-backport.patch (sha256 9b92baec9ffacfde1d6e78f39c5b57ab95947f13d3cd6494c13aa7a527dfd396)
 - The files under `Geb/` are an unmodified mirror of the source commit except where the back-port patch changes them; modified files carry a change notice in their header comment.


### PR DESCRIPTION
Upstream restates `IR.comp_isoOfEq_hom` and `IR.isoOfEq_symm_hom_comp` at a single universe, so their `linter.checkUnivs` suppression and the module-docstring paragraph describing it are gone. The back-port patch's category-2 adaptation of `IndRec/Category.lean` has nothing left to adapt, and the file drops out of the patch.