### PR TITLE
Fix Verso build dependencies

### DIFF
--- a/.github/workflows/lean_action_ci.yml
+++ b/.github/workflows/lean_action_ci.yml
@@ -41,5 +41,6 @@ jobs:
         run: bash scripts/tests/test-axiom-linter.sh
       - name: Build and generate the ramified-recurrence manual
         run: |
+          lake build GebLeanDocs
           lake lint -- GebLeanDocs
           lake exe geblean-docs

--- a/geb-lean/.claude/rules/ci-and-workflow.md
+++ b/geb-lean/.claude/rules/ci-and-workflow.md
@@ -65,7 +65,8 @@ steps: outside `testDriver`'s dependency graph, outside
 `lake lint`'s default-target coverage, and outside the
 `GebLeanAxiomChecks` gates (which name `GebLean`, `GebLeanTests`,
 and the vendored `Geb`). It is built and linted only in CI
-(`lake lint -- GebLeanDocs`, then `lake exe geblean-docs`, in
+(`lake build GebLeanDocs`, then `lake lint -- GebLeanDocs`, then
+`lake exe geblean-docs`, in
 `geb/.github/workflows/lean_action_ci.yml`), a deliberate exception
 to `scripts/pre-commit.sh`'s comment instructing that a target
 outside the test driver's dependency graph be added there and to

--- a/geb-lean/scripts/pre-commit.sh
+++ b/geb-lean/scripts/pre-commit.sh
@@ -26,9 +26,10 @@ step() { printf '\n==> %s\n' "$1"; }
 #
 # `GebLeanDocs`, the Verso manual library, is such a target and is
 # exempted from that instruction by design: its generator step
-# (`lake lint -- GebLeanDocs`, then `lake exe geblean-docs`) runs
-# only in CI (`lean_action_ci.yml`), not here or in pre-push.sh, so
-# that no contributor builds Verso on every push.
+# (`lake build GebLeanDocs`, then `lake lint -- GebLeanDocs`, then
+# `lake exe geblean-docs`) runs only in CI (`lean_action_ci.yml`),
+# not here or in pre-push.sh, so that no contributor builds Verso
+# on every push.
 step "Step 1: lake test"
 lake test
 


### PR DESCRIPTION
Build an `.olean` dependency before the Verso build that uses it.