### PR TITLE
chore(ignore): ignore an agent config file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@
 /.claude/
 geb-agda/.claude
 geb-idris/.claude
+geb-idris/opencode.json
 /geb-lean/.claude/*
 !/geb-lean/.claude/rules/
 !/geb-lean/.claude/settings.json


### PR DESCRIPTION
Ignore `geb-idris/opencode.json`.