### PR TITLE
chore(ignore): ignore an agent config file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@ geb-idris/opencode.json
 build/
 /docs/common-lisp/html/
 .superpowers/
+/geb-lean/.poolside/settings.local.yaml


### PR DESCRIPTION
Ignore a `poolside` agent config file.