### PR TITLE
chore(vendor): refresh geb-mathlib to f600ebe

### DIFF
--- a/geb-lean/docs/geb-mathlib-backport-notes.md
+++ b/geb-lean/docs/geb-mathlib-backport-notes.md
@@ -14,6 +14,7 @@
   - [7. `rw`'s closing `rfl` runs at reducible transparency](#7-rws-closing-rfl-runs-at-reducible-transparency)
   - [8. Derived `Repr` instances carry an unused precedence argument](#8-derived-repr-instances-carry-an-unused-precedence-argument)
   - [9. Subobject classifier moved out of `Topos` in v4.33](#9-subobject-classifier-moved-out-of-topos-in-v433)
+  - [10. `simp` leaves a `cast`'s proof argument unfolded](#10-simp-leaves-a-casts-proof-argument-unfolded)
 - [Updating the patch for a new upstream](#updating-the-patch-for-a-new-upstream)
   - [The no-op condition](#the-no-op-condition)
 - [Module exclusion](#module-exclusion)
@@ -77,12 +78,18 @@ genuinely new (decide the adaptation, add a category here).
 ### 3. `ConcreteCategory` redesign (mathlib pull request 34741)
 
 - Upstream cause: the post-`HasForget` `ConcreteCategory` adds the
-  `ConcreteCategory.hom` accessor, `ConcreteCategory.comp_apply`, and
-  `ConcreteCategory.hom_ext`; in v4.29 an `Over` base map, an
-  `Iᵒᵖ ⥤ Type` presheaf map, and a `Type`-category morphism are already
-  functions.
+  `ConcreteCategory.hom` accessor, `ConcreteCategory.comp_apply`,
+  `ConcreteCategory.hom_ext`, and `ConcreteCategory.hom_ofHom`; the same
+  redesign routes a `Type`-category morphism through the `TypeCat.Fun`
+  coercion layer, with `TypeCat.Fun.toFun_apply` and
+  `NatTrans.naturality_apply` reading through it. In v4.29 an `Over`
+  base map, an `Iᵒᵖ ⥤ Type` presheaf map, and a `Type`-category
+  morphism are already functions, so neither the accessors nor the
+  coercion layer exist.
 - v4.29 symptom: `Unknown identifier 'ConcreteCategory.hom'` /
-  `'ConcreteCategory.comp_apply'` / `'ConcreteCategory.hom_ext'`.
+  `'ConcreteCategory.comp_apply'` / `'ConcreteCategory.hom_ext'` /
+  `'ConcreteCategory.hom_ofHom'` / `'TypeCat.Fun.toFun_apply'`, or
+  `Unknown constant 'CategoryTheory.NatTrans.naturality_apply'`.
 - Adaptation in `Slice/Functor.lean`: drop the `ConcreteCategory.hom`
   wrapper (and its two docstring mentions); rewrite the `over_hom_comp`
   proof to `exact congrFun (Over.w g) z`.
@@ -106,6 +113,23 @@ genuinely new (decide the adaptation, add a category here).
   `ConcreteCategory.hom_ext _ _` with `funext`, and replace
   `ConcreteCategory.congr_hom g.h` with `congrFun g.h`: in v4.29 the
   morphism is the function and its equation is the function equation.
+- Adaptation in `Internal/PresheafIRProto/Basic.lean`
+  (`postcompArityHom`): the arity-hom naturality proof closes with
+  `simp only [← ConcreteCategory.comp_apply]; rw [ν.naturality f.op]`.
+  Replace both tactics with
+  `exact FunctorToTypes.naturality _ _ ν f.op _`, as in
+  `Presheaf/Basic.lean` above.
+- Adaptation in `Internal/PresheafIRProto/Codes.lean`
+  (`BaseArity.reindexHom`): the naturality proof strips the coercion
+  layers with
+  `simp only [TypeCat.Fun.toFun_apply, comp_apply, ConcreteCategory.hom_ofHom]`
+  before `exact congrFun (hP.reindex_naturality g f.unop).symm d`.
+  Delete the `simp only` line; in v4.29 the goal is already the
+  function equation the `exact` closes.
+- Adaptation in `Internal/PresheafIRProto/Functor.lean`
+  (`arityHomEquivNatTrans`): the backward direction re-states
+  naturality with `NatTrans.naturality_apply α f.op b`. Replace it
+  with `FunctorToTypes.naturality _ _ α f.op b`.
 
 ### 4. Eliminator motive left as an unreduced beta-redex
 
@@ -113,8 +137,9 @@ genuinely new (decide the adaptation, add a category here).
   explicit `motive` and enters the minor premise via
   `fun ... => by ...`. The affected sites are `elimData_valid` in
   `Slice/W.lean` and `wValidBool_eq_true_iff` in `Slice/Decidable.lean`
-  (both `WType.rec`), and `isHereditarilyNaturalBoolCore_eq_true_iff` in
-  `Presheaf/Decidable.lean` (`SlicePFunctor.W.induction`).
+  (both `WType.rec`), `isHereditarilyNaturalBoolCore_eq_true_iff` in
+  `Presheaf/Decidable.lean` (`SlicePFunctor.W.induction`), and
+  `ofRose_toRose` in `Internal/ConcreteSyntax.lean` (`Ast.ind`).
 - v4.29 symptom: the goal is `(fun w => ...) (WType.mk a f)` — the motive
   lambda is not beta-reduced at the constructor — so the opening
   `rw` reports "Did not find an occurrence of the pattern" (the rewritten
@@ -172,18 +197,27 @@ genuinely new (decide the adaptation, add a category here).
   so, and `rw` closes a residual goal only with `with_reducible rfl`.
 - Adaptation: append `rfl`, which runs at default transparency:
   `rw [comp_get, whiskerLeft_get]; rfl`.
+- Second site: `Internal/PresheafIRProto/Codes.lean`'s
+  `isFunctorial_pullback` closes its `reindex_id` field with a `rw`
+  whose residual goal is `cast ⋯ d = cast ⋯ d`. The two transport
+  proofs are definitionally equal by proof irrelevance but not
+  reducibly so. Append `rfl` after the `rw`.
 
 ### 8. Derived `Repr` instances carry an unused precedence argument
 
 - Upstream cause: `FinSetSkel/Basic.lean` declares the objects with
-  `deriving DecidableEq, Repr`.
+  `deriving DecidableEq, Repr`, and `Internal/ConcreteSyntax.lean`
+  declares `Ann` with `deriving Repr, DecidableEq, Inhabited`.
 - v4.29 symptom: the `unusedArguments` env-linter reports
-  `instReprFinSetSkel.repr argument 2 prec✝ : ℕ` under `lake lint`;
-  v4.29's `Repr` deriving handler emits a `repr` that ignores the
-  precedence argument for a structure with one non-recursive field.
+  `instReprFinSetSkel.repr argument 2 prec✝ : ℕ` (respectively
+  `instReprAnn.repr argument 2 prec✝ : ℕ`) under `lake lint`; v4.29's
+  `Repr` deriving handler emits a `repr` that ignores the precedence
+  argument for a structure whose representation needs no
+  parenthesisation.
 - Adaptation: suppress the linter on the generated declaration,
-  `attribute [nolint unusedArguments] instReprFinSetSkel.repr`, after
-  the structure (the attribute cannot be attached to a `deriving`
+  `attribute [nolint unusedArguments] instReprFinSetSkel.repr`
+  (respectively `attribute [nolint unusedArguments] instReprAnn.repr`),
+  after the structure (the attribute cannot be attached to a `deriving`
   clause).
 
 ### 9. Subobject classifier moved out of `Topos` in v4.33
@@ -206,6 +240,37 @@ genuinely new (decide the adaptation, add a category here).
   `namespace FinSetSkel` has a `Classifier` namespace of its own, so
   the mathlib structure is named in full as
   `CategoryTheory.Classifier`.
+
+### 10. `simp` leaves a `cast`'s proof argument unfolded
+
+- Upstream cause: `Internal/PresheafIRProto/Codes.lean`'s
+  `isFunctorial_pullback` proves its `reindex_comp` field by
+  `simp only [pullback] at d ⊢` followed by
+  `rw [reindex_cast_shape (hh := ...), ← reindex_comp_apply P hP]`. The
+  goal carries a `cast` transporting `d` along the shape equality
+  `hh`, and `reindex_cast_shape` states that transport with the motive
+  `fun u ↦ (P.fam (F.q u.1)).Dir i`.
+- v4.29 symptom: `Did not find an occurrence of the pattern`
+  `P.reindex ?k (cast ⋯ ?d)`, on a target that visibly contains such a
+  subterm. The `simp only [pullback]` rewrites the goal but not the
+  proof argument of `cast`, which simp treats as irrelevant, so the
+  goal's motive stays
+  `fun u ↦ ((P.pullback F.toPresheafPFunctorData).fam ↑u).Dir i`. That
+  is the lemma's motive after delta-reducing `BaseArity.pullback`,
+  below the transparency at which `rw` matches.
+- Adaptation: precede the `rw` with a `change` restating the goal's
+  `cast` at the lemma's motive, leaving the rest of the goal to
+  unification:
+
+  ```lean
+  change _ = P.reindex _ (P.reindex _
+    (cast (congrArg (fun u : F.Shape j'' ↦ (P.fam (F.q u.1)).Dir i)
+      (congrFun (F.isFunctorial.shapeRestr_comp g h) s)) d))
+  ```
+
+  `change` rather than `show`: the `show` tactic is restricted by a
+  linter to indicating intermediate goal states, and this restatement
+  is a transparency adjustment.
 
 ## Updating the patch for a new upstream
 

--- a/geb-lean/scripts/geb-mathlib-backport.patch
+++ b/geb-lean/scripts/geb-mathlib-backport.patch
@@ -1,3 +1,110 @@
+diff --git a/vendor/geb-mathlib/Geb/Internal/ConcreteSyntax.lean b/vendor/geb-mathlib/Geb/Internal/ConcreteSyntax.lean
+index c40e5fe..6c08797 100644
+--- a/vendor/geb-mathlib/Geb/Internal/ConcreteSyntax.lean
++++ b/vendor/geb-mathlib/Geb/Internal/ConcreteSyntax.lean
+@@ -3,6 +3,7 @@ Copyright (c) 2026 Terence Rokop. All rights reserved.
+ Released under Apache 2.0 license as described in the file LICENSE.
+ Authors: Terence Rokop
+ -/
++-- Modified from geb-mathlib by scripts/geb-mathlib-backport.patch.
+ module
+ 
+ public import Geb.Mathlib.Data.W.Basic
+@@ -362,6 +363,8 @@ comments, and canonical forms differ over whether they are retained. -/
+   links : List String := []
+   deriving Repr, DecidableEq, Inhabited
+ 
++attribute [nolint unusedArguments] instReprAnn.repr
++
+ /-- An annotated Geb document. -/
+ abbrev Doc (k : Nat) : Type := Tree k Ann
+ 
+@@ -549,7 +552,7 @@ back is the identity on `Ast k`. -/
+ theorem ofRose_toRose {k : Nat} (a : Ast k) : ofRose a.toRose = a :=
+   ind (motive := fun a ↦ ofRose a.toRose = a)
+     (fun i ↦ by simp only [toRose_leaf, ofRose_node, Fin.foldl_zero])
+-    (fun l r ihl ihr ↦ by rw [toRose_fork, ofRose_snoc, ihl, ihr]) a
++    (fun l r ihl ihr ↦ by beta_reduce; rw [toRose_fork, ofRose_snoc, ihl, ihr]) a
+ 
+ /-- The image of a left spine under `toRose`: the fold that `ofRose`
+ performs on a node's children is undone one child at a time, from the
+diff --git a/vendor/geb-mathlib/Geb/Internal/PresheafIRProto/Basic.lean b/vendor/geb-mathlib/Geb/Internal/PresheafIRProto/Basic.lean
+index b4e0cc6..cbb2cdf 100644
+--- a/vendor/geb-mathlib/Geb/Internal/PresheafIRProto/Basic.lean
++++ b/vendor/geb-mathlib/Geb/Internal/PresheafIRProto/Basic.lean
+@@ -3,6 +3,7 @@ Copyright (c) 2026 Terence Rokop. All rights reserved.
+ Released under Apache 2.0 license as described in the file LICENSE.
+ Authors: Terence Rokop
+ -/
++-- Modified from geb-mathlib by scripts/geb-mathlib-backport.patch.
+ module
+ 
+ public import Geb.Mathlib.Data.PFunctor.Presheaf.Basic
+@@ -468,8 +469,7 @@ def postcompArityHom (F : PresheafPFunctor.{uI, uJ, uA, uB, vI, vJ} I J) (a : F.
+     intro i i' f b
+     change ν.app ⟨i'⟩ (μ.1 i' (F.directionRestr a f b)) = Z'.map f.op (ν.app ⟨i⟩ (μ.1 i b))
+     rw [μ.2 f b]
+-    simp only [← ConcreteCategory.comp_apply]
+-    rw [ν.naturality f.op]⟩
++    exact FunctorToTypes.naturality _ _ ν f.op _⟩
+ 
+ /-- The identity arity hom, of `F` at `a` into `F`'s own arity presheaf. -/
+ def idArityHom (F : PresheafPFunctor.{uI, uJ, uA, uB, vI, vJ} I J) (a : F.A) :
+diff --git a/vendor/geb-mathlib/Geb/Internal/PresheafIRProto/Codes.lean b/vendor/geb-mathlib/Geb/Internal/PresheafIRProto/Codes.lean
+index 20b88f6..2313daf 100644
+--- a/vendor/geb-mathlib/Geb/Internal/PresheafIRProto/Codes.lean
++++ b/vendor/geb-mathlib/Geb/Internal/PresheafIRProto/Codes.lean
+@@ -3,6 +3,7 @@ Copyright (c) 2026 Terence Rokop. All rights reserved.
+ Released under Apache 2.0 license as described in the file LICENSE.
+ Authors: Terence Rokop
+ -/
++-- Modified from geb-mathlib by scripts/geb-mathlib-backport.patch.
+ module
+ 
+ public import Geb.Internal.PresheafIRProto.Basic
+@@ -447,7 +448,6 @@ def reindexHom (hP : P.IsFunctorial) ⦃j j' : J⦄ (g : j' ⟶ j) :
+   naturality := by
+     intro i i' f
+     ext d
+-    simp only [TypeCat.Fun.toFun_apply, comp_apply, ConcreteCategory.hom_ofHom]
+     exact congrFun (hP.reindex_naturality g f.unop).symm d
+ 
+ /-- Reindexing along an `eqToHom` is the transport along the underlying
+@@ -500,9 +500,13 @@ theorem isFunctorial_pullback (hP : P.IsFunctorial)
+       (eqToHom (F.shapeRestr (𝟙 j) s).2 ≫ (𝟙 j) ≫ eqToHom s.2.symm) =
+         eqToHom (((F.shapeRestr (𝟙 j) s).2).trans s.2.symm) by simp,
+       reindex_eqToHom P hP]
++    rfl
+   reindex_comp := by
+     intro j j' j'' g h s i d
+     simp only [pullback] at d ⊢
++    change _ = P.reindex _ (P.reindex _
++      (cast (congrArg (fun u : F.Shape j'' ↦ (P.fam (F.q u.1)).Dir i)
++        (congrFun (F.isFunctorial.shapeRestr_comp g h) s)) d))
+     rw [reindex_cast_shape (hh := congrFun (F.isFunctorial.shapeRestr_comp g h) s),
+       ← reindex_comp_apply P hP]
+     congr 1
+diff --git a/vendor/geb-mathlib/Geb/Internal/PresheafIRProto/Functor.lean b/vendor/geb-mathlib/Geb/Internal/PresheafIRProto/Functor.lean
+index d958e4f..0919ac2 100644
+--- a/vendor/geb-mathlib/Geb/Internal/PresheafIRProto/Functor.lean
++++ b/vendor/geb-mathlib/Geb/Internal/PresheafIRProto/Functor.lean
+@@ -3,6 +3,7 @@ Copyright (c) 2026 Terence Rokop. All rights reserved.
+ Released under Apache 2.0 license as described in the file LICENSE.
+ Authors: Terence Rokop
+ -/
++-- Modified from geb-mathlib by scripts/geb-mathlib-backport.patch.
+ module
+ 
+ public import Geb.Internal.PresheafIRProto.Basic
+@@ -69,7 +70,7 @@ definitional. -/
+ def arityHomEquivNatTrans (F : PresheafPFunctor.{uI, uJ, uA, uB, vI, vJ} I J) (a : F.A)
+     (Z : Iᵒᵖ ⥤ Type uB) : ArityHom F a Z ≃ (arityPresheaf F a ⟶ Z) where
+   toFun μ := natTransOfArityHom F a μ
+-  invFun α := ⟨fun i ↦ α.app ⟨i⟩, fun _ _ f b ↦ NatTrans.naturality_apply α f.op b⟩
++  invFun α := ⟨fun i ↦ α.app ⟨i⟩, fun _ _ f b ↦ FunctorToTypes.naturality _ _ α f.op b⟩
+   left_inv _ := rfl
+   right_inv _ := rfl
+ 
 diff --git a/vendor/geb-mathlib/Geb/Mathlib/CategoryTheory/ElementaryTopos.lean b/vendor/geb-mathlib/Geb/Mathlib/CategoryTheory/ElementaryTopos.lean
 index 970932c..df65d6d 100644
 --- a/vendor/geb-mathlib/Geb/Mathlib/CategoryTheory/ElementaryTopos.lean
@@ -710,7 +817,7 @@ index 3e3a14b..b6d465b 100644
    haveI := P.wUniqueHom B
    Subsingleton.elim _ _
 diff --git a/vendor/geb-mathlib/Geb/Mathlib/Data/PFunctor/Univariate/W.lean b/vendor/geb-mathlib/Geb/Mathlib/Data/PFunctor/Univariate/W.lean
-index b0f82d0..72c12a6 100644
+index db2075e..f713039 100644
 --- a/vendor/geb-mathlib/Geb/Mathlib/Data/PFunctor/Univariate/W.lean
 +++ b/vendor/geb-mathlib/Geb/Mathlib/Data/PFunctor/Univariate/W.lean
 @@ -3,6 +3,7 @@ Copyright (c) 2026 Terence Rokop. All rights reserved.

--- a/geb-lean/vendor/geb-mathlib/Geb/Internal.lean
+++ b/geb-lean/vendor/geb-mathlib/Geb/Internal.lean
@@ -5,6 +5,11 @@ Authors: Terence Rokop
 -/
 module
 
+public import Geb.Internal.CanonicalSExpr
+public import Geb.Internal.ConcreteSyntax
+public import Geb.Internal.PresheafIRProto
+public import Geb.Internal.ReadableSExpr
+
 /-!
 # Geb.Internal — downstream-only content
 

--- a/geb-lean/vendor/geb-mathlib/Geb/Internal/CanonicalSExpr.lean
+++ b/geb-lean/vendor/geb-mathlib/Geb/Internal/CanonicalSExpr.lean
@@ -1,0 +1,441 @@
+/-
+Copyright (c) 2026 Terence Rokop. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Terence Rokop
+-/
+module
+
+public import Geb.Internal.ConcreteSyntax
+public import Mathlib.Data.Fin.VecNotation
+
+/-!
+# Canonical S-expressions as a data type
+
+[FormalSExpr] models canonical S-expressions as a family indexed by the
+octet string representing them, with an atom's index
+`base10 (length xs) ++ [58] ++ xs` and a list's index
+`40 :: xs ++ [41]`. `CSexp` is the non-dependent form of that family and
+`CSexp.render` is the index function: `58`, `40` and `41` being `:`, `(`
+and `)`, the atom index is `Geb.Csexp.printVerbatim` and the list index
+is the parenthesized concatenation of the children's.
+
+The point of carrying the family separately is
+`Csexp.print_eq_render_toCSexp`. `Geb.Csexp.parse_print` says the local
+parser accepts what the local printer emits; it does not say the output
+is a canonical S-expression. Factoring the printer through `CSexp` says
+exactly that, every `CSexp` over ASCII atoms rendering to one by
+construction; the implementation notes below give the condition.
+
+`Rose.toCSexp` is the other map into the family: a rose node becomes the
+list whose head is its label and whose tail is its children, which is
+the S-expression convention for applying a function to arguments and
+agrees with the reading `Geb.Ast.toRose` fixes. It is a different
+encoding of the same trees from `Ast.toCSexp`, and
+`GebTests.Internal.CanonicalSExpr` exhibits a tree they spell
+differently.
+
+## Main definitions
+
+* `CSexp` — canonical S-expressions, the W-type on `CSexp.Shape`.
+* `CSexp.render` — the octet string a term is indexed by.
+* `Ast.toCSexp` — the map underlying the implemented syntax.
+* `Rose.toCSexp` — the label-applied-to-arguments encoding, with
+  `Rose.print` its rendering and `Ast.printViaRose` its composite with
+  the rose bijection.
+* `Rose.parse`, `Ast.parseViaRose` — the parsers matching `Rose.print`
+  and `Ast.printViaRose`, built from `Geb.Rose.parseChildren`, the
+  bounded loop over a node's children that
+  `Geb.Internal.ConcreteSyntax` supplies to every spelling closing a
+  child list with `')'`.
+
+## Main statements
+
+* `Csexp.print_eq_render_toCSexp` — the implemented printer's output is
+  the rendering of a canonical S-expression.
+* `Rose.parse_print`, `Ast.parseViaRose_printViaRose` — the retraction
+  law for the rose spelling, on `Rose` and on `Ast`, with
+  `Rose.format_idem` and `Rose.print_injective` instantiating the
+  generic corollaries at the first.
+
+## Implementation notes
+
+`CSexp.render` is canonical over ASCII atoms only. [RFC9804] counts an
+atom's length in octets where `Csexp.printVerbatim` counts `Char`s, so
+`CSexp.atom ['é']` renders as `1:é` where the format requires `2:é`.
+Every atom this module constructs is ASCII — `Csexp.leafTok`,
+`Csexp.forkTok`, and `Csexp.decOf` applied to a label, whose digits come
+from `Csexp.digitChar` — so `Csexp.print_eq_render_toCSexp` states
+conformance for the trees at hand. An atom type over octets would
+discharge the condition outright.
+
+A rose node's arity is unbounded, so `Geb.Rose.parseChildren` — shared,
+and declared in `Geb.Internal.ConcreteSyntax` for that reason — reads
+until the
+closing parenthesis where `Geb.Csexp.parseStep` reads exactly two at a
+fork and none at a leaf. Two consequences follow. First, the loop needs
+a recursion bound, and it is `Rose.parseAux`'s own `Nat`, used at each
+layer in two roles: undecremented as the loop's bound, and decremented
+as the child parser's fuel. A measure `M` therefore has to satisfy two
+inequalities at every node of `n` children: `M ≥ n + 1`, so that the loop
+reaches the closing parenthesis, and `M > M'` for each child's `M'`, so
+that one decrement still leaves that child enough. Second, the loop
+returns a `List (Rose k)` where a node takes a `Fin n`-indexed tuple;
+`Geb.Rose.ofList` is that transport and `Geb.Rose.ofList_ofFn` the
+equation justifying it.
+
+A node count satisfies both — `1 + Σ` over the children majorises
+`n + 1` because each child counts at least one, and majorises `1 + M'`
+for each child because a sum majorises each summand. The printed length
+is taken not for any greater reach — it exceeds the node count several
+times over — but because `Rose.parse` supplies the input length in any
+case, so taking the bound in those terms leaves no node count to define
+and no counterpart to `Geb.Csexp.size_le_length_printAst` to prove. The
+bound is correspondingly far from tight.
+
+`CSexp.render` concatenates a node's children by `Fin.foldr`, while the
+parser produces them as a `List`; `CSexp.render_list_eq_flatten` states
+their equality, and `Rose.print_node` is the resulting spelling
+equation. `Rose.parseAux_print` rewrites with it, having to read a
+node's own label and children. Where all that is needed of a child is
+that its spelling opens with a parenthesis, the weaker
+`Rose.exists_print_eq_cons` serves: `Rose.parseChildren_print` uses it to
+identify the head of a child's spelling, and `Rose.parseAux_print` to
+bound a node's arity by the length of its children's spellings.
+
+## References
+
+* [FormalSExpr]
+* [RFC9804]
+
+## Tags
+
+canonical S-expression, conformance, parser, retraction, W-type
+-/
+
+@[expose] public section
+
+namespace Geb
+
+namespace CSexp
+
+/-- The node shapes of a canonical S-expression: an atom carrying its
+octets, or a list of a given length. [FormalSExpr]'s `MkCanonicalHint`
+has no shape here; display hints have no counterpart in this
+development, and nothing below emits one. -/
+inductive Shape where
+  /-- An atom, carrying its octets. -/
+  | atom : List Char → Shape
+  /-- A list of the given length. -/
+  | list : Nat → Shape
+  deriving DecidableEq
+
+/-- The child index type: an atom has no children, a list of length `n`
+has `n`. A `def` rather than an `abbrev`, so that instance search at a
+shape already a literal cannot reduce past it to `Empty` or `Fin n` and
+select mathlib's `Classical.choice`-dependent `FinEnum`; deciding
+equality asks for the family at a general shape and reaches the named
+instance either way. -/
+def Arity : Shape → Type
+  | .atom _ => Empty
+  | .list n => Fin n
+
+/-- Every arity is finitely enumerable. -/
+instance instFinEnumArity (s : Shape) : FinEnum (Arity s) :=
+  match s with
+  | .atom _ => finEnumEmpty
+  | .list n => finEnumFin n
+
+end CSexp
+
+/-- Canonical S-expressions, the non-dependent form of [FormalSExpr]'s
+`CanonicalSExpr`. -/
+abbrev CSexp : Type := WType CSexp.Arity
+
+namespace CSexp
+
+/-- An atom carrying the octets `s`. -/
+def atom (s : List Char) : CSexp := WType.mk (.atom s) Empty.elim
+
+/-- A list of `n` elements. -/
+def list {n : Nat} (f : Fin n → CSexp) : CSexp := WType.mk (.list n) f
+
+/-- The octet string a term is indexed by in [FormalSExpr]: an atom
+renders as its verbatim encoding, a list as its elements' renderings
+concatenated between parentheses. -/
+def render : CSexp → List Char :=
+  WType.elim (List Char) fun x ↦
+    match x with
+    | ⟨.atom s, _⟩ => Csexp.printVerbatim s
+    | ⟨.list n, ch⟩ => '(' :: (Fin.foldr n (fun j acc ↦ ch j ++ acc) [] ++ [')'])
+
+@[simp] theorem render_atom (s : List Char) :
+    render (atom s) = Csexp.printVerbatim s := rfl
+
+@[simp] theorem render_list {n : Nat} (f : Fin n → CSexp) :
+    render (list f)
+      = '(' :: (Fin.foldr n (fun j acc ↦ render (f j) ++ acc) [] ++ [')']) :=
+  rfl
+
+/-- `render_list` with the children's renderings as a `List`. `render`
+concatenates a node's children by `Fin.foldr` where the parser produces
+them as a `List`; `Rose.print_node` is proved from this equality. -/
+theorem render_list_eq_flatten {n : Nat} (f : Fin n → CSexp) :
+    render (list f) = '(' :: (((List.ofFn f).map render).flatten ++ [')']) := by
+  rw [render_list]
+  simp [Fin.foldr_eq_finRange_foldr, List.ofFn_eq_map, Function.comp_def]
+
+end CSexp
+
+namespace Ast
+
+/-- The canonical S-expression the implemented syntax prints: a leaf is
+the two-element list `(leaf label)`, a fork the three-element list
+`(fork left right)`. -/
+def toCSexp {k : Nat} : Ast k → CSexp :=
+  WType.elim CSexp fun x ↦
+    match x with
+    | ⟨.leaf i, _⟩ =>
+      CSexp.list ![CSexp.atom Csexp.leafTok, CSexp.atom (Csexp.decOf i.val)]
+    | ⟨.fork, ch⟩ =>
+      CSexp.list ![CSexp.atom Csexp.forkTok, ch (0 : Fin 2), ch (1 : Fin 2)]
+
+@[simp] theorem toCSexp_leaf {k : Nat} (i : Fin k) :
+    (leaf i).toCSexp
+      = CSexp.list ![CSexp.atom Csexp.leafTok, CSexp.atom (Csexp.decOf i.val)] :=
+  rfl
+
+@[simp] theorem toCSexp_fork {k : Nat} (l r : Ast k) :
+    (fork l r).toCSexp
+      = CSexp.list ![CSexp.atom Csexp.forkTok, l.toCSexp, r.toCSexp] :=
+  rfl
+
+end Ast
+
+namespace Rose
+
+/-- The canonical S-expression of a rose tree: the head is the atom of
+the node's label and the tail is its children, so a node is spelled as
+its label applied to its arguments. -/
+def toCSexp {k : Nat} : Rose k → CSexp :=
+  WType.elim CSexp fun x ↦
+    CSexp.list (Fin.cases (CSexp.atom (Csexp.decOf x.1.1.val)) x.2)
+
+@[simp] theorem toCSexp_node {k : Nat} (i : Fin k) {n : Nat}
+    (f : Fin n → Rose k) :
+    (node i f).toCSexp
+      = CSexp.list (Fin.cases (CSexp.atom (Csexp.decOf i.val))
+          fun j ↦ (f j).toCSexp) :=
+  rfl
+
+/-- Print a rose tree as a canonical S-expression. -/
+def print {k : Nat} (r : Rose k) : List Char := CSexp.render r.toCSexp
+
+/-- The spelling of a node: its label as a verbatim atom, then its
+children in order, all between parentheses. -/
+theorem print_node {k : Nat} (i : Fin k) {n : Nat} (f : Fin n → Rose k) :
+    print (node i f)
+      = '(' :: (Csexp.printVerbatim (Csexp.decOf i.val)
+          ++ ((List.ofFn f).map print).flatten ++ [')']) := by
+  rw [print, toCSexp_node, CSexp.render_list_eq_flatten, List.ofFn_succ]
+  simp only [Fin.cases_zero, Fin.cases_succ, List.map_cons, List.flatten_cons,
+    List.map_ofFn, CSexp.render_atom, List.append_assoc]
+  rfl
+
+/-- Every spelling opens with a parenthesis, which is what tells a child
+of a node from the parenthesis that closes the child list. -/
+theorem exists_print_eq_cons {k : Nat} (r : Rose k) :
+    ∃ cs : List Char, print r = '(' :: cs := by
+  obtain ⟨⟨i, n⟩, f⟩ := r
+  exact ⟨_, print_node i f⟩
+
+/-! ## Parser -/
+
+/-- One layer of the recursive descent: read a single s-expression,
+delegating each child to `childParse` and the loop over them to
+`parseChildren` with `loopFuel`. -/
+def parseStep (k : Nat) (childParse : List Char → Option (Rose k × List Char))
+    (loopFuel : Nat) : List Char → Option (Rose k × List Char)
+  | [] => none
+  | c :: cs =>
+    if c = '(' then
+      match Csexp.readVerbatim cs with
+      | some (ds, cs1) =>
+        match Csexp.digitsVal ds with
+        | some m =>
+          if h : m < k then
+            (parseChildren childParse loopFuel cs1).map
+              fun p ↦ (ofList ⟨m, h⟩ p.1, p.2)
+          else none
+        | none => none
+      | none => none
+    else none
+
+/-- Recursive descent over the rose spelling, returning the tree and the
+unconsumed input. The `Nat` argument bounds the recursion, as it does in
+`Geb.Csexp.parseAst`, and serves in two roles at each layer:
+undecremented as the child loop's bound, and decremented as the child
+parser's fuel. `parse` supplies the input length, which `parseAux_print`
+shows admits every tree the printer emits. -/
+def parseAux (k : Nat) : Nat → List Char → Option (Rose k × List Char) :=
+  Nat.rec (motive := fun _ ↦ List Char → Option (Rose k × List Char))
+    (fun _ ↦ none) fun f ih ↦ parseStep k ih (f + 1)
+
+@[simp] theorem parseAux_succ (k f : Nat) :
+    parseAux k (f + 1) = parseStep k (parseAux k f) (f + 1) := rfl
+
+/-- The parser of the rose spelling, rejecting trailing input. -/
+def parse (k : Nat) (cs : List Char) : Option (Rose k) :=
+  match parseAux k cs.length cs with
+  | some (r, []) => some r
+  | _ => none
+
+/-! ## The retraction law -/
+
+/-- The child loop reads back a printed child sequence, given a child
+parser that reads back each of them and one unit of fuel per child plus
+one for the closing parenthesis. -/
+theorem parseChildren_print {k : Nat}
+    (childParse : List Char → Option (Rose k × List Char)) :
+    ∀ (ts : List (Rose k)) (fuel : Nat) (rest : List Char),
+      (∀ t ∈ ts, ∀ r : List Char, childParse (print t ++ r) = some (t, r)) →
+      ts.length < fuel →
+      parseChildren childParse fuel ((ts.map print).flatten ++ ')' :: rest)
+        = some (ts, rest) :=
+  List.rec (motive := fun ts ↦ ∀ (fuel : Nat) (rest : List Char),
+      (∀ t ∈ ts, ∀ r : List Char, childParse (print t ++ r) = some (t, r)) →
+      ts.length < fuel →
+      parseChildren childParse fuel ((ts.map print).flatten ++ ')' :: rest)
+        = some (ts, rest))
+    (fun fuel rest _ hfuel ↦ by
+      obtain ⟨g, rfl⟩ : ∃ g, fuel = g + 1 := ⟨fuel - 1, by omega⟩
+      simp)
+    (fun t ts ih fuel rest hchild hfuel ↦ by
+      obtain ⟨g, rfl⟩ : ∃ g, fuel = g + 1 := ⟨fuel - 1, by omega⟩
+      obtain ⟨body, hbody⟩ := exists_print_eq_cons t
+      have hne : '(' ≠ ')' := by decide
+      have hlt : ts.length < g := by simp at hfuel; omega
+      have hcons : print t ++ ((ts.map print).flatten ++ ')' :: rest)
+          = '(' :: (body ++ ((ts.map print).flatten ++ ')' :: rest)) := by
+        rw [hbody, List.cons_append]
+      rw [List.map_cons, List.flatten_cons, List.append_assoc, hcons,
+        parseChildren_succ_cons _ _ _ _ hne, ← hcons,
+        hchild t (by simp) _, Option.bind_some,
+        ih g rest (fun x hx ↦ hchild x (by simp [hx])) hlt, Option.map_some])
+
+/-- The parser inverts the printer on printed input, given fuel at least
+the printed length, and returns the unconsumed remainder. The module
+docstring's implementation notes say what a measure has to satisfy and
+why this one is taken. -/
+theorem parseAux_print {k : Nat} (r : Rose k) :
+    ∀ (f : Nat) (rest : List Char), (print r).length ≤ f →
+      parseAux k f (print r ++ rest) = some (r, rest) :=
+  WType.rec (motive := fun r ↦ ∀ (f : Nat) (rest : List Char),
+      (print r).length ≤ f → parseAux k f (print r ++ rest) = some (r, rest))
+    (fun s ch ih f rest hf ↦ by
+      obtain ⟨i, n⟩ := s
+      change (print (node i ch)).length ≤ f at hf
+      change parseAux k f (print (node i ch) ++ rest) = some (node i ch, rest)
+      rw [print_node] at hf ⊢
+      cases f with
+      | zero => simp at hf
+      | succ g =>
+        have hL : (((List.ofFn ch).map print).flatten).length ≤ g := by
+          simp only [List.length_cons, List.length_append] at hf
+          omega
+        have hchild : ∀ t ∈ List.ofFn ch, ∀ r : List Char,
+            parseAux k g (print t ++ r) = some (t, r) := by
+          intro t ht r'
+          obtain ⟨j, rfl⟩ := List.mem_ofFn.mp ht
+          refine ih j g r' (le_trans ?_ hL)
+          exact (List.sublist_flatten_of_mem
+            (List.mem_map_of_mem (List.mem_ofFn.mpr ⟨j, rfl⟩))).length_le
+        have hfuel : (List.ofFn ch).length < g + 1 := by
+          have hpos : ∀ x ∈ ((List.ofFn ch).map print).map List.length, 1 ≤ x := by
+            intro x hx
+            obtain ⟨y, hy, rfl⟩ := List.mem_map.mp hx
+            obtain ⟨t, _, rfl⟩ := List.mem_map.mp hy
+            obtain ⟨b, hb⟩ := exists_print_eq_cons t
+            simp [hb]
+          have h := List.length_le_sum_of_one_le _ hpos
+          rw [List.length_map, List.length_map, ← List.length_flatten] at h
+          omega
+        rw [List.cons_append, parseAux_succ]
+        simp only [parseStep, List.append_assoc, List.singleton_append,
+          Csexp.readVerbatim_append, Csexp.digitsVal_decOf, Fin.is_lt,
+          parseChildren_print _ _ _ _ hchild hfuel, Option.map_some,
+          if_true, dif_pos, Fin.eta, ofList_ofFn]) r
+
+/-- The retraction law for the rose spelling: printing a rose tree and
+parsing the result returns that tree. -/
+theorem parse_print {k : Nat} (r : Rose k) : parse k (print r) = some r := by
+  unfold parse
+  rw [show print r = print r ++ [] by simp,
+    parseAux_print r _ [] (by simp)]
+
+/-! ## The generic corollaries, instantiated here -/
+
+/-- `parse_print` in the form the generic corollaries consume. -/
+theorem retraction (k : Nat) : Retraction (parse k) (print (k := k)) :=
+  parse_print
+
+/-- `Geb.format_idem` at the rose spelling. -/
+theorem format_idem (k : Nat) (c : List Char) :
+    (format (parse k) print c).bind (format (parse k) print)
+      = format (parse k) print c :=
+  Geb.format_idem _ _ (retraction k) c
+
+/-- `Geb.print_injective` at the rose spelling. -/
+theorem print_injective (k : Nat) : Function.Injective (print (k := k)) :=
+  Geb.print_injective _ _ (retraction k)
+
+end Rose
+
+namespace Ast
+
+/-- Print an abstract syntax tree through the rose presentation. Not the
+same spelling as `Geb.Csexp.print`, which prints from `Ast` directly;
+see `GebTests.Internal.CanonicalSExpr`. -/
+def printViaRose {k : Nat} (a : Ast k) : List Char := Rose.print a.toRose
+
+/-- Parse an abstract syntax tree from the rose spelling, by parsing a
+rose tree and crossing the bijection. -/
+def parseViaRose (k : Nat) (cs : List Char) : Option (Ast k) :=
+  (Rose.parse k cs).map ofRose
+
+/-- The retraction law for the rose spelling read as a syntax on `Ast`:
+the rose retraction transported along `Ast.ofRose_toRose`. -/
+theorem parseViaRose_printViaRose {k : Nat} (a : Ast k) :
+    parseViaRose k (printViaRose a) = some a := by
+  rw [parseViaRose, printViaRose, Rose.parse_print, Option.map_some,
+    ofRose_toRose]
+
+end Ast
+
+namespace Csexp
+
+/-- The implemented printer's output is the rendering of a canonical
+S-expression, hence a canonical S-expression by construction. -/
+theorem printAst_eq_render_toCSexp {k : Nat} (a : Ast k) :
+    printAst a = CSexp.render a.toCSexp :=
+  Ast.ind (motive := fun a ↦ printAst a = CSexp.render a.toCSexp)
+    (fun i ↦ by
+      simp only [printAst_leaf, Ast.toCSexp_leaf, CSexp.render_list,
+        Fin.foldr_succ, Fin.foldr_zero, Matrix.cons_val_zero,
+        Matrix.cons_val_succ, CSexp.render_atom, List.append_nil,
+        List.append_assoc])
+    (fun l r ihl ihr ↦ by
+      simp only [printAst_fork, Ast.toCSexp_fork, CSexp.render_list,
+        Fin.foldr_succ, Fin.foldr_zero, Matrix.cons_val_zero,
+        Matrix.cons_val_succ, CSexp.render_atom, List.append_nil,
+        List.append_assoc, ihl, ihr]) a
+
+/-- `printAst_eq_render_toCSexp` at the syntax's printer. This is the
+conformance statement `parse_print` does not make: that law says only
+that the local parser accepts the local printer's output. -/
+theorem print_eq_render_toCSexp {k : Nat} (a : Ast k) :
+    print a = CSexp.render a.toCSexp :=
+  printAst_eq_render_toCSexp a
+
+end Csexp
+
+end Geb

--- a/geb-lean/vendor/geb-mathlib/Geb/Internal/ConcreteSyntax.lean
+++ b/geb-lean/vendor/geb-mathlib/Geb/Internal/ConcreteSyntax.lean
@@ -1,0 +1,973 @@
+/-
+Copyright (c) 2026 Terence Rokop. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Terence Rokop
+-/
+-- Modified from geb-mathlib by scripts/geb-mathlib-backport.patch.
+module
+
+public import Geb.Mathlib.Data.W.Basic
+
+/-!
+# Concrete syntaxes for the Geb AST (prototype)
+
+The abstract syntax is the initial algebra of `F X = Fin k + X × X`.
+A concrete syntax is a pair `parse : C → Option D`, `print : D → C`
+satisfying the retraction law `parse (print d) = some d`; formatter
+idempotence and injectivity of `print` are corollaries, proved once
+here for every syntax.
+
+This module carries the format-independent core (the abstract syntax,
+its annotated form, the rose presentation), one worked concrete
+syntax, the canonical S-expression form of [RFC9804], and the parser
+machinery more than one spelling shares: the decimal layer and the
+bounded loop over a rose node's children.
+
+Every tree type here is a `WType`, so its recursion is carried by
+`WType.elim`, `WType.para` and `WType.rec`.
+
+## Main definitions
+
+* `Ast` — the abstract syntax, the W-type on `Ast.Shape`.
+* `Ast.toRose`, `Ast.ofRose` — the two directions of the rose
+  presentation's bijection with `Ast`.
+* `Tree` — the abstract syntax with every node decorated by an `A`,
+  with `Tree.map`, `Tree.extract`, `Tree.duplicate` its functor and
+  comonad structure and `Tree.erase` the forgetful map to `Ast`.
+* `Ann`, `Doc` — the annotation vocabulary and the annotated document
+  type `Tree k Ann`, with `Ast.trivialDoc` the empty decoration.
+* `Rose` — the rose-tree presentation of the same fixed point, with
+  `Rose.node` and `Rose.ofList` its constructors and `Rose.snoc`
+  appending a child to one.
+* `Rose.parseChildren` — the bounded loop reading a rose node's
+  children up to the closing parenthesis, shared by every spelling of
+  the rose presentation that closes a child list with `')'`.
+* `Retraction`, `format` — the law skeleton a concrete syntax proves.
+* `Csexp.print`, `Csexp.parse` — the [RFC9804] canonical S-expression
+  syntax.
+
+## Main statements
+
+* `Ast.ind` — the two-constructor induction principle on `Ast`.
+* `Ast.ofRose_toRose`, `Ast.toRose_ofRose` — the rose presentation is
+  a bijection.
+* `Rose.ofList_ofFn` — a rose node rebuilt by `Rose.ofList` from the
+  list of its children is that node. It is the equation justifying the
+  transport a variable-arity parser needs.
+* `Csexp.parse_print` — the retraction law for the S-expression syntax,
+  from `Csexp.parseAst_printAst` and `Csexp.size_le_length_printAst`.
+* `Csexp.readVerbatim_append` — a printed atom reads back whole,
+  whatever it contains.
+* `Ast.erase_trivialDoc` — the trivial decoration is erased away.
+* `Csexp.format_idem`, `Csexp.print_injective` — the generic corollaries
+  instantiated, which is what shows the law skeleton applies to a
+  syntax rather than only to a hypothetical one.
+* `Geb.format_idem`, `Geb.print_injective` — the corollaries of a
+  retraction, proved once for every syntax.
+* `Tree.extract_duplicate`, `Tree.map_extract_duplicate`,
+  `Tree.duplicate_duplicate` — the comonad laws on the annotated
+  syntax, with `Tree.map_id` and `Tree.map_map` the functor laws they
+  presuppose and `Tree.extract_map`, `Tree.duplicate_map` the
+  naturality of the two structure maps.
+
+## Implementation notes
+
+`Csexp.parseAst` recurses on an explicit `Nat` bound rather than on its
+input: the recursion descends only through the remainder each call
+returns, which is not a form Lean's structural recursion accepts.
+`Csexp.parse` supplies the input length, and `Csexp.size_le_length_printAst`
+shows that bound admits every tree the printer emits.
+
+The decimal layer is written here rather than reused, and the reason is
+`Classical.choice` throughout. mathlib's `Nat.digits` depends on it.
+Core supplies the whole layer — `Nat.toDigits`, which agrees with
+`Csexp.decOf` pointwise on base 10, the decoder `Nat.ofDigitChars`, and
+the same round trip in total form, `Nat.ofDigitChars_ten_toDigits`,
+where `Csexp.digitsVal_decOf` is partial. It cannot be used. That round
+trip depends on `Classical.choice`, and so does every lemma descending
+from `toDigits b n` to `toDigits b (n / b)` — `Nat.toDigits_eq_if` and
+`Nat.toDigits_of_base_le` — so it can be neither imported nor reproved.
+The boundary is not depth but direction: the printer's descent lemmas
+are choice-dependent, while the decoder's recursion equations and the
+digit-character lemmas are not.
+
+`finEnumFin` and `finEnumEmpty` are named because mathlib's `FinEnum`
+instances for `Fin n` and `Empty` are `Classical.choice`-dependent.
+
+`Rose.Arity` is an `abbrev` because a proof matching a child function's
+type against a lemma stated at `Fin n → _` needs it reducible;
+`Ast.ofRose_snoc` and `Ast.toRose_ofRose` are the two here, and
+`Rose.parseAux_print` and `Rsexp.parseAux_print` the third and fourth,
+downstream. Its docstring names all
+four and says what the reducibility costs.
+
+`Ast.Arity` and `Tree.Arity` are plain `def`s, which keeps instance
+search from reducing past them at a literal shape. No demand here
+reaches that case; the `def`s guard against one arising later, which
+would otherwise resolve through mathlib's `Classical.choice`-dependent
+`FinEnum.fin`.
+
+## References
+
+* [RFC9804]
+* [UustaluVene2011]
+
+## Tags
+
+abstract syntax, concrete syntax, W-type, retraction, S-expression
+-/
+
+universe uA uB uC
+
+@[expose] public section
+
+namespace Geb
+
+/-! ## Choice-free finite enumerations
+
+Every `Arity` family below is finitely enumerable, which is what lets
+`WType.instDecidableEq` decide equality of the corresponding tree type.
+The `#guard`s in the three `GebTests` syntax modules decide equality at
+`Ast k`, at `Tree k Ann` and at `Rose k`. The two enumerations are named
+because mathlib's `FinEnum.fin` and `FinEnum.empty` are built by
+`FinEnum.ofList`, whose proof obligations depend on `Classical.choice`,
+which [CONTRIBUTING.md § Constructive-only](../../CONTRIBUTING.md)
+forbids. Naming them suffices for that consumer: `WType.instDecidableEq`
+asks for a family at a general shape, where nothing reduces, so equality
+is decided choice-free however the family is declared — `Rose.Arity` is
+an `abbrev` and equality at `Rose k` is choice-free. What a reducible
+family gives up is `FinEnum` demanded at a shape already a literal,
+where search reduces past it to `Empty` or `Fin n` and selects mathlib's.
+`Ast.Arity` and `Tree.Arity` are plain `def`s so that such a demand
+would reach the named instance; nothing here makes one. Neither
+construction is specific to syntax. -/
+
+/-- `Fin n` enumerated by the identity equivalence. -/
+@[instance_reducible] def finEnumFin (n : Nat) : FinEnum (Fin n) := ⟨n, Equiv.refl (Fin n)⟩
+
+/-- `Empty` enumerated by the empty equivalence. -/
+@[instance_reducible] def finEnumEmpty : FinEnum Empty :=
+  ⟨0, ⟨Empty.elim, Fin.elim0, fun e ↦ e.elim, fun i ↦ i.elim0⟩⟩
+
+/-! ## Abstract syntax -/
+
+namespace Ast
+
+/-- The node shapes of the Geb abstract syntax: a leaf carrying a label
+in `Fin k`, or a fork. -/
+inductive Shape (k : Nat) where
+  /-- A leaf, labelled by an element of `Fin k`. -/
+  | leaf : Fin k → Shape k
+  /-- A fork, with two children. -/
+  | fork : Shape k
+  deriving DecidableEq
+
+/-- The child index type of each shape: a leaf has none, a fork has two.
+`Fin 2` rather than `Bool`, so that every non-empty arity here is
+enumerated by `finEnumFin`. A `def` rather than an `abbrev`: reducible,
+instance search at a concrete shape would whnf past this family to
+`Empty` or `Fin 2` and select mathlib's `Classical.choice`-dependent
+`FinEnum`, never reaching `instFinEnumArity`. -/
+def Arity {k : Nat} : Shape k → Type
+  | .leaf _ => Empty
+  | .fork => Fin 2
+
+/-- Every arity is finitely enumerable. -/
+instance instFinEnumArity {k : Nat} (s : Shape k) : FinEnum (Arity s) :=
+  match s with
+  | .leaf _ => finEnumEmpty
+  | .fork => finEnumFin 2
+
+end Ast
+
+/-- The Geb abstract syntax: the initial algebra of `F X = Fin k + X × X`,
+presented as the W-type on `Ast.Shape k`. -/
+abbrev Ast (k : Nat) : Type := WType (Ast.Arity (k := k))
+
+namespace Ast
+
+/-- A leaf labelled `i`. -/
+def leaf {k : Nat} (i : Fin k) : Ast k :=
+  WType.mk (.leaf i) Empty.elim
+
+/-- A fork with left child `l` and right child `r`. -/
+def fork {k : Nat} (l r : Ast k) : Ast k :=
+  WType.mk .fork fun b : Fin 2 ↦ Fin.cases l (fun _ ↦ r) b
+
+/-- The number of nodes. -/
+def size {k : Nat} : Ast k → Nat :=
+  WType.elim Nat fun x ↦
+    match x with
+    | ⟨.leaf _, _⟩ => 1
+    | ⟨.fork, ch⟩ => 1 + ch (0 : Fin 2) + ch (1 : Fin 2)
+
+/-- Induction on `Ast` in its two-constructor presentation, so that a
+proof driven by it need not mention the underlying shape and arity. -/
+theorem ind {k : Nat} {motive : Ast k → Prop}
+    (leaf : ∀ i, motive (leaf i))
+    (fork : ∀ l r, motive l → motive r → motive (fork l r)) :
+    ∀ t, motive t :=
+  WType.rec (motive := motive) fun s f ih ↦
+    match s, f, ih with
+    | .leaf i, f, _ => by
+        have : f = Empty.elim := funext (fun e ↦ e.elim)
+        subst this; exact leaf i
+    | .fork, f, ih => by
+        have : (fun b : Fin 2 ↦ Fin.cases (f (0 : Fin 2))
+            (fun _ ↦ f (1 : Fin 2)) b) = f :=
+          funext fun b ↦ match b with
+            | ⟨0, _⟩ => rfl
+            | ⟨1, _⟩ => rfl
+        exact this ▸ fork (f (0 : Fin 2)) (f (1 : Fin 2))
+          (ih (0 : Fin 2)) (ih (1 : Fin 2))
+
+@[simp] theorem size_leaf {k : Nat} (i : Fin k) : (leaf i).size = 1 := rfl
+
+@[simp] theorem size_fork {k : Nat} (l r : Ast k) :
+    (fork l r).size = 1 + l.size + r.size := rfl
+
+end Ast
+
+/-! ## Annotated syntax -/
+
+namespace Tree
+
+/-- The node shapes of the annotated syntax: an `Ast.Shape` paired with
+the decoration carried at that node. -/
+abbrev Shape (k : Nat) (A : Type uA) : Type uA := A × Ast.Shape k
+
+/-- The child index type of an annotated shape: that of the underlying
+`Ast.Shape`, since decorating a node does not change its children. A
+`def` rather than an `abbrev`, for the reason `Ast.Arity` gives. -/
+def Arity {k : Nat} {A : Type uA} (s : Shape k A) : Type := Ast.Arity s.2
+
+/-- Every annotated arity is finitely enumerable. -/
+instance instFinEnumArity {k : Nat} {A : Type uA} (s : Shape k A) :
+    FinEnum (Arity s) :=
+  Ast.instFinEnumArity s.2
+
+end Tree
+
+/-- `Ast k` with every node decorated by an `A`: the initial algebra of
+`X ↦ A × F X`. The initial algebra rather than the terminal coalgebra,
+because syntax trees are finite; the cofree comonad on `F` admits
+infinitely deep trees and is the home of execution traces, not syntax. -/
+abbrev Tree (k : Nat) (A : Type uA) : Type uA :=
+  WType (Tree.Arity (k := k) (A := A))
+
+namespace Tree
+
+/-- Relabel every node along `f`. -/
+def map {k : Nat} {A : Type uA} {B : Type uB} (f : A → B) :
+    Tree k A → Tree k B :=
+  WType.elim (Tree k B) fun x ↦ WType.mk (f x.1.1, x.1.2) x.2
+
+/-- The comonad counit: the decoration at the root. -/
+def extract {k : Nat} {A : Type uA} (t : Tree k A) : A :=
+  (WType.toSigma t).1.1
+
+/-- The comonad comultiplication: relabel each node with the annotated
+subtree rooted at it, in the sense [UustaluVene2011] gives the
+comultiplication of the cofree recursive comonad. A paramorphism, since
+the new decoration at a node is that node's own subtree. -/
+def duplicate {k : Nat} {A : Type uA} : Tree k A → Tree k (Tree k A) :=
+  WType.para (Tree k (Tree k A)) fun x ↦
+    WType.mk (WType.mk x.1 fun b ↦ (x.2 b).1, x.1.2) fun b ↦ (x.2 b).2
+
+/-- Forget every decoration, recovering the bare tree. This is the fold
+induced by the second projection `A × F X → F X`, not the comonad
+counit. -/
+def erase {k : Nat} {A : Type uA} : Tree k A → Ast k :=
+  WType.elim (Ast k) fun x ↦ WType.mk x.1.2 x.2
+
+@[simp] theorem map_mk {k : Nat} {A : Type uA} {B : Type uB} (f : A → B)
+    (s : Shape k A) (ch : Arity s → Tree k A) :
+    map f (WType.mk s ch) = WType.mk (f s.1, s.2) fun b ↦ map f (ch b) :=
+  rfl
+
+@[simp] theorem extract_mk {k : Nat} {A : Type uA} (s : Shape k A)
+    (ch : Arity s → Tree k A) : extract (WType.mk s ch) = s.1 :=
+  rfl
+
+@[simp] theorem duplicate_mk {k : Nat} {A : Type uA} (s : Shape k A)
+    (ch : Arity s → Tree k A) :
+    duplicate (WType.mk s ch)
+      = WType.mk (WType.mk s ch, s.2) fun b ↦ duplicate (ch b) :=
+  WType.para_mk _ s ch
+
+/-- The first functor law: relabelling along the identity is the
+identity. -/
+theorem map_id {k : Nat} {A : Type uA} (t : Tree k A) : map id t = t :=
+  WType.rec (motive := fun t ↦ map id t = t)
+    (fun s ch ih ↦ by simp only [map_mk, id_eq]; exact congrArg _ (funext ih)) t
+
+/-- The second functor law: relabelling twice is relabelling along the
+composite. -/
+theorem map_map {k : Nat} {A : Type uA} {B : Type uB} {C : Type uC}
+    (f : A → B) (g : B → C) (t : Tree k A) :
+    map g (map f t) = map (g ∘ f) t :=
+  WType.rec (motive := fun t ↦ map g (map f t) = map (g ∘ f) t)
+    (fun s ch ih ↦ by simp only [map_mk, Function.comp_apply]
+                      exact congrArg _ (funext ih)) t
+
+/-- Naturality of the counit: reading the root decoration commutes with
+relabelling. -/
+theorem extract_map {k : Nat} {A : Type uA} {B : Type uB} (f : A → B)
+    (t : Tree k A) : extract (map f t) = f (extract t) := by
+  cases t with
+  | mk s ch => rfl
+
+/-- Naturality of the comultiplication: redecorating commutes with
+relabelling, the relabelling acting on each subtree. -/
+theorem duplicate_map {k : Nat} {A : Type uA} {B : Type uB} (f : A → B)
+    (t : Tree k A) :
+    duplicate (map f t) = map (map f) (duplicate t) :=
+  WType.rec (motive := fun t ↦ duplicate (map f t) = map (map f) (duplicate t))
+    (fun s ch ih ↦ by simp only [map_mk, duplicate_mk]
+                      exact congrArg _ (funext ih)) t
+
+/-- The first comonad law: the subtree redecorating the root is the whole
+tree. -/
+theorem extract_duplicate {k : Nat} {A : Type uA} (t : Tree k A) :
+    extract (duplicate t) = t := by
+  cases t with
+  | mk s ch => simp
+
+/-- The second comonad law: taking each node's subtree and then keeping
+only its root decoration recovers the original decoration. -/
+theorem map_extract_duplicate {k : Nat} {A : Type uA} (t : Tree k A) :
+    map extract (duplicate t) = t :=
+  WType.rec (motive := fun t ↦ map extract (duplicate t) = t)
+    (fun s ch ih ↦ by simp only [duplicate_mk, map_mk, extract_mk]
+                      exact congrArg _ (funext ih)) t
+
+/-- The third comonad law, coassociativity of the redecoration map. -/
+theorem duplicate_duplicate {k : Nat} {A : Type uA} (t : Tree k A) :
+    duplicate (duplicate t) = map duplicate (duplicate t) :=
+  WType.rec (motive := fun t ↦ duplicate (duplicate t) = map duplicate (duplicate t))
+    (fun s ch ih ↦ by simp only [duplicate_mk, map_mk]
+                      rw [duplicate_mk]
+                      exact congrArg _ (funext ih)) t
+
+end Tree
+
+/-- The annotation vocabulary carried at a node. Durable metadata is an
+annotation value, never a lexical comment: generic parsers discard
+comments, and canonical forms differ over whether they are retained. -/
+@[ext] structure Ann where
+  /-- A name for the annotated occurrence. -/
+  name : Option String := none
+  /-- Prose documentation of the annotated occurrence. -/
+  doc : Option String := none
+  /-- References to material bearing on the annotated occurrence. -/
+  links : List String := []
+  deriving Repr, DecidableEq, Inhabited
+
+attribute [nolint unusedArguments] instReprAnn.repr
+
+/-- An annotated Geb document. -/
+abbrev Doc (k : Nat) : Type := Tree k Ann
+
+namespace Ast
+
+/-- Decorate every node with the empty annotation. -/
+def trivialDoc {k : Nat} : Ast k → Doc k :=
+  WType.elim (Doc k) fun x ↦ WType.mk (({} : Ann), x.1) x.2
+
+/-- Decorating every node with the empty annotation and then erasing is
+the identity. -/
+theorem erase_trivialDoc {k : Nat} (a : Ast k) :
+    Tree.erase a.trivialDoc = a :=
+  WType.rec (motive := fun a ↦ Tree.erase (trivialDoc a) = a)
+    (fun s ch ih ↦ by simp only [trivialDoc, WType.elim_mk]
+                      exact congrArg _ (funext ih)) a
+
+end Ast
+
+/-! ## The rose presentation and its bijection -/
+
+namespace Rose
+
+/-- The node shapes of the rose presentation: a label in `Fin k` and a
+number of children. -/
+abbrev Shape (k : Nat) : Type := Fin k × Nat
+
+/-- The child index type of a rose shape. Reducible, and this is the one
+family that has to be: `simp` and `rw` match at reducible transparency,
+so with a plain `def` a child function whose type reads
+`Rose.Arity (i, n) → _` in a goal fails to unify with a lemma stated at
+`Fin n → _`, and the proofs of `Ast.ofRose_snoc` and
+`Ast.toRose_ofRose` fail here, `Geb.Rose.parseAux_print`'s and
+`Geb.Rsexp.parseAux_print`'s downstream.
+The cost is that `instFinEnumArity` below is unreachable at a concrete
+shape: instance search reduces past this family to `Fin n` and selects
+mathlib's `Classical.choice`-dependent `FinEnum.fin`. Deciding equality
+at a `Rose k` does not incur that, `WType.instDecidableEq` asking for
+the family at a general shape and so reaching the named instance; what
+would pay it is a demand for `FinEnum` at a shape already a literal.
+`Ast.Arity` and `Tree.Arity` are plain `def`s, at which search reaches
+the named instance either way. -/
+abbrev Arity {k : Nat} (s : Shape k) : Type := Fin s.2
+
+/-- Every rose arity is finitely enumerable. Named for the same reason
+as the other two: `WType.instDecidableEq` asks for this family at a
+general shape, so deciding equality at a `Rose k` goes through this
+instance rather than mathlib's `Classical.choice`-dependent
+`FinEnum.fin`. All three `GebTests` syntax modules decide it. A `#guard`
+is not a declaration, so `GebMeta.detectNonstandardAxiom` would not
+catch a leak there. -/
+instance instFinEnumArity {k : Nat} (s : Shape k) : FinEnum (Arity s) :=
+  finEnumFin s.2
+
+end Rose
+
+/-- The rose-tree presentation: a label in `Fin k` and a finite sequence
+of children, satisfying the same fixed-point equation as `Ast k`. -/
+abbrev Rose (k : Nat) : Type := WType (Rose.Arity (k := k))
+
+namespace Rose
+
+/-- Append `t` to the children of `r`, keeping `r`'s label. -/
+def snoc {k : Nat} (r t : Rose k) : Rose k :=
+  match r with
+  | ⟨(i, n), f⟩ => WType.mk (i, n + 1) (Fin.snoc f t)
+
+/-- The node with label `i` and children `f`. -/
+def node {k : Nat} (i : Fin k) {n : Nat} (f : Fin n → Rose k) : Rose k :=
+  WType.mk (i, n) f
+
+@[simp] theorem snoc_node {k : Nat} (i : Fin k) {n : Nat}
+    (f : Fin n → Rose k) (t : Rose k) :
+    snoc (node i f) t = node i (Fin.snoc f t) := rfl
+
+/-- The node with label `i` whose children are the entries of `ts`. The
+arity is read off the list, so this is the constructor available to a
+parser, which learns a node's children one at a time and its arity only
+when the list ends. -/
+def ofList {k : Nat} (i : Fin k) (ts : List (Rose k)) : Rose k :=
+  node i fun j : Fin ts.length ↦ ts.get j
+
+/-- `ofList` against a tuple presentation of the same children. The list
+is a parameter rather than `List.ofFn f`, which is what makes the arity
+equation substitutable: `n = (List.ofFn f).length` cannot be substituted,
+`n` occurring on the right through the type of `f`. -/
+theorem ofList_eq {k n : Nat} (i : Fin k) (ts : List (Rose k))
+    (f : Fin n → Rose k) (h : n = ts.length)
+    (hf : ∀ j : Fin n, ts.get (j.cast h) = f j) :
+    ofList i ts = node i f := by
+  subst h
+  exact congrArg (node i) (funext hf)
+
+/-- Rebuilding a node from the list of its children recovers it. This is
+the equation justifying the transport a variable-arity parser needs and
+a fixed-arity one does not: the loop that reads the children returns a
+`List`, while the node takes a `Fin n`-indexed tuple. -/
+theorem ofList_ofFn {k n : Nat} (i : Fin k) (f : Fin n → Rose k) :
+    ofList i (List.ofFn f) = node i f :=
+  ofList_eq i _ f List.length_ofFn.symm fun j ↦ by simp
+
+end Rose
+
+namespace Rose
+
+/-- Read children until the closing parenthesis, delegating each to
+`childParse`. The `Nat` argument bounds the loop: it recurses on the
+remainder `childParse` returns, which is not a form Lean's structural
+recursion accepts. The loop consumes one unit per child and one on the
+closing parenthesis, so a node of `n` children needs `n + 1`.
+Shared by every spelling that closes a child list with `')'`. -/
+def parseChildren {k : Nat}
+    (childParse : List Char → Option (Rose k × List Char)) :
+    Nat → List Char → Option (List (Rose k) × List Char) :=
+  Nat.rec (motive := fun _ ↦ List Char → Option (List (Rose k) × List Char))
+    (fun _ ↦ none)
+    fun _ ih cs ↦
+      match cs with
+      | [] => none
+      | c :: cs' =>
+        if c = ')' then some ([], cs')
+        else (childParse (c :: cs')).bind fun p ↦
+          (ih p.2).map fun q ↦ (p.1 :: q.1, q.2)
+
+@[simp] theorem parseChildren_succ_close {k : Nat}
+    (childParse : List Char → Option (Rose k × List Char)) (f : Nat)
+    (rest : List Char) :
+    parseChildren childParse (f + 1) (')' :: rest) = some ([], rest) := rfl
+
+theorem parseChildren_succ_cons {k : Nat}
+    (childParse : List Char → Option (Rose k × List Char)) (f : Nat)
+    (c : Char) (cs : List Char) (h : c ≠ ')') :
+    parseChildren childParse (f + 1) (c :: cs)
+      = (childParse (c :: cs)).bind fun p ↦
+          (parseChildren childParse f p.2).map fun q ↦ (p.1 :: q.1, q.2) :=
+  if_neg h
+
+end Rose
+
+namespace Ast
+
+/-- The binary-to-rose direction. A rose node is read as a curried
+function: its label is the function and its children are the arguments
+it is applied to, in order. A fork `(l, r)` is read as the application
+of `l` to `r`. Application of a curried function is left-associative, so
+`l` carries the label together with every argument but the last, and `r`
+is the last argument alone — that is, the child sequence is consumed as
+a snoclist. Reading application to the right instead gives a different
+and equally valid bijection, so the choice has to be fixed. -/
+def toRose {k : Nat} : Ast k → Rose k :=
+  WType.elim (Rose k) fun x ↦
+    match x with
+    | ⟨.leaf i, _⟩ => Rose.node i Fin.elim0
+    | ⟨.fork, ch⟩ => Rose.snoc (ch (0 : Fin 2)) (ch (1 : Fin 2))
+
+/-- The rose-to-binary direction, folding a node's children into the left
+spine that carries the label at its head. -/
+def ofRose {k : Nat} : Rose k → Ast k :=
+  WType.elim (Ast k) fun x ↦
+    Fin.foldl x.1.2 (fun acc j ↦ fork acc (x.2 j)) (leaf x.1.1)
+
+@[simp] theorem toRose_leaf {k : Nat} (i : Fin k) :
+    (leaf i).toRose = Rose.node i Fin.elim0 := rfl
+
+@[simp] theorem toRose_fork {k : Nat} (l r : Ast k) :
+    (fork l r).toRose = Rose.snoc l.toRose r.toRose := rfl
+
+@[simp] theorem ofRose_node {k : Nat} (i : Fin k) {n : Nat} (f : Fin n → Rose k) :
+    ofRose (Rose.node i f) =
+      Fin.foldl n (fun acc j ↦ fork acc (ofRose (f j))) (leaf i) :=
+  rfl
+
+/-- Appending a child to a rose node appends a fork on the binary side,
+which is the step `Ast.ofRose_toRose` turns on. -/
+theorem ofRose_snoc {k : Nat} (r t : Rose k) :
+    ofRose (Rose.snoc r t) = fork (ofRose r) (ofRose t) := by
+  obtain ⟨⟨i, n⟩, f⟩ := r
+  change ofRose (Rose.snoc (Rose.node i f) t)
+      = fork (ofRose (Rose.node i f)) (ofRose t)
+  simp only [Rose.snoc_node, ofRose_node, Fin.foldl_succ_last, Fin.snoc_castSucc,
+    Fin.snoc_last]
+
+/-- One half of the rose/binary bijection: converting to a rose tree and
+back is the identity on `Ast k`. -/
+theorem ofRose_toRose {k : Nat} (a : Ast k) : ofRose a.toRose = a :=
+  ind (motive := fun a ↦ ofRose a.toRose = a)
+    (fun i ↦ by simp only [toRose_leaf, ofRose_node, Fin.foldl_zero])
+    (fun l r ihl ihr ↦ by beta_reduce; rw [toRose_fork, ofRose_snoc, ihl, ihr]) a
+
+/-- The image of a left spine under `toRose`: the fold that `ofRose`
+performs on a node's children is undone one child at a time, from the
+last. -/
+theorem toRose_foldl {k : Nat} (i : Fin k) :
+    ∀ (n : Nat) (g : Fin n → Ast k),
+      (Fin.foldl n (fun acc j ↦ fork acc (g j)) (leaf i)).toRose
+        = Rose.node i fun j ↦ (g j).toRose :=
+  Nat.rec
+    (motive := fun n ↦ ∀ g : Fin n → Ast k,
+      (Fin.foldl n (fun acc j ↦ fork acc (g j)) (leaf i)).toRose
+        = Rose.node i fun j ↦ (g j).toRose)
+    (fun g ↦ by
+      simp only [Fin.foldl_zero, toRose_leaf]
+      exact congrArg _ (funext fun j ↦ j.elim0))
+    (fun n ih g ↦ by
+      simp only [Fin.foldl_succ_last, toRose_fork,
+        ih (fun j ↦ g j.castSucc), Rose.snoc_node]
+      exact congrArg _ (Fin.snoc_init_self fun j ↦ (g j).toRose))
+
+/-- The other half of the rose/binary bijection: converting from a rose
+tree and back is the identity on `Rose k`. -/
+theorem toRose_ofRose {k : Nat} (r : Rose k) : (ofRose r).toRose = r :=
+  WType.rec (motive := fun r ↦ (ofRose r).toRose = r)
+    (fun s f ih ↦ by
+      obtain ⟨i, n⟩ := s
+      change (ofRose (Rose.node i f)).toRose = Rose.node i f
+      rw [ofRose_node, toRose_foldl]
+      exact congrArg _ (funext ih)) r
+
+end Ast
+
+/-! ## Law skeletons for a concrete syntax -/
+
+section Laws
+
+variable {D : Type uA} {C : Type uB} (parse : C → Option D) (print : D → C)
+
+/-- The document-level retraction law: the only law a syntax must prove. -/
+def Retraction : Prop := ∀ d : D, parse (print d) = some d
+
+/-- The formatter, defined where parsing succeeds. -/
+def format (c : C) : Option C := (parse c).map print
+
+/-- Formatter idempotence, the first corollary of a retraction:
+reformatting formatted input changes nothing. -/
+theorem format_idem (hr : Retraction parse print) (c : C) :
+    (format parse print c).bind (format parse print)
+      = format parse print c := by
+  unfold format
+  cases h : parse c with
+  | none => simp
+  | some d => simp [hr d]
+
+/-- Injectivity of the printer, the second corollary of a retraction: a
+syntax that can be parsed back cannot spell two documents alike. -/
+theorem print_injective (hr : Retraction parse print) :
+    Function.Injective print := by
+  intro d1 d2 h
+  have h1 := hr d1
+  rw [h, hr d2] at h1
+  exact (Option.some.inj h1).symm
+
+end Laws
+
+/-! ## A concrete syntax: RFC 9804 canonical S-expressions -/
+
+namespace Csexp
+
+/-! ### Decimal digits -/
+
+/-- The ASCII character for a decimal digit; meaningful for `d < 10`. -/
+def digitChar (d : Nat) : Char := Char.ofNat (48 + d)
+
+/-- The decimal value of an ASCII digit character. -/
+def charDigit (c : Char) : Option Nat :=
+  if 48 ≤ c.toNat && c.toNat ≤ 57 then some (c.toNat - 48) else none
+
+theorem charDigit_digitChar (d : Nat) (h : d < 10) :
+    charDigit (digitChar d) = some d := by
+  revert h; revert d; decide
+
+theorem mapM_charDigit_digitChar : ∀ ds : List Nat, (∀ d ∈ ds, d < 10) →
+    (ds.map digitChar).mapM charDigit = some ds :=
+  List.rec (motive := fun ds ↦ (∀ d ∈ ds, d < 10) →
+      (ds.map digitChar).mapM charDigit = some ds)
+    (fun _ ↦ rfl)
+    (fun d ds ih h ↦ by
+      have hd : d < 10 := h d (by simp)
+      have ht : ∀ x ∈ ds, x < 10 := fun x hx ↦ h x (by simp [hx])
+      simp [List.mapM_cons, charDigit_digitChar d hd, ih ht])
+
+/-- The value of a little-endian decimal digit list. -/
+def ofLE : List Nat → Nat := List.rec 0 fun d _ ih ↦ d + 10 * ih
+
+@[simp] theorem ofLE_nil : ofLE [] = 0 := rfl
+
+@[simp] theorem ofLE_cons (d : Nat) (ds : List Nat) :
+    ofLE (d :: ds) = d + 10 * ofLE ds := rfl
+
+/-- Little-endian decimal digits of `n`, on an explicit recursion bound.
+Each step divides by ten, so `n` itself is always a sufficient bound. -/
+def digitsLEAux : Nat → Nat → List Nat :=
+  Nat.rec (fun _ ↦ []) fun _ ih n ↦ if n = 0 then [] else n % 10 :: ih (n / 10)
+
+@[simp] theorem digitsLEAux_zero (n : Nat) : digitsLEAux 0 n = [] := rfl
+
+theorem digitsLEAux_succ (f n : Nat) :
+    digitsLEAux (f + 1) n =
+      if n = 0 then [] else n % 10 :: digitsLEAux f (n / 10) := rfl
+
+/-- Little-endian decimal digits. Hand-rolled because every route to a
+decimal round trip in mathlib and in core depends on `Classical.choice`;
+see the module docstring's implementation notes. -/
+def digitsLE (n : Nat) : List Nat := digitsLEAux n n
+
+theorem ofLE_digitsLEAux : ∀ f n : Nat, n ≤ f → ofLE (digitsLEAux f n) = n :=
+  Nat.rec (motive := fun f ↦ ∀ n : Nat, n ≤ f → ofLE (digitsLEAux f n) = n)
+    (fun n hn ↦ by
+      simp only [digitsLEAux_zero, ofLE_nil]
+      exact (Nat.le_zero.mp hn).symm)
+    (fun f ih n hn ↦ by
+      rw [digitsLEAux_succ]
+      split
+      next h => simp [h]
+      next h => rw [ofLE_cons, ih (n / 10) (by omega)]; omega)
+
+theorem ofLE_digitsLE (n : Nat) : ofLE (digitsLE n) = n :=
+  ofLE_digitsLEAux n n (Nat.le_refl n)
+
+theorem digitsLEAux_lt : ∀ f n : Nat, ∀ d ∈ digitsLEAux f n, d < 10 :=
+  Nat.rec (motive := fun f ↦ ∀ n : Nat, ∀ d ∈ digitsLEAux f n, d < 10)
+    (fun n d hd ↦ by simp at hd)
+    (fun f ih n d hd ↦ by
+      rw [digitsLEAux_succ] at hd
+      split at hd
+      next => simp at hd
+      next =>
+        rcases List.mem_cons.mp hd with rfl | hd'
+        · omega
+        · exact ih (n / 10) d hd')
+
+theorem digitsLE_lt (n : Nat) : ∀ d ∈ digitsLE n, d < 10 := digitsLEAux_lt n n
+
+theorem digitsLE_ne_nil {n : Nat} (h : n ≠ 0) : digitsLE n ≠ [] := by
+  obtain ⟨m, rfl⟩ : ∃ m, n = m + 1 := ⟨n - 1, by omega⟩
+  simp [digitsLE, digitsLEAux_succ]
+
+/-- Shortest-form decimal, big-endian, `"0"` for zero. -/
+def decOf (n : Nat) : List Char :=
+  if n = 0 then ['0'] else (digitsLE n).reverse.map digitChar
+
+/-- The value of a big-endian decimal digit string, or `none` if any
+character is not a digit. Leading zeros are accepted, and so is the empty
+string, whose value is `0`: the parser may admit more than the printer
+emits, since the retraction law constrains only the composite. -/
+def digitsVal (cs : List Char) : Option Nat :=
+  (cs.mapM charDigit).map fun l ↦ ofLE l.reverse
+
+/-- The decimal round trip: reading back a shortest-form spelling
+recovers the number. This is what the retraction law rests on at the
+label level. -/
+theorem digitsVal_decOf (n : Nat) : digitsVal (decOf n) = some n := by
+  unfold decOf digitsVal
+  by_cases h : n = 0
+  · subst h; decide
+  · have hlt : ∀ d ∈ (digitsLE n).reverse, d < 10 := by
+      intro d hd
+      exact digitsLE_lt n d (List.mem_reverse.mp hd)
+    rw [if_neg h, mapM_charDigit_digitChar _ hlt]
+    simp [ofLE_digitsLE]
+
+theorem decOf_all_digits (n : Nat) : ∀ c ∈ decOf n, (charDigit c).isSome := by
+  intro c hc
+  unfold decOf at hc
+  by_cases h : n = 0
+  · subst h; rw [if_pos rfl, List.mem_singleton] at hc; subst hc; decide
+  · rw [if_neg h] at hc
+    obtain ⟨d, hd, rfl⟩ := List.mem_map.mp hc
+    have : d < 10 := digitsLE_lt n d (List.mem_reverse.mp hd)
+    simp [charDigit_digitChar d this]
+
+theorem decOf_ne_nil (n : Nat) : decOf n ≠ [] := by
+  unfold decOf
+  by_cases h : n = 0
+  · subst h; simp
+  · rw [if_neg h]
+    simp [digitsLE_ne_nil h]
+
+/-! ### Reading a decimal prefix -/
+
+/-- Split off the longest decimal prefix. -/
+def readDigits : List Char → List Char × List Char :=
+  List.rec ([], []) fun c cs ih ↦
+    match charDigit c with
+    | some _ => (c :: ih.1, ih.2)
+    | none => ([], c :: cs)
+
+theorem readDigits_cons (c : Char) (cs : List Char) :
+    readDigits (c :: cs) =
+      match charDigit c with
+      | some _ => (c :: (readDigits cs).1, (readDigits cs).2)
+      | none => ([], c :: cs) := rfl
+
+theorem readDigits_append : ∀ ds rest : List Char,
+    (∀ c ∈ ds, (charDigit c).isSome) →
+    (∀ c cs, rest = c :: cs → charDigit c = none) →
+    readDigits (ds ++ rest) = (ds, rest) :=
+  List.rec (motive := fun ds ↦ ∀ rest : List Char,
+      (∀ c ∈ ds, (charDigit c).isSome) →
+      (∀ c cs, rest = c :: cs → charDigit c = none) →
+      readDigits (ds ++ rest) = (ds, rest))
+    (fun rest _ hr ↦ by
+      cases rest with
+      | nil => rfl
+      | cons c cs => simp [readDigits_cons, hr c cs rfl])
+    (fun d ds ih rest hd hr ↦ by
+      have h1 : (charDigit d).isSome := hd d (by simp)
+      have h2 : ∀ c ∈ ds, (charDigit c).isSome := fun c hc ↦ hd c (by simp [hc])
+      obtain ⟨v, hv⟩ := Option.isSome_iff_exists.mp h1
+      simp [readDigits_cons, hv, ih rest h2 hr])
+
+/-- Read a non-empty decimal prefix and its value. -/
+def readNat (cs : List Char) : Option (Nat × List Char) :=
+  let (ds, r) := readDigits cs
+  if ds.isEmpty then none else (digitsVal ds).map (·, r)
+
+/-! ### Canonical verbatim atoms -/
+
+/-- The [RFC9804] verbatim encoding of an atom, `length ":" content`. -/
+def printVerbatim (s : List Char) : List Char :=
+  decOf s.length ++ ':' :: s
+
+/-- Read one verbatim atom, returning it and the remaining input. The
+`n ≤ r.length` guard rejects an atom declaring more content than
+follows it, rather than truncating. `parse` cannot observe the guard —
+a truncating read would consume the whole remaining input, and every
+position that can follow one demands more — so what the guard buys is
+that `readVerbatim` reads the [RFC9804] `verbatim` production correctly
+on its own. `GebTests.Internal.ConcreteSyntax` asserts that directly. -/
+def readVerbatim (cs : List Char) : Option (List Char × List Char) :=
+  match readNat cs with
+  | some (n, ':' :: r) => if n ≤ r.length then some (r.take n, r.drop n) else none
+  | _ => none
+
+/-- A printed atom reads back whole, and leaves exactly what followed
+it. The length prefix is what delimits the content, so the content may
+contain `:` and parentheses. -/
+theorem readVerbatim_append (s rest : List Char) :
+    readVerbatim (printVerbatim s ++ rest) = some (s, rest) := by
+  have hcolon : ∀ c cs, (':' :: (s ++ rest)) = c :: cs → charDigit c = none := by
+    intro c cs hc; injection hc with h1 _; subst h1; decide
+  have h : readNat (printVerbatim s ++ rest)
+      = some (s.length, ':' :: (s ++ rest)) := by
+    unfold readNat printVerbatim
+    rw [List.append_assoc, List.cons_append,
+      readDigits_append _ _ (decOf_all_digits s.length) hcolon]
+    simp [decOf_ne_nil s.length, digitsVal_decOf, List.isEmpty_iff]
+  simp [readVerbatim, h]
+
+/-! ### Printer -/
+
+/-- The head atom of a leaf s-expression. -/
+def leafTok : List Char := ['l', 'e', 'a', 'f']
+
+/-- The head atom of a fork s-expression. -/
+def forkTok : List Char := ['f', 'o', 'r', 'k']
+
+/-- Print a tree in [RFC9804] canonical form. A leaf label is its
+shortest-form decimal, written as a verbatim atom: canonical form admits
+no other atom encoding. -/
+def printAst {k : Nat} : Ast k → List Char :=
+  WType.elim (List Char) fun x ↦
+    match x with
+    | ⟨.leaf i, _⟩ =>
+      '(' :: (printVerbatim leafTok ++ printVerbatim (decOf i.val) ++ [')'])
+    | ⟨.fork, ch⟩ =>
+      '(' :: (printVerbatim forkTok ++ ch (0 : Fin 2) ++ ch (1 : Fin 2) ++ [')'])
+
+@[simp] theorem printAst_leaf {k : Nat} (i : Fin k) :
+    printAst (Ast.leaf i)
+      = '(' :: (printVerbatim leafTok ++ printVerbatim (decOf i.val) ++ [')']) :=
+  rfl
+
+@[simp] theorem printAst_fork {k : Nat} (l r : Ast k) :
+    printAst (Ast.fork l r)
+      = '(' :: (printVerbatim forkTok ++ printAst l ++ printAst r ++ [')']) :=
+  rfl
+
+/-! ### Parser -/
+
+/-- One layer of the recursive descent: read a single s-expression,
+delegating each child to `childParse`. -/
+def parseStep (k : Nat) (childParse : List Char → Option (Ast k × List Char)) :
+    List Char → Option (Ast k × List Char)
+  | [] => none
+  | c :: cs =>
+    if c = '(' then
+      match readVerbatim cs with
+      | some (tok, cs1) =>
+        if tok = leafTok then
+          match readVerbatim cs1 with
+          | some (ds, ')' :: cs2) =>
+            match digitsVal ds with
+            | some n => if h : n < k then some (Ast.leaf ⟨n, h⟩, cs2) else none
+            | none => none
+          | _ => none
+        else if tok = forkTok then
+          match childParse cs1 with
+          | some (l, cs2) =>
+            match childParse cs2 with
+            | some (r, ')' :: cs3) => some (Ast.fork l r, cs3)
+            | _ => none
+          | none => none
+        else none
+      | none => none
+    else none
+
+/-- Recursive descent over the canonical form, returning the tree and the
+unconsumed input. The `Nat` argument bounds the recursion: the recursion
+is on the input's structure only through the remainder each call returns,
+which is not a form Lean's structural recursion accepts. `parse` supplies
+the input length; `size_le_length_printAst` shows that this bound admits every
+tree the printer emits. Whether it admits every input the grammar accepts
+is not stated, and is not needed for the retraction law. -/
+def parseAst (k : Nat) : Nat → List Char → Option (Ast k × List Char) :=
+  Nat.rec (fun _ ↦ none) fun _ ih ↦ parseStep k ih
+
+@[simp] theorem parseAst_succ (k f : Nat) :
+    parseAst k (f + 1) = parseStep k (parseAst k f) := rfl
+
+/-- The parser inverts the printer on printed input, given fuel at least
+the tree's node count, and returns the unconsumed remainder. -/
+theorem parseAst_printAst {k : Nat} (a : Ast k) :
+    ∀ (f : Nat) (rest : List Char), a.size ≤ f →
+      parseAst k f (printAst a ++ rest) = some (a, rest) :=
+  Ast.ind (motive := fun a ↦ ∀ (f : Nat) (rest : List Char), a.size ≤ f →
+      parseAst k f (printAst a ++ rest) = some (a, rest))
+    (fun i f rest hf ↦ by
+      cases f with
+      | zero => simp at hf
+      | succ f =>
+        simp only [printAst_leaf, List.cons_append, parseAst_succ, parseStep,
+          List.append_assoc, List.nil_append]
+        rw [readVerbatim_append]
+        -- reduce the match on the `some` just produced, exposing the next atom
+        simp only []
+        rw [readVerbatim_append]
+        simp [digitsVal_decOf, i.isLt])
+    (fun l r ihl ihr f rest hf ↦ by
+      cases f with
+      | zero => simp at hf
+      | succ f =>
+        have hl : l.size ≤ f := by simp at hf; omega
+        have hr : r.size ≤ f := by simp at hf; omega
+        simp only [printAst_fork, List.cons_append, parseAst_succ, parseStep,
+          List.append_assoc, List.nil_append]
+        rw [readVerbatim_append]
+        have hne : forkTok ≠ leafTok := by decide
+        simp only [if_neg hne]
+        rw [ihl f _ hl]
+        -- reduce the match on the `some` just produced, exposing the second child
+        simp only []
+        rw [ihr f _ hr]
+        simp) a
+
+/-- A tree's node count bounds the length of its printed form, so the
+input length is fuel enough for `parseAst` to read anything `printAst`
+emits. -/
+theorem size_le_length_printAst {k : Nat} (a : Ast k) : a.size ≤ (printAst a).length :=
+  Ast.ind (motive := fun a ↦ a.size ≤ (printAst a).length)
+    (fun i ↦ by simp [printAst_leaf])
+    (fun l r ihl ihr ↦ by
+      simp only [Ast.size_fork, printAst_fork, List.length_cons,
+        List.length_append]
+      omega) a
+
+/-! ### The two syntax maps and the retraction law -/
+
+/-- The printer of the canonical S-expression syntax. A concrete syntax
+needs a deterministic printer, not a normative canonical form; that this
+one also emits the format's canonical spelling is incidental rather than
+required. -/
+def print {k : Nat} (a : Ast k) : List Char := printAst a
+
+/-- The parser of the canonical S-expression syntax, rejecting trailing
+input. -/
+def parse (k : Nat) (cs : List Char) : Option (Ast k) :=
+  match parseAst k cs.length cs with
+  | some (a, []) => some a
+  | _ => none
+
+/-- The retraction law for the canonical S-expression syntax: printing a
+tree and parsing the result returns that tree. -/
+theorem parse_print {k : Nat} (a : Ast k) : parse k (print a) = some a := by
+  unfold parse print
+  rw [show printAst a = printAst a ++ [] by simp,
+    parseAst_printAst a _ [] (by simpa using size_le_length_printAst a)]
+
+/-! ### The generic corollaries, instantiated here -/
+
+/-- `parse_print` in the form the generic corollaries consume. -/
+theorem retraction (k : Nat) : Retraction (parse k) (print (k := k)) :=
+  parse_print
+
+/-- `Geb.format_idem` at this syntax. -/
+theorem format_idem (k : Nat) (c : List Char) :
+    (format (parse k) print c).bind (format (parse k) print)
+      = format (parse k) print c :=
+  Geb.format_idem _ _ (retraction k) c
+
+/-- `Geb.print_injective` at this syntax. -/
+theorem print_injective (k : Nat) : Function.Injective (print (k := k)) :=
+  Geb.print_injective _ _ (retraction k)
+
+end Csexp
+
+end Geb

--- a/geb-lean/vendor/geb-mathlib/Geb/Internal/PresheafIRProto.lean
+++ b/geb-lean/vendor/geb-mathlib/Geb/Internal/PresheafIRProto.lean
@@ -1,0 +1,14 @@
+/-
+Copyright (c) 2026 Terence Rokop. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Terence Rokop
+-/
+module
+
+public import Geb.Internal.PresheafIRProto.Basic
+public import Geb.Internal.PresheafIRProto.Codes
+public import Geb.Internal.PresheafIRProto.Functor
+
+/-!
+# PresheafIRProto — index
+-/

--- a/geb-lean/vendor/geb-mathlib/Geb/Internal/PresheafIRProto/Basic.lean
+++ b/geb-lean/vendor/geb-mathlib/Geb/Internal/PresheafIRProto/Basic.lean
@@ -1,0 +1,1018 @@
+/-
+Copyright (c) 2026 Terence Rokop. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Terence Rokop
+-/
+-- Modified from geb-mathlib by scripts/geb-mathlib-backport.patch.
+module
+
+public import Geb.Mathlib.Data.PFunctor.Presheaf.Basic
+public import Geb.Mathlib.Data.PFunctor.IndRec.Hom
+
+/-!
+# Prototype: morphisms of presheaf p.r.a. functors, and the `ι` generator
+
+Throwaway exploration, not upstream-eligible content. Every declaration here is
+`Classical.choice`-free; the bundled restatement of the p.r.a. formula, which
+writes `⟶` between two objects of a presheaf category and so pulls in
+`Classical.choice` from mathlib, is in the sibling `PresheafIRProto.Functor`
+module.
+
+Two developments sit here. The larger is the morphism theory: the p.r.a.
+formula as the equivalence `F.obj Z ≃ Σ a : F.A, ArityHom F a Z`
+(`objEquivSigmaArityHom`), unindexed — its `j`-fibred form
+`F Z j = Σ (a : T₁ j), Hom (E a) Z` is reached through `ObjFib` and
+`ofSigmaFib` — the morphism type `PshHom` with its action, and the
+representation theorem `pshHomEquivNatFamily` classifying the natural families
+between two such functors by shape-map-forward and arity-map-backward data,
+with `DomHom` / `domHomEquivNatFamily` as its domain-level warm-up. The
+smaller, first in the file, is the constant functor at a representable. The
+code type itself and its two rules are in the sibling
+`PresheafIRProto.Codes` module; nothing here is a code constructor.
+
+Two claims are tested here:
+
+1. `iotaPresheaf` — the constant (`iota`) case generalizes to the functor
+   constant at the representable `y j₀`, whose shape type is the total space
+   `Σ j', (j' ⟶ j₀)` of that representable rather than a single shape.
+2. `Functoriality` — that `IR.rec` reaches the subcodes, which is all it
+   establishes. Its witness type is built from `IR.Hom`, whose `ι`-clause is
+   propositional equality of indices and so ignores `C₀`'s morphisms; it is
+   not the type the source requires.
+
+## Main definitions
+
+* `GebProto.isFunctorial_of_subsingletonDirection` — the five direction-side
+  functor laws where every direction fibre is a subsingleton.
+* `GebProto.idPshHom` — the identity morphism of presheaf p.r.a. functors.
+* `GebProto.SliceHom` / `GebProto.sliceHomApp` — the morphism formula at a
+  discrete base, and its action.
+* `GebProto.iotaPresheaf` / `iotaPresheafData` — the constant functor at a
+  representable, and its operations.
+* `GebProto.Functoriality` — the witness family attached over pre-codes.
+* `GebProto.ArityB` — the fibre family the worked example in `Codes` is
+  built on.
+* `GebProto.shapePresheaf` / `GebProto.arityPresheaf` — the shape presheaf `T₁`
+  and the arity presheaf `E(a)`, as `Functor` values built from the raw fields.
+* `GebProto.ArityHom` / `GebProto.ofArityHomElt` /
+  `GebProto.objEquivSigmaArityHom` — the p.r.a. formula
+  `T Z ≃ Σ a, Hom(E(a), Z)` with the presheaf hom unbundled, hence free of
+  `Classical.choice`, and the slice element its inverse produces.
+* `GebProto.DomHom` / `GebProto.DomNatFamily` /
+  `GebProto.domHomEquivNatFamily` — the domain-level morphism data, the natural
+  families it represents, and the Yoneda equivalence between them.
+* `GebProto.ShapeHom` — the unbundled presheaf hom `T₁ ⟶ T₁'`.
+* `GebProto.PshHom` — the full morphism data of presheaf p.r.a. functors:
+  a `ShapeHom`, a backward arity map, and the `el(T₁)` naturality of the
+  latter, stated across a transport along the former's naturality.
+* `GebProto.ObjFib` / `GebProto.objFibRestr` / `GebProto.objFibMap` /
+  `GebProto.ofSigmaFib` — the output presheaf's fibres, their `J`-restriction
+  and input-presheaf action, unbundled, and the fibre element of a shape and an
+  arity hom.
+* `GebProto.pshHomFib` — the action of a `PshHom` on those fibres.
+* `GebProto.PshNatFamily` / `GebProto.pshHomEquivNatFamily` — the natural
+  families a `PshHom` represents, and the equivalence between them.
+
+## Main statements
+
+* `GebProto.pshHomFib_objFibRestr` — the action of a `PshHom` commutes with the
+  `J`-restriction, which is the content of `PshHom`'s `reindexCompat` clause.
+
+## References
+
+* [GhaniNordvallForsbergMalatesta2015]
+* [GhaniMalatestaNordvallForsberg2014Agda]
+* [HancockMcBrideGhaniMalatestaAltenkirch2013]
+* [Weber2007]
+
+## Tags
+
+prototype, inductive-recursive, presheaf, parametric right adjoint
+-/
+
+@[expose] public section
+
+universe uI uJ uA uB uX uZ vI vJ
+
+open CategoryTheory
+
+namespace GebProto
+
+section Iota
+
+variable {I : Type uI} [Category.{vI} I] {J : Type uJ} [Category.{vJ} J]
+
+/-- Where every direction fiber is a subsingleton, the five direction-side
+functor laws are all `Subsingleton.elim` and only the two shape-side laws carry
+content. `iotaPresheaf` is of that kind. -/
+theorem isFunctorial_of_subsingletonDirection
+    (D : PresheafPFunctorData.{uI, uJ, uA, uB, vI, vJ} I J)
+    (h : ∀ (a : D.A) (i : I), Subsingleton (D.Direction a i))
+    (hid : D.ShapeRestrId) (hc : D.ShapeRestrComp) : D.IsFunctorial where
+  directionRestr_id := by intro a i; funext d; exact (h a i).elim _ _
+  directionRestr_comp := by intro a i i' i'' f g; funext d; exact (h a i'').elim _ _
+  shapeRestr_id := hid
+  shapeRestr_comp := hc
+  reindex_naturality := by intro j j' g a i i' f; funext d; exact (h a.1 i').elim _ _
+  reindex_id := by intro j a i d; exact (h a.1 i).elim _ _
+  reindex_comp := by intro j j' j'' g h' a i d; exact (h a.1 i).elim _ _
+
+/-- The operations of the constant functor at the representable `y j₀`: shapes
+are the total space of `y j₀`, the shape-output map is its projection, there
+are no directions, and `shapeRestr` is precomposition. -/
+def iotaPresheafData (j₀ : J) :
+    PresheafPFunctorData.{uI, uJ, max uJ vJ, uB, vI, vJ} I J where
+  A := Σ j' : J, (j' ⟶ j₀)
+  B := fun _ ↦ PEmpty
+  r := fun x ↦ PEmpty.elim x.2
+  q := fun x ↦ x.1
+  directionRestr := fun _ {_ _} _g d ↦ PEmpty.elim d.1
+  shapeRestr := fun {_ j'} g s ↦ ⟨⟨j', g ≫ eqToHom s.2.symm ≫ s.1.2⟩, rfl⟩
+  reindex := fun {_ _} _g _a {_} d ↦ PEmpty.elim d.1
+
+/-- Every direction fiber of `iotaPresheafData` is empty, hence a subsingleton;
+this discharges all five direction-side functor laws. -/
+instance subsingleton_iotaDirection (j₀ : J)
+    (a : (iotaPresheafData.{uI, uJ, uB, vI, vJ} (I := I) j₀).A) (i : I) :
+    Subsingleton ((iotaPresheafData.{uI, uJ, uB, vI, vJ} (I := I) j₀).Direction a i) :=
+  ⟨fun x _ ↦ PEmpty.elim x.1⟩
+
+/-- The functor whose shape type is the total space of the representable
+`y j₀` and which has no directions, as a `PresheafPFunctor`. That its shape
+presheaf is `y j₀` is not established here.
+The shape-side laws are the category laws of `J`; the direction-side laws hold
+because every direction fiber is empty. -/
+def iotaPresheaf (j₀ : J) : PresheafPFunctor.{uI, uJ, max uJ vJ, uB, vI, vJ} I J where
+  toPresheafPFunctorData := iotaPresheafData j₀
+  isFunctorial :=
+    isFunctorial_of_subsingletonDirection _ (fun _ _ ↦ inferInstance)
+      (by
+        intro j
+        funext s
+        obtain ⟨⟨jj, h⟩, rfl⟩ := s
+        exact Subtype.ext (Sigma.ext rfl (heq_of_eq (by simp [iotaPresheafData]))))
+      (by
+        intro j j' j'' g h
+        funext s
+        obtain ⟨⟨jj, k⟩, rfl⟩ := s
+        refine Subtype.ext (Sigma.ext rfl (heq_of_eq ?_))
+        simp only [iotaPresheafData, Function.comp_apply, eqToHom_refl, Category.id_comp]
+        exact Category.assoc _ _ _)
+
+end Iota
+
+section Functoriality
+
+/-!
+Can the functoriality witness be attached after the codes, rather than as a
+code field defined simultaneously with the morphisms?
+
+That depends on which morphism collection is taken. Remark 3.4 of
+[GhaniNordvallForsbergMalatesta2015] states that its results are parametric
+in that choice: any collection
+representing natural transformations between the codes works, provided
+identities and composition are definable. Its Definition 3.1 takes a natural
+transformation, whose naturality refers to the witnesses and to composition of
+code morphisms; [GhaniMalatestaNordvallForsberg2014Agda] takes a bare
+family of components, whose
+`δ→δ` rule mentions the witnesses only in its conclusion's indices, never in its
+premises. Under the
+latter the morphism type does not depend on the witnesses, so the witness can
+be attached afterwards, by `IR.rec` against an already-defined morphism type.
+
+`Functoriality` below demonstrates only that `IR.rec` reaches the subcodes,
+which is what such an attachment needs. Its witness type is built from
+`IR.Hom`, whose `ι`-clause is propositional equality of indices and so ignores
+the category's morphisms; that is not the type the source requires, and no
+claim is made here that this witness is the right one.
+-/
+
+open IndRec IndRec.IR
+
+universe u
+
+variable (C₀ : Type u) [Category.{u} C₀]
+
+/-- The functoriality witness of a code, attached after the fact by `IR.rec`:
+nothing at `ι`, componentwise at `σ`, and at `δ` the Positive-IR witness `F→`
+— a code morphism between the subcodes at any two labellings related by a
+family of `C₀`-morphisms — paired with the witnesses of those subcodes.
+
+That this elaborates at all is the point: `IR.Hom` is already defined, so the
+witness needs no mutual definition with the codes. -/
+def Functoriality : IR.{u, u, u, u} C₀ C₀ → Type u :=
+  rec.{u, u, u, u, u + 1} C₀ C₀ (motive := fun _ ↦ Type u)
+    (fun s ↦ match s with
+      | Sum.inl _ => fun _ _ ↦ PUnit
+      | Sum.inr (Sum.inl _) => fun _ m ↦ ∀ a, m a
+      | Sum.inr (Sum.inr B) => fun f m ↦
+          (∀ g h : B → C₀, (∀ b, g b ⟶ h b) → Hom C₀ C₀ (f ⟨g⟩) (f ⟨h⟩)) ×
+            (∀ i, m i))
+
+end Functoriality
+
+section Reindex
+
+/-!
+`reindex` is the obligation neither prior paper has an analogue for: Positive
+IR's `F→` witnesses functoriality of subcodes in the input labelling
+(`A → C`), which is the `directionRestr` side, whereas `reindex` witnesses
+functoriality of the arity assignment over `el(T₁)` — the output side.
+
+`ArityB` below is the fibre family the worked example in `Codes` is built on:
+one direction at `1`, none at `0`, so that reindexing along `0 ⟶ 1` is the map
+out of the empty type.
+-/
+
+/-- The arity of the output object `a`: one direction at `1`, none at `0`.
+`Codes`' `arityVariesBase` takes its fibres from this. -/
+abbrev ArityB (a : Fin 2) : Type := ULift (Fin a.val)
+
+/-- Each fibre of `ArityB` is a subsingleton: `Fin 0` is empty and `Fin 1` is a
+point, so the two elements of any fibre are equal. -/
+instance subsingleton_arityB (a : Fin 2) : Subsingleton (ArityB a) :=
+  ⟨fun x y ↦ ULift.ext _ _ (Fin.ext (by
+    have hx := x.down.isLt
+    have hy := y.down.isLt
+    have ha := a.isLt
+    omega))⟩
+
+end Reindex
+
+section PolyMorphism
+
+/-!
+The regular formula for natural transformations between polynomial functors:
+shapes forward, arities backward. For slice polynomial functors `F`, `F'` over
+the same `dom` and `cod`, a transformation is a map of shapes over each output
+index together with, for each shape, a map of arities in the opposite
+direction. `SliceHom` carries no naturality field; `sliceHomApp` below
+constructs the action from those two components alone.
+
+Derivation, for the presheaf case: `T Z j = Σ_{a ∈ T₁ j} Hom(E a, Z)` is a
+coproduct of representables in `Z`, so by Yoneda
+`Nat(Σ_a Hom(E a, −), Σ_b Hom(E' b, −)) = Π_a Σ_b Hom(E' b, E a)`. Yoneda for
+covariant hom-functors holds in any locally small category, so it is not what
+restricts the argument. What restricts it is the premise: over the free
+coproduct completion the `δ` interpretation is not a coproduct of
+`Fam(C)`-representables, since by Theorem 2.4 of
+[GhaniNordvallForsbergMalatesta2015] its coproduct is indexed by set maps
+`A → X`, whereas by Definition 2.2 a `Fam(C)`-morphism carries `C`-morphism
+data that index does not.
+-/
+
+/-- A morphism of slice polynomial functors: shapes forward over each output
+index, arities backward at each shape. This is Definition 7 of
+[HancockMcBrideGhaniMalatestaAltenkirch2013] (morphisms of indexed containers)
+at a discrete base. -/
+@[ext] structure SliceHom {dom : Type uI} {cod : Type uJ}
+    (F F' : SlicePFunctor.{uA, uB, uI, uJ} dom cod) : Type (max uA uB uI uJ) where
+  /-- The shape map, over each output index. -/
+  shape : ∀ j : cod, F.Shape j → F'.Shape j
+  /-- The arity map, in the opposite direction, at each shape and base point. -/
+  arity : ∀ (j : cod) (a : F.Shape j) (i : dom),
+    F'.Direction (shape j a).1 i → F.Direction a.1 i
+
+/-- The action of a `SliceHom` on the domain-restricted functor's value: the
+shape travels forward, and each direction of the new shape is filled by pulling
+it back along `arity` and reading off the original assignment. That this is
+definable with no further data is the content of the formula. -/
+def sliceHomApp {dom : Type uI} {cod : Type uJ}
+    {F F' : SlicePFunctor.{uA, uB, uI, uJ} dom cod} (α : SliceHom F F')
+    {X : Type uX} (p : X → dom) (j : cod)
+    (x : F.toSliceDomPFunctor.Obj p) (hq : F.q x.1.1 = j) :
+    F'.toSliceDomPFunctor.Obj p :=
+  ⟨⟨(α.shape j ⟨x.1.1, hq⟩).1,
+      fun (b' : F'.toPFunctor.B (α.shape j ⟨x.1.1, hq⟩).1) ↦
+        x.1.2 (α.arity j ⟨x.1.1, hq⟩ (F'.rCurried _ b') ⟨b', rfl⟩).1⟩,
+    (F'.toSliceDomPFunctor.compatible_iff _ _ _).mpr fun b' ↦
+      ((F.toSliceDomPFunctor.compatible_iff _ _ _).mp x.2
+        (α.arity j ⟨x.1.1, hq⟩ (F'.rCurried _ b') ⟨b', rfl⟩).1).trans
+        (α.arity j ⟨x.1.1, hq⟩ (F'.rCurried _ b') ⟨b', rfl⟩).2⟩
+
+end PolyMorphism
+
+section ShapeAndArityPresheaves
+
+/-!
+The two presheaves the p.r.a. formula names, extracted from the raw fields as
+`Functor` values, on the model of `PresheafPFunctor.objPresheaf`.
+
+`shapePresheaf` lands in `Type uA` and `arityPresheaf` in `Type uB`, those being
+the universes of `SlicePFunctor.Shape` (a `Subtype` of `F.A : Type uA`) and of
+`SliceDomPFunctor.Direction` (a `Subtype` of `F.B a : Type uB`). Neither carries
+a `max` with the base or morphism universes: `Shape j` is cut out of `F.A` by a
+`Prop`, and `Direction a i` out of `F.B a` by a `Prop`.
+
+Consequently `arityPresheaf F a : Iᵒᵖ ⥤ Type uB` is an object of the same
+category as `Z : Iᵒᵖ ⥤ Type uZ` only when `uB` and `uZ` are the same level.
+Lean's `Type` hierarchy is not cumulative, so no relation `uB ≤ uZ` (which is
+not expressible on levels anyway) helps; the two options are to instantiate
+`uZ := uB`, or to `ULift` both sides into `Type (max uB uZ)`. Both are exhibited
+below.
+-/
+
+variable {I : Type uI} [Category.{vI} I] {J : Type uJ} [Category.{vJ} J]
+
+/-- The shape presheaf `T₁ : Jᵒᵖ ⥤ Type uA` of the familial presentation of
+[Weber2007]: fibre `F.Shape j` over `j`,
+restriction maps `F.shapeRestr`, functor laws from `shapeRestr_id` /
+`shapeRestr_comp`. -/
+def shapePresheaf (F : PresheafPFunctor.{uI, uJ, uA, uB, vI, vJ} I J) :
+    Jᵒᵖ ⥤ Type uA where
+  obj j := F.Shape j.unop
+  map g := ↾ F.shapeRestr g.unop
+  map_id j := by
+    ext a
+    exact congrFun (F.isFunctorial.shapeRestr_id j.unop) a
+  map_comp g h := by
+    ext a
+    exact congrFun (F.isFunctorial.shapeRestr_comp g.unop h.unop) a
+
+/-- The arity presheaf `E(a) : Iᵒᵖ ⥤ Type uB` of a shape `a`, the second half
+of [Weber2007]'s familial presentation: fibre
+`F.Direction a i` over `i`, restriction maps `F.directionRestr a`, functor laws
+from `directionRestr_id` / `directionRestr_comp`. -/
+def arityPresheaf (F : PresheafPFunctor.{uI, uJ, uA, uB, vI, vJ} I J) (a : F.A) :
+    Iᵒᵖ ⥤ Type uB where
+  obj i := F.Direction a i.unop
+  map f := ↾ F.directionRestr a f.unop
+  map_id i := by
+    ext d
+    exact congrFun (F.isFunctorial.directionRestr_id a i.unop) d
+  map_comp f g := by
+    ext d
+    exact congrFun (F.isFunctorial.directionRestr_comp a f.unop g.unop) d
+
+-- The two declarations exhibiting the bundled hom, and the universes at which
+-- it is formable, live in the sibling `Functor` module: they name `⟶` between
+-- objects of a functor category, which is what introduces `Classical.choice`.
+
+end ShapeAndArityPresheaves
+
+section UnbundledArityHom
+
+/-!
+The p.r.a. formula again, with the presheaf hom in unbundled form.
+
+`objEquivSigmaHom`, in the sibling `PresheafIRProto.Functor` module, depends on
+`Classical.choice`, and so does anything
+built on it. The dependence enters through `CategoryTheory.Functor.category`,
+that is, through writing `⟶` between two objects of a functor category at all,
+before any proof: `#print axioms CategoryTheory.Functor.category` reports
+`Classical.choice`, whereas `shapePresheaf`, `arityPresheaf`,
+`PresheafDomPFunctorData.obj` and `PresheafDomPFunctorData.value` do not.
+
+`ArityHom` is the same data as `arityPresheaf F a ⟶ Z` written as a subtype of
+a family of fibre maps, with the naturality square as the subtype predicate —
+literally `PresheafDomPFunctorData.IsNatural`'s shape. `Z.map f.op` is
+unaffected: the category instance on `Type u` is axiom-free; only the functor
+category's instance is not.
+
+Restating the equivalence over `ArityHom` also frees the universe of `Z`:
+`objEquivSigmaHom` needs `Z : Iᵒᵖ ⥤ Type uB` so that `Z` and `arityPresheaf F a`
+are objects of one category, whereas `ArityHom F a Z` is formable at any `uZ`.
+-/
+
+variable {I : Type uI} [Category.{vI} I] {J : Type uJ} [Category.{vJ} J]
+
+/-- The unbundled presheaf hom `E(a) ⟶ Z`: a family of fibre maps
+`F.Direction a i → Z.obj ⟨i⟩` subject to the naturality square. -/
+def ArityHom (F : PresheafPFunctor.{uI, uJ, uA, uB, vI, vJ} I J) (a : F.A)
+    (Z : Iᵒᵖ ⥤ Type uZ) : Type (max uI uB uZ) :=
+  { α : (i : I) → F.Direction a i → Z.obj ⟨i⟩ //
+      ∀ ⦃i i' : I⦄ (f : i' ⟶ i) (b : F.Direction a i),
+        α i' (F.directionRestr a f b) = Z.map f.op (α i b) }
+
+/-- The slice element determined by a shape `a` and an unbundled arity hom
+`α : E(a) ⟶ Z`: the direction `b` is assigned the `α`-image of `b`, read at
+`b`'s own base point `F.rCurried a b`. Compatibility holds by construction, the
+index component being that base point. -/
+def ofArityHomElt (F : PresheafPFunctor.{uI, uJ, uA, uB, vI, vJ} I J) {Z : Iᵒᵖ ⥤ Type uZ}
+    (a : F.A) (α : ArityHom F a Z) :
+    F.toSliceDomPFunctor.Obj (PresheafDomPFunctorData.elemProj Z) :=
+  ⟨⟨a, fun b ↦ ⟨F.rCurried a b, α.1 (F.rCurried a b) ⟨b, rfl⟩⟩⟩,
+    (F.compatible_iff _ _ _).mpr fun _ ↦ rfl⟩
+
+/-- The component `ofArityHomElt` assigns to a direction is the component `α`
+assigns to it. Destructing the direction makes the `cast` inside `value` a
+`cast` along a proof of `t = t`, which proof irrelevance reduces away. -/
+theorem value_ofArityHom (F : PresheafPFunctor.{uI, uJ, uA, uB, vI, vJ} I J)
+    {Z : Iᵒᵖ ⥤ Type uZ} (a : F.A) (α : ArityHom F a Z) ⦃i : I⦄
+    (b : F.Direction (ofArityHomElt F a α).1.1 i) :
+    F.value (ofArityHomElt F a α) b = α.1 i b := by
+  obtain ⟨b1, rfl⟩ := b
+  rfl
+
+/-- The p.r.a. formula of [Weber2007] with the hom unbundled: the domain-restricted
+interpretation of `F` at `Z` is the coproduct over shapes of the unbundled
+representables on the arity presheaves. The forward map reads off the shape and
+repackages the direction-assignment, its components being `value` and its
+naturality being `IsNatural`; the inverse is `ofArityHomElt`. -/
+def objEquivSigmaArityHom (F : PresheafPFunctor.{uI, uJ, uA, uB, vI, vJ} I J)
+    (Z : Iᵒᵖ ⥤ Type uZ) :
+    F.toPresheafDomPFunctorData.obj Z ≃ Σ a : F.A, ArityHom F a Z where
+  toFun x := ⟨x.1.1.1, ⟨fun i ↦ F.value x.1 (i := i), x.2⟩⟩
+  invFun p :=
+    ⟨ofArityHomElt F p.1 p.2, by
+      intro i i' f b
+      rw [value_ofArityHom, value_ofArityHom]
+      exact p.2.2 f b⟩
+  left_inv x := by
+    refine Subtype.ext (Subtype.ext (Sigma.ext rfl (heq_of_eq (funext fun b ↦ ?_))))
+    exact Sigma.ext ((F.compatible_iff _ _ _).mp x.1.2 b).symm (cast_heq _ _)
+  right_inv p := by
+    refine Sigma.ext rfl (heq_of_eq (Subtype.ext (funext fun i ↦ funext fun b ↦ ?_)))
+    exact value_ofArityHom F p.1 p.2 b
+
+end UnbundledArityHom
+
+section UnbundledYoneda
+
+/-!
+The Yoneda step, unbundled, at the domain level only: `q`, `shapeRestr` and
+`reindex` play no part here, so `DomHom` records only the shape map and the
+backward arity map.
+
+`DomHom F F'` is `Π a, Σ a', Hom(E'(a'), E(a))`, and its arity component is
+definitionally `ArityHom F' a' (arityPresheaf F a)` — the unbundled hom into
+the representing presheaf. `DomNatFamily F F'` is the families
+`Π Z, T Z → T' Z` natural in `Z`, with naturality stated against
+`PresheafDomPFunctorData.map`, which takes a bare `NatTrans` and so avoids the
+functor category's instance.
+
+The two are equivalent. Composing `objEquivSigmaArityHom` on both sides turns a
+natural family into a map `Π a, Σ a', ArityHom F' a' (arityPresheaf F a)`, and
+Yoneda supplies the inverse: a natural family out of `Σ a, ArityHom F a (−)` is
+determined by its value at the representing object, recovered by evaluating at
+`Z := arityPresheaf F a` on the generic element `idElt F a` — the element whose
+arity hom is the identity.
+-/
+
+variable {I : Type uI} [Category.{vI} I] {J : Type uJ} [Category.{vJ} J]
+
+/-- The bundled natural transformation `E(a) ⟶ Z` of an unbundled arity hom.
+The functor category's instance is not involved: `NatTrans` is a structure, and
+only `⟶` between two functors would require it. -/
+def natTransOfArityHom (F : PresheafPFunctor.{uI, uJ, uA, uB, vI, vJ} I J) (a : F.A)
+    {Z : Iᵒᵖ ⥤ Type uB} (μ : ArityHom F a Z) : NatTrans (arityPresheaf F a) Z where
+  app X := ↾ μ.1 X.unop
+  naturality := by
+    intro _ _ f
+    ext b
+    exact μ.2 f.unop b
+
+/-- Postcomposition of an unbundled arity hom with a natural transformation. -/
+def postcompArityHom (F : PresheafPFunctor.{uI, uJ, uA, uB, vI, vJ} I J) (a : F.A)
+    {Z Z' : Iᵒᵖ ⥤ Type uZ} (ν : NatTrans Z Z') (μ : ArityHom F a Z) : ArityHom F a Z' :=
+  ⟨fun i b ↦ ν.app ⟨i⟩ (μ.1 i b), by
+    intro i i' f b
+    change ν.app ⟨i'⟩ (μ.1 i' (F.directionRestr a f b)) = Z'.map f.op (ν.app ⟨i⟩ (μ.1 i b))
+    rw [μ.2 f b]
+    exact FunctorToTypes.naturality _ _ ν f.op _⟩
+
+/-- The identity arity hom, of `F` at `a` into `F`'s own arity presheaf. -/
+def idArityHom (F : PresheafPFunctor.{uI, uJ, uA, uB, vI, vJ} I J) (a : F.A) :
+    ArityHom F a (arityPresheaf F a) :=
+  ⟨fun _ b ↦ b, by intro i i' f b; rfl⟩
+
+/-- The generic element of shape `a`: the element of `T (E(a))` whose arity hom
+is the identity. Yoneda's representing datum. -/
+def idElt (F : PresheafPFunctor.{uI, uJ, uA, uB, vI, vJ} I J) (a : F.A) :
+    F.toPresheafDomPFunctorData.obj (arityPresheaf F a) :=
+  (objEquivSigmaArityHom F (arityPresheaf F a)).symm ⟨a, idArityHom F a⟩
+
+/-- The generic element's shape and arity hom are `a` and the identity. -/
+theorem objEquivSigmaArityHom_idElt (F : PresheafPFunctor.{uI, uJ, uA, uB, vI, vJ} I J)
+    (a : F.A) :
+    objEquivSigmaArityHom F (arityPresheaf F a) (idElt F a) = ⟨a, idArityHom F a⟩ :=
+  (objEquivSigmaArityHom F (arityPresheaf F a)).apply_symm_apply _
+
+/-- The morphism data between two presheaf p.r.a. functors at the domain level:
+shapes forward, arities backward, the arity map a morphism of arity
+presheaves. -/
+def DomHom (F F' : PresheafPFunctor.{uI, uJ, uA, uB, vI, vJ} I J) : Type (max uA uI uB) :=
+  (a : F.A) → Σ a' : F'.A, { ψ : (i : I) → F'.Direction a' i → F.Direction a i //
+      ∀ ⦃i i' : I⦄ (f : i' ⟶ i) (b : F'.Direction a' i),
+        ψ i' (F'.directionRestr a' f b) = F.directionRestr a f (ψ i b) }
+
+/-- The arity component of a `DomHom` is an unbundled arity hom of `F'` into the
+arity presheaf of `F`: the representing presheaf of Yoneda's statement. -/
+theorem domHom_eq_pi_sigma_arityHom (F F' : PresheafPFunctor.{uI, uJ, uA, uB, vI, vJ} I J) :
+    DomHom F F' = ((a : F.A) → Σ a' : F'.A, ArityHom F' a' (arityPresheaf F a)) := rfl
+
+/-- Families `T Z → T' Z` natural in `Z`, with naturality stated unbundled
+against `PresheafDomPFunctorData.map`. -/
+def DomNatFamily (F F' : PresheafPFunctor.{uI, uJ, uA, uB, vI, vJ} I J) :
+    Type (max uA uI vI (uB + 1)) :=
+  { η : (Z : Iᵒᵖ ⥤ Type uB) → F.toPresheafDomPFunctorData.obj Z →
+        F'.toPresheafDomPFunctorData.obj Z //
+      ∀ (Z Z' : Iᵒᵖ ⥤ Type uB) (ν : NatTrans Z Z') (x : F.toPresheafDomPFunctorData.obj Z),
+        η Z' (F.toPresheafDomPFunctorData.map ν x) =
+          F'.toPresheafDomPFunctorData.map ν (η Z x) }
+
+/-- Under `objEquivSigmaArityHom`, the action on input presheaves is
+postcomposition: the shape is untouched and the arity hom is composed with `ν`.
+Stated on the inverse side, where both sides are `ofArityHomElt` of the same
+data. -/
+theorem map_symm_arityHom (F : PresheafPFunctor.{uI, uJ, uA, uB, vI, vJ} I J)
+    {Z Z' : Iᵒᵖ ⥤ Type uB} (ν : NatTrans Z Z') (p : Σ a : F.A, ArityHom F a Z) :
+    F.toPresheafDomPFunctorData.map ν ((objEquivSigmaArityHom F Z).symm p) =
+      (objEquivSigmaArityHom F Z').symm ⟨p.1, postcompArityHom F p.1 ν p.2⟩ :=
+  rfl
+
+/-- Yoneda's reconstruction: the element of `T Z` with shape `a` and arity hom
+`μ` is the image of the generic element of shape `a` under the action of `μ`. -/
+theorem map_idElt (F : PresheafPFunctor.{uI, uJ, uA, uB, vI, vJ} I J) {Z : Iᵒᵖ ⥤ Type uB}
+    (p : Σ a : F.A, ArityHom F a Z) :
+    F.toPresheafDomPFunctorData.map (natTransOfArityHom F p.1 p.2) (idElt F p.1) =
+      (objEquivSigmaArityHom F Z).symm p := by
+  rw [idElt, map_symm_arityHom]
+  rfl
+
+/-- The action of a `DomHom` on the coproduct-of-representables side: the shape
+travels forward along `φ`, and the arity hom is precomposed with `φ`'s backward
+arity map. -/
+def domHomSigma (F F' : PresheafPFunctor.{uI, uJ, uA, uB, vI, vJ} I J) (φ : DomHom F F')
+    {Z : Iᵒᵖ ⥤ Type uB} (p : Σ a : F.A, ArityHom F a Z) : Σ a' : F'.A, ArityHom F' a' Z :=
+  ⟨(φ p.1).1, postcompArityHom F' _ (natTransOfArityHom F p.1 p.2) (φ p.1).2⟩
+
+/-- The natural family determined by a `DomHom`: `domHomSigma` conjugated by the
+p.r.a. formula. Keeping the sigma-level action a separate function puts the
+dependent shape and arity-hom projections behind one non-dependent argument,
+which is what makes the rewrites below applicable. -/
+def domHomFamily (F F' : PresheafPFunctor.{uI, uJ, uA, uB, vI, vJ} I J) (φ : DomHom F F')
+    (Z : Iᵒᵖ ⥤ Type uB) (x : F.toPresheafDomPFunctorData.obj Z) :
+    F'.toPresheafDomPFunctorData.obj Z :=
+  (objEquivSigmaArityHom F' Z).symm (domHomSigma F F' φ (objEquivSigmaArityHom F Z x))
+
+/-- `domHomFamily` on an element presented by its shape and arity hom. -/
+theorem domHomFamily_symm (F F' : PresheafPFunctor.{uI, uJ, uA, uB, vI, vJ} I J)
+    (φ : DomHom F F') {Z : Iᵒᵖ ⥤ Type uB} (p : Σ a : F.A, ArityHom F a Z) :
+    domHomFamily F F' φ Z ((objEquivSigmaArityHom F Z).symm p) =
+      (objEquivSigmaArityHom F' Z).symm (domHomSigma F F' φ p) := by
+  rw [domHomFamily, Equiv.apply_symm_apply]
+
+/-- The representation theorem, unbundled: morphism data at the domain level is
+the same thing as a family `T Z → T' Z` natural in `Z`. The inverse is Yoneda —
+evaluation at the representing presheaf `arityPresheaf F a` on the generic
+element `idElt F a`. -/
+def domHomEquivNatFamily (F F' : PresheafPFunctor.{uI, uJ, uA, uB, vI, vJ} I J) :
+    DomHom F F' ≃ DomNatFamily F F' where
+  toFun φ :=
+    ⟨domHomFamily F F' φ, by
+      intro Z Z' ν x
+      obtain ⟨p, rfl⟩ : ∃ p, (objEquivSigmaArityHom F Z).symm p = x :=
+        ⟨_, Equiv.symm_apply_apply _ x⟩
+      rw [map_symm_arityHom, domHomFamily_symm, domHomFamily_symm, map_symm_arityHom]
+      rfl⟩
+  invFun η a :=
+    objEquivSigmaArityHom F' (arityPresheaf F a) (η.1 (arityPresheaf F a) (idElt F a))
+  left_inv φ :=
+    funext fun a ↦ by
+      simp only [domHomFamily, Equiv.apply_symm_apply, objEquivSigmaArityHom_idElt]
+      rfl
+  right_inv η := by
+    refine Subtype.ext (funext fun Z ↦ funext fun x ↦ ?_)
+    obtain ⟨p, rfl⟩ : ∃ p, (objEquivSigmaArityHom F Z).symm p = x :=
+      ⟨_, Equiv.symm_apply_apply _ x⟩
+    conv_rhs =>
+      rw [← map_idElt F p, η.2,
+        ← Equiv.symm_apply_apply (objEquivSigmaArityHom F' (arityPresheaf F p.1))
+          (η.1 (arityPresheaf F p.1) (idElt F p.1)),
+        map_symm_arityHom]
+    exact domHomFamily_symm F F' _ p
+
+end UnbundledYoneda
+
+section ShapeSide
+
+/-!
+The `J`-side of the morphism type: the shape map is a morphism of shape
+presheaves, and the arity map is natural over `el(T₁)`, not merely over each
+fibre of `q` separately.
+
+`ShapeHom` is `ArityHom`'s recipe transposed: a family of fibre maps subject to
+a naturality predicate, the fibres now `F.Shape j` and the restriction maps
+`shapeRestr`.
+
+`PshHom`'s third law is the `el(T₁)` naturality of the arity map, and it does
+not typecheck on the nose. For `g : j' ⟶ j` and `a : F.Shape j`, one route runs
+the arity map at `F.shapeRestr g a` and then `F.reindex g a`; the other runs
+`F'.reindex g (σ j a)` and then the arity map at `a`. The second route's source
+is `F'.Direction (F'.shapeRestr g (σ j a)).1 i`, the first route's is
+`F'.Direction (σ j' (F.shapeRestr g a)).1 i`, and those two shapes agree only by
+the `ShapeHom` naturality of `σ`. The law is therefore stated across a `cast`
+along that equality — the device `PresheafPFunctorData.ReindexId` and
+`ReindexComp` use, whose transports are likewise supplied by an earlier law
+rather than by definitional equality. Here the law is bundled with `σ` in
+`ShapeHom`, so the transport is threaded through `shape.2` rather than through
+an extra parameter.
+-/
+
+variable {I : Type uI} [Category.{vI} I] {J : Type uJ} [Category.{vJ} J]
+
+/-- The unbundled presheaf hom `T₁ ⟶ T₁'`: a family of fibre maps
+`F.Shape j → F'.Shape j` subject to the naturality square against
+`shapeRestr`. -/
+def ShapeHom (F F' : PresheafPFunctor.{uI, uJ, uA, uB, vI, vJ} I J) : Type (max uJ uA) :=
+  { σ : (j : J) → F.Shape j → F'.Shape j //
+      ∀ ⦃j j' : J⦄ (g : j' ⟶ j) (a : F.Shape j),
+        σ j' (F.shapeRestr g a) = F'.shapeRestr g (σ j a) }
+
+/-- A morphism of presheaf p.r.a. functors, unbundled: a morphism `σ` of shape
+presheaves, an arity map backwards at each shape — a morphism of arity
+presheaves, so `q`-fibrewise this is `DomHom`'s data — and the `el(T₁)`
+naturality of that arity map, stated across the `cast` along `σ`'s own
+naturality. -/
+@[ext] structure PshHom (F F' : PresheafPFunctor.{uI, uJ, uA, uB, vI, vJ} I J) :
+    Type (max uI uJ uA uB) where
+  /-- The shape map, a morphism of shape presheaves. -/
+  shape : ShapeHom F F'
+  /-- The arity map, backwards, a morphism of arity presheaves. -/
+  arity : (j : J) → (a : F.Shape j) → ArityHom F' (shape.1 j a).1 (arityPresheaf F a.1)
+  /-- Naturality of `arity` over `el(T₁)`: applying the arity map at
+  `F.shapeRestr g a` and then `F.reindex g a` agrees with applying
+  `F'.reindex g (shape.1 j a)` and then the arity map at `a`, once the source of
+  the second route is transported along `shape.2`. -/
+  reindexCompat : ∀ ⦃j j' : J⦄ (g : j' ⟶ j) (a : F.Shape j) ⦃i : I⦄
+      (d : F'.Direction (shape.1 j' (F.shapeRestr g a)).1 i),
+    F.reindex g a ((arity j' (F.shapeRestr g a)).1 i d) =
+      (arity j a).1 i (F'.reindex g (shape.1 j a)
+        (cast (congrArg (fun s : F'.Shape j' ↦ F'.Direction s.1 i) (shape.2 g a)) d))
+
+/-- The identity morphism. The `cast` in `reindexCompat` is along `rfl`, so the
+law reduces to reflexivity — the smallest check that the transport is threaded
+in the direction that makes the two routes comparable. -/
+def idPshHom (F : PresheafPFunctor.{uI, uJ, uA, uB, vI, vJ} I J) : PshHom F F where
+  shape := ⟨fun _ a ↦ a, fun _ _ _ _ ↦ rfl⟩
+  arity _ a := idArityHom F a.1
+  reindexCompat _ _ _ _ _ _ := rfl
+
+end ShapeSide
+
+section ShapeSideAction
+
+/-!
+The action of a `PshHom` on the p.r.a. formula, and the two laws that make it a
+map of output presheaves. The `Z`-naturality is `DomHom`'s and needs nothing new;
+the `J`-restriction law is what tests clause (c) of `PshHom`: the two sides have
+different shapes, equal only by the `ShapeHom` naturality of `φ.shape`, and the
+components agree exactly when `reindexCompat` holds, which is what
+`pshHomFib_objFibRestr` needs; no `PshHom`-minus-`reindexCompat` type is
+defined here, so its unprovability without the clause is not established.
+
+`PresheafPFunctor.value_objRestrElt` is `private` upstream. Stating the
+restriction lemma on the `symm` side of `objEquivSigmaArityHom` does not avoid
+it: `objRestrElt` of an `ofArityHomElt` is not `ofArityHomElt` of the reindexed
+arity hom on the nose, the two direction-assignments differing by the transport
+along a direction's own base-point constraint. That transport is the content of
+`value_objRestrElt`, so it is restated here instead.
+-/
+
+variable {I : Type uI} [Category.{vI} I] {J : Type uJ} [Category.{vJ} J]
+
+/-- The component the restricted element assigns to a direction is the component
+the original assigns to the direction's `reindex`. Local restatement of the
+`private` `PresheafPFunctor.value_objRestrElt`. -/
+theorem value_objRestrElt (F : PresheafPFunctor.{uI, uJ, uA, uB, vI, vJ} I J)
+    {Z : Iᵒᵖ ⥤ Type uZ} ⦃j j' : J⦄ (g : j' ⟶ j)
+    (x : F.toSliceDomPFunctor.Obj (PresheafDomPFunctorData.elemProj Z)) (hq : F.q x.1.1 = j)
+    ⦃i : I⦄ (b : F.Direction (F.objRestrElt g x hq).1.1 i) :
+    F.value (F.objRestrElt g x hq) b = F.value x (F.reindex g ⟨x.1.1, hq⟩ b) := by
+  obtain ⟨b1, rfl⟩ := b
+  rfl
+
+/-- Precomposition of an unbundled arity hom with `reindex g a`, which is a
+morphism of arity presheaves by `reindex_naturality`. -/
+def reindexArityHom (F : PresheafPFunctor.{uI, uJ, uA, uB, vI, vJ} I J) {Z : Iᵒᵖ ⥤ Type uZ}
+    ⦃j j' : J⦄ (g : j' ⟶ j) (a : F.Shape j) (μ : ArityHom F a.1 Z) :
+    ArityHom F (F.shapeRestr g a).1 Z :=
+  ⟨fun i d ↦ μ.1 i (F.reindex g a d), by
+    intro i i' f d
+    refine Eq.trans (congrArg (μ.1 i') ?_) (μ.2 f (F.reindex g a d))
+    exact (congrFun (F.isFunctorial.reindex_naturality g a f) d).symm⟩
+
+/-- The `J`-restriction on the coproduct-of-representables side: the shape is
+restricted along `shapeRestr` and the arity hom is precomposed with `reindex`. -/
+def objRestrSigma (F : PresheafPFunctor.{uI, uJ, uA, uB, vI, vJ} I J) {Z : Iᵒᵖ ⥤ Type uZ}
+    ⦃j j' : J⦄ (g : j' ⟶ j) (a : F.A) (hq : F.q a = j) (μ : ArityHom F a Z) :
+    Σ a' : F.A, ArityHom F a' Z :=
+  ⟨(F.shapeRestr g ⟨a, hq⟩).1, reindexArityHom F g ⟨a, hq⟩ μ⟩
+
+/-- Under `objEquivSigmaArityHom`, the `J`-restriction is `objRestrSigma`. -/
+theorem objEquivSigmaArityHom_objRestr (F : PresheafPFunctor.{uI, uJ, uA, uB, vI, vJ} I J)
+    {Z : Iᵒᵖ ⥤ Type uZ} ⦃j j' : J⦄ (g : j' ⟶ j) (a : F.A) (hq : F.q a = j)
+    (μ : ArityHom F a Z) :
+    objEquivSigmaArityHom F Z
+        (F.objRestr g ((objEquivSigmaArityHom F Z).symm ⟨a, μ⟩) hq) =
+      objRestrSigma F g a hq μ := by
+  refine Sigma.ext rfl (heq_of_eq (Subtype.ext (funext fun i ↦ funext fun d ↦ ?_)))
+  exact (value_objRestrElt F g _ hq d).trans (value_ofArityHom F a μ _)
+
+/-- The same on the `symm` side, which is the form the action below rewrites
+with. Transported by hand rather than by `Equiv.eq_symm_apply`, which depends on
+`Classical.choice`. -/
+theorem objRestr_symm (F : PresheafPFunctor.{uI, uJ, uA, uB, vI, vJ} I J)
+    {Z : Iᵒᵖ ⥤ Type uZ} ⦃j j' : J⦄ (g : j' ⟶ j) (a : F.A) (hq : F.q a = j)
+    (μ : ArityHom F a Z) :
+    F.objRestr g ((objEquivSigmaArityHom F Z).symm ⟨a, μ⟩) hq =
+      (objEquivSigmaArityHom F Z).symm (objRestrSigma F g a hq μ) :=
+  ((objEquivSigmaArityHom F Z).symm_apply_apply _).symm.trans
+    (congrArg (objEquivSigmaArityHom F Z).symm (objEquivSigmaArityHom_objRestr F g a hq μ))
+
+/-- Two shape-and-arity-hom pairs are equal when the shapes are equal and the
+arity homs agree across the transport along that equality. The `cast` is along
+a `Prop`-valued equality, so proof irrelevance identifies it with the `cast` of
+`PshHom.reindexCompat`, which is stated along the `F'.Shape`-level equality. -/
+theorem sigmaArityHom_ext (F : PresheafPFunctor.{uI, uJ, uA, uB, vI, vJ} I J)
+    {Z : Iᵒᵖ ⥤ Type uZ} {a a' : F.A} (h : a = a') (μ : ArityHom F a Z) (μ' : ArityHom F a' Z)
+    (hμ : ∀ (i : I) (d : F.Direction a i),
+      μ.1 i d = μ'.1 i (cast (congrArg (fun t : F.A ↦ F.Direction t i) h) d)) :
+    (⟨a, μ⟩ : Σ b : F.A, ArityHom F b Z) = ⟨a', μ'⟩ := by
+  cases h
+  exact Sigma.ext rfl (heq_of_eq (Subtype.ext (funext fun i ↦ funext fun d ↦ hμ i d)))
+
+/-- The action of a `PshHom` on the coproduct-of-representables side: the shape
+travels forward along `φ.shape`, and the arity hom is precomposed with `φ`'s
+backward arity map. `DomHom`'s `domHomSigma`, now indexed by an output index. -/
+def pshHomSigma (F F' : PresheafPFunctor.{uI, uJ, uA, uB, vI, vJ} I J) (φ : PshHom F F')
+    {Z : Iᵒᵖ ⥤ Type uB} (j : J) (a : F.Shape j) (μ : ArityHom F a.1 Z) :
+    Σ a' : F'.A, ArityHom F' a' Z :=
+  ⟨(φ.shape.1 j a).1, postcompArityHom F' _ (natTransOfArityHom F a.1 μ) (φ.arity j a)⟩
+
+/-- The fibre of the output presheaf over `j`: the elements of
+`F.toPresheafDomPFunctorData.obj Z` whose `q`-output index is `j`. It is
+`(F.objPresheaf Z).obj ⟨j⟩` on the nose, and `objPresheaf` is choice-free, so
+this layer buys no constructivity and supplies nothing `objPresheaf` does not.
+It is retained because the representation theorem below is stated against it;
+restating that chain against `objPresheaf` and `mapPresheaf` is the work of the
+upstream port, not of this module. -/
+@[reducible] def ObjFib (F : PresheafPFunctor.{uI, uJ, uA, uB, vI, vJ} I J)
+    (Z : Iᵒᵖ ⥤ Type uZ) (j : J) : Type (max uI uZ uA uB) :=
+  { z : F.toPresheafDomPFunctorData.obj Z // F.q z.shape = j }
+
+/-- The `J`-restriction of the output presheaf: `objRestr` together with the
+`q`-index of the restricted shape. It is `(F.objPresheaf Z).map g.op` on the
+nose, up to the `ConcreteCategory` coercion; see `ObjFib` for why the layer is
+retained. -/
+def objFibRestr (F : PresheafPFunctor.{uI, uJ, uA, uB, vI, vJ} I J) {Z : Iᵒᵖ ⥤ Type uZ}
+    ⦃j j' : J⦄ (g : j' ⟶ j) (w : ObjFib F Z j) : ObjFib F Z j' :=
+  ⟨F.objRestr g w.1 w.2, (F.shapeRestr g ⟨w.1.shape, w.2⟩).2⟩
+
+/-- The action of an input-presheaf morphism on a fibre: the dom `map`, which
+fixes the shape and so fixes the `q`-output index. -/
+def objFibMap (F : PresheafPFunctor.{uI, uJ, uA, uB, vI, vJ} I J) {Z Z' : Iᵒᵖ ⥤ Type uZ}
+    (ν : NatTrans Z Z') {j : J} (w : ObjFib F Z j) : ObjFib F Z' j :=
+  ⟨F.toPresheafDomPFunctorData.map ν w.1, w.2⟩
+
+/-- The fibre element with shape `a : F.Shape j` and arity hom `μ`. -/
+def ofSigmaFib (F : PresheafPFunctor.{uI, uJ, uA, uB, vI, vJ} I J) {Z : Iᵒᵖ ⥤ Type uZ} {j : J}
+    (a : F.Shape j) (μ : ArityHom F a.1 Z) : ObjFib F Z j :=
+  ⟨(objEquivSigmaArityHom F Z).symm ⟨a.1, μ⟩, a.2⟩
+
+/-- Every fibre element is `ofSigmaFib` of its own shape and arity hom, which is
+what lets the laws below be proved on `ofSigmaFib` alone. -/
+theorem ofSigmaFib_self (F : PresheafPFunctor.{uI, uJ, uA, uB, vI, vJ} I J)
+    {Z : Iᵒᵖ ⥤ Type uZ} {j : J} (w : ObjFib F Z j) :
+    ofSigmaFib F ⟨w.1.shape, w.2⟩ (objEquivSigmaArityHom F Z w.1).2 = w :=
+  Subtype.ext ((objEquivSigmaArityHom F Z).symm_apply_apply w.1)
+
+/-- The `J`-restriction of an `ofSigmaFib`: the shape restricts and the arity
+hom is precomposed with `reindex`. -/
+theorem objFibRestr_ofSigmaFib (F : PresheafPFunctor.{uI, uJ, uA, uB, vI, vJ} I J)
+    {Z : Iᵒᵖ ⥤ Type uZ} ⦃j j' : J⦄ (g : j' ⟶ j) (a : F.Shape j) (μ : ArityHom F a.1 Z) :
+    objFibRestr F g (ofSigmaFib F a μ) =
+      ofSigmaFib F (F.shapeRestr g a) (reindexArityHom F g a μ) :=
+  Subtype.ext (objRestr_symm F g a.1 a.2 μ)
+
+/-- The input-presheaf action on an `ofSigmaFib`: the shape is untouched and the
+arity hom is postcomposed. -/
+theorem objFibMap_ofSigmaFib (F : PresheafPFunctor.{uI, uJ, uA, uB, vI, vJ} I J)
+    {Z Z' : Iᵒᵖ ⥤ Type uB} (ν : NatTrans Z Z') {j : J} (a : F.Shape j) (μ : ArityHom F a.1 Z) :
+    objFibMap F ν (ofSigmaFib F a μ) = ofSigmaFib F a (postcompArityHom F a.1 ν μ) :=
+  Subtype.ext (map_symm_arityHom F ν ⟨a.1, μ⟩)
+
+/-- The action of a `PshHom` on a fibre of the output presheaf. -/
+def pshHomFib (F F' : PresheafPFunctor.{uI, uJ, uA, uB, vI, vJ} I J) (φ : PshHom F F')
+    {Z : Iᵒᵖ ⥤ Type uB} (j : J) (w : ObjFib F Z j) : ObjFib F' Z j :=
+  ⟨(objEquivSigmaArityHom F' Z).symm
+      (pshHomSigma F F' φ j ⟨w.1.shape, w.2⟩ (objEquivSigmaArityHom F Z w.1).2),
+    (φ.shape.1 j ⟨w.1.shape, w.2⟩).2⟩
+
+/-- The action on an `ofSigmaFib`: the shape travels along `φ.shape`, and the
+arity hom is `φ`'s backward arity map followed by the original. -/
+theorem pshHomFib_ofSigmaFib (F F' : PresheafPFunctor.{uI, uJ, uA, uB, vI, vJ} I J)
+    (φ : PshHom F F') {Z : Iᵒᵖ ⥤ Type uB} {j : J} (a : F.Shape j) (μ : ArityHom F a.1 Z) :
+    pshHomFib F F' φ j (ofSigmaFib F a μ) =
+      ofSigmaFib F' (φ.shape.1 j a)
+        (postcompArityHom F' _ (natTransOfArityHom F a.1 μ) (φ.arity j a)) :=
+  Subtype.ext (congrArg (objEquivSigmaArityHom F' Z).symm
+    (congrArg (pshHomSigma F F' φ j a)
+      (Subtype.ext (funext fun _i ↦ funext fun b ↦ value_ofArityHom F a.1 μ b))))
+
+/-- Naturality of the action in the input presheaf. Nothing beyond `DomHom`'s
+argument: both sides postcompose the same two arity homs. -/
+theorem pshHomFib_objFibMap (F F' : PresheafPFunctor.{uI, uJ, uA, uB, vI, vJ} I J)
+    (φ : PshHom F F') {Z Z' : Iᵒᵖ ⥤ Type uB} (ν : NatTrans Z Z') (j : J) (w : ObjFib F Z j) :
+    pshHomFib F F' φ j (objFibMap F ν w) = objFibMap F' ν (pshHomFib F F' φ j w) := by
+  obtain ⟨a, μ, rfl⟩ : ∃ (a : F.Shape j) (μ : ArityHom F a.1 Z), ofSigmaFib F a μ = w :=
+    ⟨⟨w.1.shape, w.2⟩, _, ofSigmaFib_self F w⟩
+  rw [objFibMap_ofSigmaFib, pshHomFib_ofSigmaFib, pshHomFib_ofSigmaFib, objFibMap_ofSigmaFib]
+  rfl
+
+/-- Clause (c) of `PshHom` is what makes the action commute with the
+`J`-restriction of the output presheaves. The two sides carry different shapes —
+`φ.shape` of a restricted shape against the restriction of a `φ.shape`-image —
+identified only by `φ.shape.2`, and their arity homs agree across that transport
+exactly by `reindexCompat`, which is what discharges the law. That the law
+fails without clause (c) is not established here, no
+`PshHom`-minus-`reindexCompat` type being defined. -/
+theorem pshHomFib_objFibRestr (F F' : PresheafPFunctor.{uI, uJ, uA, uB, vI, vJ} I J)
+    (φ : PshHom F F') {Z : Iᵒᵖ ⥤ Type uB} ⦃j j' : J⦄ (g : j' ⟶ j) (w : ObjFib F Z j) :
+    pshHomFib F F' φ j' (objFibRestr F g w) = objFibRestr F' g (pshHomFib F F' φ j w) := by
+  obtain ⟨a, μ, rfl⟩ : ∃ (a : F.Shape j) (μ : ArityHom F a.1 Z), ofSigmaFib F a μ = w :=
+    ⟨⟨w.1.shape, w.2⟩, _, ofSigmaFib_self F w⟩
+  rw [objFibRestr_ofSigmaFib, pshHomFib_ofSigmaFib, pshHomFib_ofSigmaFib,
+    objFibRestr_ofSigmaFib]
+  refine Subtype.ext (congrArg (objEquivSigmaArityHom F' Z).symm ?_)
+  refine sigmaArityHom_ext F' (congrArg Subtype.val (φ.shape.2 g a)) _ _ fun i d ↦ ?_
+  exact congrArg (μ.1 i) (φ.reindexCompat g a d)
+
+end ShapeSideAction
+
+section ShapeSideYoneda
+
+/-!
+The representation theorem on the `J`-side: `PshHom F F'` is the same thing as a
+family of maps of output-presheaf fibres, natural in the input presheaf and
+commuting with the `J`-restriction.
+
+Both laws are needed and each supplies one half of the reconstruction: the
+`Z`-naturality is Yoneda, recovering the shape map and the arity map from the
+value at the representing presheaf `arityPresheaf F a`; the `J`-restriction law
+supplies the two remaining clauses of `PshHom`, the naturality of the shape map
+and `reindexCompat`, which are the shape component and the arity component of a
+single equation between fibre elements.
+-/
+
+variable {I : Type uI} [Category.{vI} I] {J : Type uJ} [Category.{vJ} J]
+
+/-- The generic fibre element of shape `a`: the element whose arity hom is the
+identity, bundled with its `q`-output index. Yoneda's representing datum. -/
+def genericFib (F : PresheafPFunctor.{uI, uJ, uA, uB, vI, vJ} I J) {j : J} (a : F.Shape j) :
+    ObjFib F (arityPresheaf F a.1) j :=
+  ofSigmaFib F a (idArityHom F a.1)
+
+/-- Yoneda at the fibre level: the fibre element of shape `a` and arity hom `μ`
+is the image of the generic element of shape `a` under the action of `μ`. -/
+theorem ofSigmaFib_eq_objFibMap (F : PresheafPFunctor.{uI, uJ, uA, uB, vI, vJ} I J)
+    {Z : Iᵒᵖ ⥤ Type uB} {j : J} (a : F.Shape j) (μ : ArityHom F a.1 Z) :
+    ofSigmaFib F a μ = objFibMap F (natTransOfArityHom F a.1 μ) (genericFib F a) := by
+  rw [genericFib, objFibMap_ofSigmaFib]
+  rfl
+
+/-- The arity hom the p.r.a. formula reads off an `ofArityHomElt` is the one it
+was built from. -/
+theorem objEquivSigmaArityHom_symm_snd (F : PresheafPFunctor.{uI, uJ, uA, uB, vI, vJ} I J)
+    {Z : Iᵒᵖ ⥤ Type uZ} (a : F.A) (μ : ArityHom F a Z) :
+    (objEquivSigmaArityHom F Z ((objEquivSigmaArityHom F Z).symm ⟨a, μ⟩)).2 = μ :=
+  Subtype.ext (funext fun _i ↦ funext fun b ↦ value_ofArityHom F a μ b)
+
+/-- Converse of `sigmaArityHom_ext`: an equality of fibre elements whose shapes
+agree gives agreement of the arity homs across the transport along that
+equality. -/
+theorem ofSigmaFib_apply (F : PresheafPFunctor.{uI, uJ, uA, uB, vI, vJ} I J)
+    {Z : Iᵒᵖ ⥤ Type uZ} {j : J} {s s' : F.Shape j} {γ : ArityHom F s.1 Z}
+    {γ' : ArityHom F s'.1 Z} (h : ofSigmaFib F s γ = ofSigmaFib F s' γ') (hs : s = s')
+    (i : I) (d : F.Direction s.1 i) :
+    γ.1 i d = γ'.1 i (cast (congrArg (fun t : F.Shape j ↦ F.Direction t.1 i) hs) d) := by
+  cases hs
+  have hγ : (⟨s.1, γ⟩ : Σ b : F.A, ArityHom F b Z) = ⟨s.1, γ'⟩ :=
+    (objEquivSigmaArityHom F Z).symm.injective (congrArg Subtype.val h)
+  injection hγ with _ h2
+  cases h2
+  rfl
+
+/-- The arity component of an equality between an input-presheaf image and a
+`J`-restriction of fibre elements, once their shapes are known to agree. -/
+theorem objFibMap_eq_objFibRestr_apply (F : PresheafPFunctor.{uI, uJ, uA, uB, vI, vJ} I J)
+    {Z Z' : Iᵒᵖ ⥤ Type uB} (ν : NatTrans Z Z') ⦃j j' : J⦄ (g : j' ⟶ j)
+    (u : ObjFib F Z j') (v : ObjFib F Z' j)
+    (h : objFibMap F ν u = objFibRestr F g v)
+    (hs : (⟨u.1.shape, u.2⟩ : F.Shape j') = F.shapeRestr g ⟨v.1.shape, v.2⟩)
+    (i : I) (d : F.Direction u.1.shape i) :
+    (postcompArityHom F u.1.shape ν (objEquivSigmaArityHom F Z u.1).2).1 i d =
+      (reindexArityHom F g ⟨v.1.shape, v.2⟩ (objEquivSigmaArityHom F Z' v.1).2).1 i
+        (cast (congrArg (fun t : F.Shape j' ↦ F.Direction t.1 i) hs) d) := by
+  refine ofSigmaFib_apply F ?_ hs i d
+  exact ((objFibMap_ofSigmaFib F ν ⟨u.1.shape, u.2⟩
+      (objEquivSigmaArityHom F Z u.1).2).symm.trans
+    ((congrArg (objFibMap F ν) (ofSigmaFib_self F u)).trans h)).trans
+    ((congrArg (objFibRestr F g) (ofSigmaFib_self F v).symm).trans
+      (objFibRestr_ofSigmaFib F g ⟨v.1.shape, v.2⟩ (objEquivSigmaArityHom F Z' v.1).2))
+
+/-- Families of maps of output-presheaf fibres, natural in the input presheaf
+and commuting with the `J`-restriction. The `J`-restriction is stated unbundled
+against `objFibRestr` (that is, `PresheafPFunctor.objRestr`) rather than via
+`objPresheaf.map`. Both are choice-free — `objPresheaf` is a functor into
+`Type`, not an object of a functor category — so the unbundled form is a
+presentational choice, not a constructivity one. -/
+def PshNatFamily (F F' : PresheafPFunctor.{uI, uJ, uA, uB, vI, vJ} I J) :
+    Type (max uA uI uJ vI (uB + 1)) :=
+  { η : (Z : Iᵒᵖ ⥤ Type uB) → (j : J) → ObjFib F Z j → ObjFib F' Z j //
+      (∀ (Z Z' : Iᵒᵖ ⥤ Type uB) (ν : NatTrans Z Z') (j : J) (w : ObjFib F Z j),
+          η Z' j (objFibMap F ν w) = objFibMap F' ν (η Z j w)) ∧
+        ∀ (Z : Iᵒᵖ ⥤ Type uB) ⦃j j' : J⦄ (g : j' ⟶ j) (w : ObjFib F Z j),
+          η Z j' (objFibRestr F g w) = objFibRestr F' g (η Z j w) }
+
+/-- The natural family determined by a `PshHom`. -/
+def pshHomFamily (F F' : PresheafPFunctor.{uI, uJ, uA, uB, vI, vJ} I J) (φ : PshHom F F') :
+    PshNatFamily F F' :=
+  ⟨fun _ j ↦ pshHomFib F F' φ j,
+    ⟨fun _ _ ν j w ↦ pshHomFib_objFibMap F F' φ ν j w,
+      fun _ _ _ g w ↦ pshHomFib_objFibRestr F F' φ g w⟩⟩
+
+/-- The equation the reconstruction rests on: the generic element of the
+restricted shape, pushed along `reindex`, is the restriction of the generic
+element. Both remaining `PshHom` clauses are components of it. -/
+theorem natFamily_generic (F F' : PresheafPFunctor.{uI, uJ, uA, uB, vI, vJ} I J)
+    (η : PshNatFamily F F') ⦃j j' : J⦄ (g : j' ⟶ j) (a : F.Shape j) :
+    objFibMap F'
+        (natTransOfArityHom F (F.shapeRestr g a).1 (reindexArityHom F g a (idArityHom F a.1)))
+        (η.1 (arityPresheaf F (F.shapeRestr g a).1) j' (genericFib F (F.shapeRestr g a))) =
+      objFibRestr F' g (η.1 (arityPresheaf F a.1) j (genericFib F a)) := by
+  rw [← η.2.1, ← ofSigmaFib_eq_objFibMap, ← objFibRestr_ofSigmaFib]
+  exact η.2.2 _ g (genericFib F a)
+
+/-- The shape map recovered from a natural family: the shape of its value on the
+generic element. Its naturality is the shape component of `natFamily_generic`. -/
+def natFamilyShape (F F' : PresheafPFunctor.{uI, uJ, uA, uB, vI, vJ} I J)
+    (η : PshNatFamily F F') : ShapeHom F F' :=
+  ⟨fun j a ↦ ⟨(η.1 (arityPresheaf F a.1) j (genericFib F a)).1.shape,
+      (η.1 (arityPresheaf F a.1) j (genericFib F a)).2⟩,
+    fun _ _ g a ↦ Subtype.ext (congrArg (fun w ↦ w.1.shape) (natFamily_generic F F' η g a))⟩
+
+/-- The arity map recovered from a natural family: the arity hom of its value on
+the generic element. -/
+def natFamilyArity (F F' : PresheafPFunctor.{uI, uJ, uA, uB, vI, vJ} I J)
+    (η : PshNatFamily F F') (j : J) (a : F.Shape j) :
+    ArityHom F' ((natFamilyShape F F' η).1 j a).1 (arityPresheaf F a.1) :=
+  (objEquivSigmaArityHom F' (arityPresheaf F a.1)
+    (η.1 (arityPresheaf F a.1) j (genericFib F a)).1).2
+
+/-- The `PshHom` recovered from a natural family. `reindexCompat` is the arity
+component of `natFamily_generic`, read off across the transport along the shape
+component of the same equation. -/
+def natFamilyPshHom (F F' : PresheafPFunctor.{uI, uJ, uA, uB, vI, vJ} I J)
+    (η : PshNatFamily F F') : PshHom F F' where
+  shape := natFamilyShape F F' η
+  arity := natFamilyArity F F' η
+  reindexCompat := by
+    intro j j' g a i d
+    exact objFibMap_eq_objFibRestr_apply F'
+      (natTransOfArityHom F (F.shapeRestr g a).1 (reindexArityHom F g a (idArityHom F a.1)))
+      g _ _ (natFamily_generic F F' η g a) ((natFamilyShape F F' η).2 g a) i d
+
+/-- The arity map recovered from the family of a `PshHom` is the original: the
+generic element's arity hom is the identity, so the postcomposition it induces
+is trivial. -/
+theorem natFamilyArity_pshHomFamily (F F' : PresheafPFunctor.{uI, uJ, uA, uB, vI, vJ} I J)
+    (φ : PshHom F F') (j : J) (a : F.Shape j) :
+    natFamilyArity F F' (pshHomFamily F F' φ) j a = φ.arity j a :=
+  (objEquivSigmaArityHom_symm_snd F' _ _).trans
+    (Subtype.ext (funext fun i ↦ funext fun b ↦
+      value_ofArityHom F a.1 (idArityHom F a.1) ((φ.arity j a).1 i b)))
+
+/-- The representation theorem on the `J`-side: the full morphism data of
+presheaf p.r.a. functors is the same thing as a family of maps of
+output-presheaf fibres, natural in the input presheaf and commuting with the
+`J`-restriction. -/
+def pshHomEquivNatFamily (F F' : PresheafPFunctor.{uI, uJ, uA, uB, vI, vJ} I J) :
+    PshHom F F' ≃ PshNatFamily F F' where
+  toFun := pshHomFamily F F'
+  invFun := natFamilyPshHom F F'
+  left_inv φ :=
+    PshHom.ext rfl
+      (heq_of_eq (funext fun j ↦ funext fun a ↦ natFamilyArity_pshHomFamily F F' φ j a))
+  right_inv η := by
+    refine Subtype.ext (funext fun Z ↦ funext fun j ↦ funext fun w ↦ ?_)
+    obtain ⟨a, μ, rfl⟩ : ∃ (a : F.Shape j) (μ : ArityHom F a.1 Z), ofSigmaFib F a μ = w :=
+      ⟨⟨w.1.shape, w.2⟩, _, ofSigmaFib_self F w⟩
+    change pshHomFib F F' (natFamilyPshHom F F' η) j (ofSigmaFib F a μ) =
+      η.1 Z j (ofSigmaFib F a μ)
+    refine (pshHomFib_ofSigmaFib F F' (natFamilyPshHom F F' η) a μ).trans ?_
+    refine Eq.trans ?_ (congrArg (η.1 Z j) (ofSigmaFib_eq_objFibMap F a μ)).symm
+    refine Eq.trans ?_
+      (η.2.1 (arityPresheaf F a.1) Z (natTransOfArityHom F a.1 μ) j (genericFib F a)).symm
+    exact (objFibMap_ofSigmaFib F' (natTransOfArityHom F a.1 μ)
+        ⟨(η.1 (arityPresheaf F a.1) j (genericFib F a)).1.shape,
+          (η.1 (arityPresheaf F a.1) j (genericFib F a)).2⟩
+        (objEquivSigmaArityHom F' (arityPresheaf F a.1)
+          (η.1 (arityPresheaf F a.1) j (genericFib F a)).1).2).symm.trans
+      (congrArg (objFibMap F' (natTransOfArityHom F a.1 μ))
+        (ofSigmaFib_self F' (η.1 (arityPresheaf F a.1) j (genericFib F a))))
+
+end ShapeSideYoneda
+
+end GebProto

--- a/geb-lean/vendor/geb-mathlib/Geb/Internal/PresheafIRProto/Codes.lean
+++ b/geb-lean/vendor/geb-mathlib/Geb/Internal/PresheafIRProto/Codes.lean
@@ -1,0 +1,1269 @@
+/-
+Copyright (c) 2026 Terence Rokop. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Terence Rokop
+-/
+-- Modified from geb-mathlib by scripts/geb-mathlib-backport.patch.
+module
+
+public import Geb.Internal.PresheafIRProto.Basic
+public import Geb.Mathlib.Data.PFunctor.Slice.W
+public import Mathlib.CategoryTheory.Category.Cat
+public import Mathlib.CategoryTheory.Category.Preorder
+public import Mathlib.Order.Fin.Basic
+
+/-!
+# Prototype: code combinators at the presheaf p.r.a. level
+
+Throwaway exploration, not upstream-eligible content. Continues
+`PresheafIRProto.Basic` with the semantic counterparts of the code
+constructors of Section 6 of [HancockMcBrideGhaniMalatestaAltenkirch2013],
+generalized from families to presheaves. `Basic` supplies `iotaPresheaf`;
+this module supplies the semantic operations and the code type.
+
+## Main definitions
+
+* `GebProto.DomArity` — a presheaf on `I` unbundled, in the presentation
+  `PresheafDomPFunctorData` uses for its arities.
+* `GebProto.ShapeArity` — the arity a `δ` adjoins, varying over the shape
+  presheaf.
+* `GebProto.adjoinArityData` / `GebProto.adjoinArity` — `δ`'s direction-adjoining
+  half, which is not `δ`: adjoin a `ShapeArity` to every arity of a functor,
+  leaving the shapes untouched.
+* `GebProto.BaseArity` / `GebProto.BaseArity.pullback` — the arity a code's `δ`
+  carries, indexed by output objects rather than by shapes, and its pullback
+  along a functor's shape-output map to the `ShapeArity` that `adjoinArity` consumes.
+* `GebProto.ElObj` / `GebProto.elCategory` — the category of elements of a
+  presheaf on `J`, as a base category. Presheaves on it are expected to be the
+  slice `PSh(J)/S`; nothing here establishes that.
+* `GebProto.sigmaLiftHom` / `GebProto.sigmaPshData` / `GebProto.sigmaPsh` — the
+  `σ` case: push a functor over the base `ElObj S` forward along the projection
+  to `J`.
+* `GebProto.elEqToHom` — the transport in the category of elements, with its
+  underlying `J`-morphism definitionally an `eqToHom`.
+* `GebProto.PshMor` — a morphism from a `DomArity` to a presheaf, unbundled:
+  the decodings a `δ`'s continuation may depend on.
+* `GebProto.fibreArity` — the arity a decoding adjoins, its fibres.
+* `GebProto.decPresheaf` / `GebProto.decArity` / `GebProto.delta` — the
+  decodings of an output-varying arity as a presheaf on the output base, the
+  arity indexed by that presheaf's elements, and the `δ` carrying both
+  features.
+* `GebProto.CodeShape` / `GebProto.CodeDir` / `GebProto.CodeNext` /
+  `GebProto.codePFunctor` — the polynomial functor on `Cat` whose W-type is the
+  type of codes, and `GebProto.Code`, that W-type.
+* `GebProto.praCode` / `GebProto.deltaCode` — the two code constructors. `pra`
+  abbreviates parametric right adjoint: the leaf injects a presheaf p.r.a.
+  functor as it stands, and `δ` adjoins an arity with one continuation over the
+  category of elements of its decoding presheaf.
+* `GebProto.Interp` — the interpretation's target, a presheaf p.r.a. functor
+  paired with the base category it lands in.
+* `GebProto.DomArity.presheaf` — an arity's fibrewise presentation, as a
+  presheaf on the input base.
+* `GebProto.BaseArity.famPresheaf` / `GebProto.BaseArity.reindexHom` — an
+  output-indexed arity's presheaf at each output object, and the morphism of
+  presheaves each output morphism induces.
+* `GebProto.termPsh` / `GebProto.arityVariesBase` / `GebProto.deltaVaries` —
+  the worked example's decoding target, its output-varying arity, and the
+  `δ` at it.
+* `GebProto.deltaCodeVaries` — a `δ` code at that arity.
+* `GebProto.codeAlgOn` / `GebProto.codeAlg` / `GebProto.interp` — the
+  interpretation of a code node, the slice algebra it assembles into, and the
+  fold.
+* `GebProto.praCodeOf` — the leaf as a section of the interpretation.
+
+## Main statements
+
+* `GebProto.BaseArity.isFunctorial_pullback` — the pullback of a functorial
+  `BaseArity` is functorial, so a code's `δ` need not mention its subcode's
+  shapes.
+* `GebProto.sigmaPsh_shapeRestr_id`, `GebProto.sigmaPsh_shapeRestr_comp`,
+  `GebProto.sigmaPsh_reindex_naturality`, `GebProto.sigmaPsh_reindex_id`,
+  `GebProto.sigmaPsh_reindex_comp` — the five laws the `σ` case does not
+  inherit unchanged from its subfunctor.
+* `GebProto.elObj_eq_of_hom` / `GebProto.elHom_eq_eqToHom_comp` — the source of
+  a morphism of elements is determined by its base and its underlying
+  `J`-morphism, and two morphisms with equal underlying `J`-morphisms differ by
+  that transport.
+* `GebProto.interp_praCode`, `GebProto.interp_deltaCode` — the interpretation's
+  computation rules, one per constructor, each definitional. The first of them
+  is what makes the interpretation surjective on objects.
+* `GebProto.interp_praCode_interp` — every code has the interpretation of a
+  one-node code, so `δ` adds no functor the leaf does not already supply.
+* `GebProto.leftInverse_interp_praCodeOf`, `GebProto.surjective_interp` — the
+  interpretation retracts onto the leaf, so the codes denote exactly the
+  presheaf p.r.a. functors over `ElObj D` at the universes `CodeShape` pins.
+* `GebProto.interp_deltaCodeVaries` — the check that `interp_deltaCode`'s
+  transports reduce at a closed instance.
+* `GebProto.interp_fst` — a code's index is the base its interpretation lands
+  in.
+
+## Implementation notes
+
+`ShapeArity` indexes the adjoined arity by `F`'s shapes rather than by output
+objects, which is what keeps `adjoinArityData` free of transports: the arity of the
+shape `a` is `fam a`, not `fam (F.q a)` transported along `a`'s membership
+proof. Its `IsFunctorial` mirrors `PresheafPFunctorData.IsFunctorial` clause for
+clause, so `adjoinArity`'s law proofs split over the two direction summands into the
+arity's law and `F`'s.
+
+`BaseArity.pullback` is where the transport `ShapeArity` avoids reappears: its
+reindexing runs along `g` conjugated by the two shape-membership proofs, so its
+two transported laws reduce to equalities of `J`-morphisms built from
+`eqToHom`s. `BaseArity.reindex_eqToHom`, `BaseArity.reindex_cast_shape` and
+`BaseArity.reindex_comp_apply` are the three lemmas that reduction needs.
+
+The `σ` case's laws are `eqToHom` bookkeeping over `ElObj S`. Two devices carry
+them. `elEqToHom` is a transport whose underlying `J`-morphism reduces
+definitionally, because `eqToHom` is opaque to `rw` and `simp` and blocks the
+`J`-level identities the laws reduce to. And the reindexing laws are stated and
+combined through `HEq`, because a direction over a restricted shape and its
+counterpart over the same shape reached by a different route have types that
+agree only once the morphisms are identified; `reindex_heq_congr_shape`,
+`reindex_heq_eqToHom`, `reindex_eq_of_eq_comp` and
+`reindex_eq_of_eq_eqToHom_comp` are the resulting toolkit.
+
+The code type is the W-type of a slice polynomial functor on `Cat`, not an
+inductive family: the index is a base category, which `δ` replaces by the
+category of elements of its decoding presheaf. `Cat.{v, u}` is closed under
+that step because the category of elements of a presheaf valued in `Type u` on
+a base in `Type u` is again in `Type u`, with homs a subtype of the base's. The
+arity carrier universe is pinned to the base's, which the prototype does not
+need to vary. Nothing here is defined simultaneously with anything else, so no
+inductive-inductive definition or encoding of one is required.
+
+## References
+
+* [DybjerSetzer1999]
+* [HancockMcBrideGhaniMalatestaAltenkirch2013]
+* [MacLaneMoerdijk1992]
+* [nLabParametricRightAdjoint]
+
+## Tags
+
+prototype, inductive-recursive, presheaf, parametric right adjoint
+-/
+
+@[expose] public section
+
+universe uI uJ uA uB uS uD vI vJ u v
+
+open CategoryTheory
+
+namespace GebProto
+
+section Arity
+
+variable {I : Type uI} [Category.{vI} I] {J : Type uJ} [Category.{vJ} J]
+
+/-- A presheaf on `I`, unbundled: a carrier with a base-point map `proj`, the
+directions over `i` being the fiber of `proj`, and the contravariant action
+`restr` on those fibers. Presented the way `PresheafDomPFunctorData` presents
+its arities, so that these directions plug into a `PresheafPFunctorData`'s
+without transport.
+
+Writing this as `Iᵒᵖ ⥤ Type uB` and its morphisms with `⟶` would draw in
+`Classical.choice` through `CategoryTheory.Functor.category`. -/
+@[ext] structure DomArity (I : Type uI) [Category.{vI} I] : Type (max (uB + 1) uI vI) where
+  /-- The total space of the arity. -/
+  carrier : Type uB
+  /-- The base-point map assigning each element of the carrier an input object. -/
+  proj : carrier → I
+  /-- The contravariant `I`-action on the fibers of `proj`. -/
+  restr : ∀ ⦃i i' : I⦄, (i' ⟶ i) → {c : carrier // proj c = i} → {c : carrier // proj c = i'}
+
+namespace DomArity
+
+/-- The directions lying over the input object `i`: the fiber of `proj`. -/
+@[reducible] def Dir (G : DomArity.{uI, uB, vI} I) (i : I) : Type uB :=
+  {c : G.carrier // G.proj c = i}
+
+/-- The presheaf laws of a `DomArity`. -/
+structure IsFunctorial (G : DomArity.{uI, uB, vI} I) : Prop where
+  /-- `restr` preserves identities. -/
+  restr_id : ∀ i : I, G.restr (𝟙 i) = id
+  /-- `restr` reverses composition. -/
+  restr_comp : ∀ ⦃i i' i'' : I⦄ (f : i' ⟶ i) (g : i'' ⟶ i'),
+    G.restr (g ≫ f) = G.restr g ∘ G.restr f
+
+/-- The arity as a presheaf on the input base: the fibers of `proj` with their
+own restriction. A `DomArity` is the total-space presentation of a discrete
+fibration over `I`, and this is the presheaf that fibration classifies. Discrete
+fibrations in this role are what [nLabParametricRightAdjoint] specifies. -/
+def presheaf (G : DomArity.{uI, uB, vI} I) (hG : G.IsFunctorial) : Iᵒᵖ ⥤ Type uB where
+  obj i := G.Dir i.unop
+  map f := ↾ G.restr f.unop
+  map_id i := by
+    ext c
+    exact congrArg Subtype.val (congrFun (hG.restr_id i.unop) c)
+  map_comp f g := by
+    ext c
+    exact congrArg Subtype.val (congrFun (hG.restr_comp f.unop g.unop) c)
+
+end DomArity
+
+end Arity
+
+section Delta
+
+variable {I : Type uI} [Category.{vI} I] {J : Type uJ} [Category.{vJ} J]
+
+/-- The arity adjoined by a `δ`, varying over `F`'s shape presheaf: a presheaf
+on `I` for each shape, together with a reindexing along shape restriction. This
+carries a family over `F.A` with a reindexing along `shapeRestr`; reading that
+as the unbundled data of a functor `el(T₁) ⥤ (Iᵒᵖ ⥤ Type)` — covariant, since
+a morphism of `el(T₁)` runs from a restricted shape to the shape and `reindex`
+follows it — is not elaborated here, there being no counterpart of
+`BaseArity.functor` for it — the same data
+`PresheafPFunctorData` carries in its `directionRestr` and `reindex` fields.
+
+Indexing by shapes rather than by output objects is what keeps the `δ`
+operation transport-free: the arity of the shape `a` is `fam a`, not
+`fam (F.q a)` transported along `a`'s membership proof. -/
+@[ext] structure ShapeArity (F : PresheafPFunctorData.{uI, uJ, uA, uB, vI, vJ} I J) :
+    Type (max (uB + 1) uA uI uJ vI vJ) where
+  /-- The presheaf on `I` adjoined over each shape. -/
+  fam : F.A → DomArity.{uI, uB, vI} I
+  /-- Reindexing along shape restriction, in the direction of
+  `PresheafPFunctorData.reindex`. -/
+  reindex : ∀ ⦃j j' : J⦄ (g : j' ⟶ j) (s : F.Shape j) ⦃i : I⦄,
+    (fam (F.shapeRestr g s).1).Dir i → (fam s.1).Dir i
+
+namespace ShapeArity
+
+/-- The functor laws of a `ShapeArity`, mirroring those of
+`PresheafPFunctorData` clause for clause: `reindex_id` and `reindex_comp` carry
+the same `cast` along `F`'s shape-restriction laws. -/
+structure IsFunctorial (F : PresheafPFunctor.{uI, uJ, uA, uB, vI, vJ} I J)
+    (P : ShapeArity F.toPresheafPFunctorData) : Prop where
+  /-- Each adjoined presheaf preserves identities. -/
+  restr_id : ∀ (a : F.A) (i : I), (P.fam a).restr (𝟙 i) = id
+  /-- Each adjoined presheaf reverses composition. -/
+  restr_comp : ∀ (a : F.A) ⦃i i' i'' : I⦄ (f : i' ⟶ i) (g : i'' ⟶ i'),
+    (P.fam a).restr (g ≫ f) = (P.fam a).restr g ∘ (P.fam a).restr f
+  /-- Reindexing is a morphism of presheaves on `I`. -/
+  reindex_naturality : ∀ ⦃j j' : J⦄ (g : j' ⟶ j) (s : F.Shape j) ⦃i i' : I⦄ (f : i' ⟶ i),
+    (P.fam s.1).restr f ∘ P.reindex g s (i := i) =
+      P.reindex g s (i := i') ∘ (P.fam (F.shapeRestr g s).1).restr f
+  /-- Reindexing along an identity is the transport along `F.shapeRestr_id`. -/
+  reindex_id : ∀ ⦃j : J⦄ (s : F.Shape j) ⦃i : I⦄
+      (d : (P.fam (F.shapeRestr (𝟙 j) s).1).Dir i),
+    P.reindex (𝟙 j) s d =
+      cast (congrArg (fun u : F.Shape j ↦ (P.fam u.1).Dir i)
+        (congrFun (F.isFunctorial.shapeRestr_id j) s)) d
+  /-- Reindexing along a composite factors, modulo the transport along
+  `F.shapeRestr_comp`. -/
+  reindex_comp : ∀ ⦃j j' j'' : J⦄ (g : j' ⟶ j) (h : j'' ⟶ j') (s : F.Shape j) ⦃i : I⦄
+      (d : (P.fam (F.shapeRestr (h ≫ g) s).1).Dir i),
+    P.reindex (h ≫ g) s d =
+      P.reindex g s (P.reindex h (F.shapeRestr g s)
+        (cast (congrArg (fun u : F.Shape j'' ↦ (P.fam u.1).Dir i)
+          (congrFun (F.isFunctorial.shapeRestr_comp g h) s)) d))
+
+end ShapeArity
+
+/-- Operations of `δ`'s direction-adjoining half: adjoin the arity `P` to every arity of `F`,
+leaving the shapes untouched. -/
+def adjoinArityData (F : PresheafPFunctorData.{uI, uJ, uA, uB, vI, vJ} I J) (P : ShapeArity F) :
+    PresheafPFunctorData.{uI, uJ, uA, uB, vI, vJ} I J where
+  A := F.A
+  B := fun a ↦ (P.fam a).carrier ⊕ F.B a
+  r := fun x ↦ Sum.elim (P.fam x.1).proj (fun b ↦ F.r ⟨x.1, b⟩) x.2
+  q := F.q
+  directionRestr := fun a _ _ g d ↦
+    match d with
+    | ⟨Sum.inl c, h⟩ => ⟨Sum.inl ((P.fam a).restr g ⟨c, h⟩).1, ((P.fam a).restr g ⟨c, h⟩).2⟩
+    | ⟨Sum.inr b, h⟩ => ⟨Sum.inr (F.directionRestr a g ⟨b, h⟩).1, (F.directionRestr a g ⟨b, h⟩).2⟩
+  shapeRestr := fun {_ _} g s ↦ F.shapeRestr g s
+  reindex := fun {_ _} g s _ d ↦
+    match d with
+    | ⟨Sum.inl c, h⟩ => ⟨Sum.inl (P.reindex g s ⟨c, h⟩).1, (P.reindex g s ⟨c, h⟩).2⟩
+    | ⟨Sum.inr b, h⟩ => ⟨Sum.inr (F.reindex g s ⟨b, h⟩).1, (F.reindex g s ⟨b, h⟩).2⟩
+
+variable (F : PresheafPFunctorData.{uI, uJ, uA, uB, vI, vJ} I J) (P : ShapeArity F)
+
+/-- Transport of an adjoined direction along an equality of shapes is the
+transport of that direction inside the arity. -/
+theorem adjoinArity_cast_inl {j : J} {i : I} {t t' : F.Shape j} (e : t = t')
+    (d : (P.fam t.1).Dir i) :
+    cast (congrArg (fun u : F.Shape j ↦ (adjoinArityData F P).Direction u.1 i) e)
+        (⟨Sum.inl d.1, d.2⟩ : (adjoinArityData F P).Direction t.1 i) =
+      ⟨Sum.inl (cast (congrArg (fun u : F.Shape j ↦ (P.fam u.1).Dir i) e) d).1,
+        (cast (congrArg (fun u : F.Shape j ↦ (P.fam u.1).Dir i) e) d).2⟩ := by
+  cases e
+  rfl
+
+/-- Transport of an original direction along an equality of shapes is the
+transport of that direction inside `F`. -/
+theorem adjoinArity_cast_inr {j : J} {i : I} {t t' : F.Shape j} (e : t = t')
+    (d : F.Direction t.1 i) :
+    cast (congrArg (fun u : F.Shape j ↦ (adjoinArityData F P).Direction u.1 i) e)
+        (⟨Sum.inr d.1, d.2⟩ : (adjoinArityData F P).Direction t.1 i) =
+      ⟨Sum.inr (cast (congrArg (fun u : F.Shape j ↦ F.Direction u.1 i) e) d).1,
+        (cast (congrArg (fun u : F.Shape j ↦ F.Direction u.1 i) e) d).2⟩ := by
+  cases e
+  rfl
+
+/-- Adjoining an arity to a presheaf p.r.a. functor yields one: the shape-side
+laws are `F`'s unchanged, and each direction-side law splits over the two
+summands into the arity's law and `F`'s.
+
+This is not `δ`. It is `δ`'s direction-adjoining half; `delta` is the rule,
+and adds the coproduct over decodings that this leaves out. -/
+def adjoinArity (F : PresheafPFunctor.{uI, uJ, uA, uB, vI, vJ} I J)
+    (P : ShapeArity F.toPresheafPFunctorData) (hP : P.IsFunctorial F) :
+    PresheafPFunctor.{uI, uJ, uA, uB, vI, vJ} I J where
+  toPresheafPFunctorData := adjoinArityData F.toPresheafPFunctorData P
+  isFunctorial :=
+    { directionRestr_id := by
+        intro a i
+        funext d
+        obtain ⟨b, h⟩ := d
+        cases b with
+        | inl c =>
+            exact Subtype.ext (congrArg (fun x : (P.fam a).Dir i ↦ Sum.inl x.1)
+              (congrFun (hP.restr_id a i) ⟨c, h⟩))
+        | inr b =>
+            exact Subtype.ext (congrArg (fun x : F.Direction a i ↦ Sum.inr x.1)
+              (congrFun (F.isFunctorial.directionRestr_id a i) ⟨b, h⟩))
+      directionRestr_comp := by
+        intro a i i' i'' f g
+        funext d
+        obtain ⟨b, h⟩ := d
+        cases b with
+        | inl c =>
+            exact Subtype.ext (congrArg (fun x : (P.fam a).Dir i'' ↦ Sum.inl x.1)
+              (congrFun (hP.restr_comp a f g) ⟨c, h⟩))
+        | inr b =>
+            exact Subtype.ext (congrArg (fun x : F.Direction a i'' ↦ Sum.inr x.1)
+              (congrFun (F.isFunctorial.directionRestr_comp a f g) ⟨b, h⟩))
+      shapeRestr_id := F.isFunctorial.shapeRestr_id
+      shapeRestr_comp := F.isFunctorial.shapeRestr_comp
+      reindex_naturality := by
+        intro j j' g a i i' f
+        funext d
+        obtain ⟨b, h⟩ := d
+        cases b with
+        | inl c =>
+            exact Subtype.ext (congrArg (fun x : (P.fam a.1).Dir i' ↦ Sum.inl x.1)
+              (congrFun (hP.reindex_naturality g a f) ⟨c, h⟩))
+        | inr b =>
+            exact Subtype.ext (congrArg (fun x : F.Direction a.1 i' ↦ Sum.inr x.1)
+              (congrFun (F.isFunctorial.reindex_naturality g a f) ⟨b, h⟩))
+      reindex_id := by
+        intro j a i d
+        obtain ⟨b, h⟩ := d
+        cases b with
+        | inl c =>
+            refine Eq.trans ?_ (adjoinArity_cast_inl F.toPresheafPFunctorData P
+              (congrFun (F.isFunctorial.shapeRestr_id j) a) ⟨c, h⟩).symm
+            exact Subtype.ext (congrArg (fun x : (P.fam a.1).Dir i ↦ Sum.inl x.1)
+              (hP.reindex_id a ⟨c, h⟩))
+        | inr b =>
+            refine Eq.trans ?_ (adjoinArity_cast_inr F.toPresheafPFunctorData P
+              (congrFun (F.isFunctorial.shapeRestr_id j) a) ⟨b, h⟩).symm
+            exact Subtype.ext (congrArg (fun x : F.Direction a.1 i ↦ Sum.inr x.1)
+              (F.isFunctorial.reindex_id a ⟨b, h⟩))
+      reindex_comp := by
+        intro j j' j'' g h a i d
+        obtain ⟨b, hb⟩ := d
+        cases b with
+        | inl c =>
+            refine Eq.trans ?_ (congrArg (fun z ↦
+              (adjoinArityData F.toPresheafPFunctorData P).reindex g a
+                ((adjoinArityData F.toPresheafPFunctorData P).reindex h
+                  ((adjoinArityData F.toPresheafPFunctorData P).shapeRestr g a) z))
+              (adjoinArity_cast_inl F.toPresheafPFunctorData P
+                (congrFun (F.isFunctorial.shapeRestr_comp g h) a) ⟨c, hb⟩)).symm
+            exact Subtype.ext (congrArg (fun x : (P.fam a.1).Dir i ↦ Sum.inl x.1)
+              (hP.reindex_comp g h a ⟨c, hb⟩))
+        | inr b =>
+            refine Eq.trans ?_ (congrArg (fun z ↦
+              (adjoinArityData F.toPresheafPFunctorData P).reindex g a
+                ((adjoinArityData F.toPresheafPFunctorData P).reindex h
+                  ((adjoinArityData F.toPresheafPFunctorData P).shapeRestr g a) z))
+              (adjoinArity_cast_inr F.toPresheafPFunctorData P
+                (congrFun (F.isFunctorial.shapeRestr_comp g h) a) ⟨b, hb⟩)).symm
+            exact Subtype.ext (congrArg (fun x : F.Direction a.1 i ↦ Sum.inr x.1)
+              (F.isFunctorial.reindex_comp g h a ⟨b, hb⟩)) }
+
+section Base
+
+variable {I : Type uI} [Category.{vI} I] {J : Type uJ} [Category.{vJ} J]
+
+/-- The arity a code's `δ` carries: a presheaf on `I` for each output object,
+with a reindexing along `J`-morphisms. This is the data of a functor
+`J ⥤ (Iᵒᵖ ⥤ Type)`, unbundled.
+
+A code's `δ` must be indexed this way rather than by shapes: the shapes belong
+to the subcode's interpretation, which a code cannot mention. `pullback`
+converts it to the shape-indexed `ShapeArity` that `adjoinArity` consumes. -/
+@[ext] structure BaseArity (I : Type uI) [Category.{vI} I] (J : Type uJ) [Category.{vJ} J] :
+    Type (max (uB + 1) uI uJ vI vJ) where
+  /-- The presheaf on `I` carried over each output object. -/
+  fam : J → DomArity.{uI, uB, vI} I
+  /-- Reindexing along a `J`-morphism, covariant, matching the direction of
+  `PresheafPFunctorData.reindex`. -/
+  reindex : ∀ ⦃j j' : J⦄, (j' ⟶ j) → ∀ ⦃i : I⦄, (fam j').Dir i → (fam j).Dir i
+
+namespace BaseArity
+
+/-- The functor laws of a `BaseArity`. No `cast` appears: there is no shape
+presheaf to transport along. -/
+structure IsFunctorial (P : BaseArity.{uI, uJ, uB, vI, vJ} I J) : Prop where
+  /-- Each presheaf preserves identities. -/
+  restr_id : ∀ (j : J) (i : I), (P.fam j).restr (𝟙 i) = id
+  /-- Each presheaf reverses composition. -/
+  restr_comp : ∀ (j : J) ⦃i i' i'' : I⦄ (f : i' ⟶ i) (g : i'' ⟶ i'),
+    (P.fam j).restr (g ≫ f) = (P.fam j).restr g ∘ (P.fam j).restr f
+  /-- Reindexing preserves identities. -/
+  reindex_id : ∀ (j : J) (i : I), P.reindex (𝟙 j) (i := i) = id
+  /-- Reindexing preserves composition, `g` being the outer factor. -/
+  reindex_comp : ∀ ⦃j j' j'' : J⦄ (g : j' ⟶ j) (h : j'' ⟶ j') (i : I),
+    P.reindex (h ≫ g) (i := i) = P.reindex g (i := i) ∘ P.reindex h (i := i)
+  /-- Reindexing is a morphism of presheaves on `I`. -/
+  reindex_naturality : ∀ ⦃j j' : J⦄ (g : j' ⟶ j) ⦃i i' : I⦄ (f : i' ⟶ i),
+    (P.fam j).restr f ∘ P.reindex g (i := i) = P.reindex g (i := i') ∘ (P.fam j').restr f
+
+variable (P : BaseArity.{uI, uJ, uB, vI, vJ} I J)
+
+/-- Each fibrewise arity of a functorial `BaseArity` is itself functorial: the
+first two clauses of `IsFunctorial` are `DomArity.IsFunctorial` at each output
+object. -/
+theorem isFunctorial_fam (hP : P.IsFunctorial) (j : J) : (P.fam j).IsFunctorial where
+  restr_id := hP.restr_id j
+  restr_comp := hP.restr_comp j
+
+/-- The arity carried over the output object `j`, as a presheaf on the input
+base — equivalently, as the discrete fibration over `I` that `δ` adjoins
+there. -/
+def famPresheaf (hP : P.IsFunctorial) (j : J) : Iᵒᵖ ⥤ Type uB :=
+  (P.fam j).presheaf (isFunctorial_fam P hP j)
+
+/-- Reindexing along a `J`-morphism is a morphism of those presheaves. Stated as
+a bare `NatTrans` rather than as a functor-category `⟶`, which would need the
+`Classical.choice`-dependent `Functor.category` instance. -/
+def reindexHom (hP : P.IsFunctorial) ⦃j j' : J⦄ (g : j' ⟶ j) :
+    NatTrans (famPresheaf P hP j') (famPresheaf P hP j) where
+  app i := ↾ P.reindex g (i := i.unop)
+  naturality := by
+    intro i i' f
+    ext d
+    exact congrFun (hP.reindex_naturality g f.unop).symm d
+
+/-- Reindexing along an `eqToHom` is the transport along the underlying
+equality. -/
+theorem reindex_eqToHom (hP : P.IsFunctorial) {x y : J} (hh : x = y) {i : I}
+    (d : (P.fam x).Dir i) :
+    P.reindex (eqToHom hh) d = cast (congrArg (fun w : J ↦ (P.fam w).Dir i) hh) d := by
+  cases hh
+  simpa using congrFun (hP.reindex_id x i) d
+
+/-- Reindexing along a composite, applied pointwise. -/
+theorem reindex_comp_apply (hP : P.IsFunctorial) {x y z : J} (k₁ : x ⟶ y) (k₂ : y ⟶ z)
+    {i : I} (d : (P.fam x).Dir i) :
+    P.reindex (k₁ ≫ k₂) d = P.reindex k₂ (P.reindex k₁ d) :=
+  congrFun (hP.reindex_comp k₂ k₁ i) d
+
+/-- Reindexing after a transport along an equality of shapes is reindexing
+along the composite with that equality's `eqToHom`. -/
+theorem reindex_cast_shape (F : PresheafPFunctorData.{uI, uJ, uA, uB, vI, vJ} I J)
+    {j : J} {t t' : F.Shape j} (hh : t = t') {x : J} (k : F.q t'.1 ⟶ x) {i : I}
+    (d : (P.fam (F.q t.1)).Dir i) :
+    P.reindex k (cast (congrArg (fun u : F.Shape j ↦ (P.fam (F.q u.1)).Dir i) hh) d) =
+      P.reindex (eqToHom (congrArg (fun u : F.Shape j ↦ F.q u.1) hh) ≫ k) d := by
+  cases hh
+  simp
+
+/-- Pull a `BaseArity` back along a functor's shape-output map: the arity over
+the shape `a` is the arity over `F.q a`, reindexed along the `J`-morphism `g`
+transported by the two shape-membership proofs. -/
+def pullback (F : PresheafPFunctorData.{uI, uJ, uA, uB, vI, vJ} I J) : ShapeArity F where
+  fam := fun a ↦ P.fam (F.q a)
+  reindex := fun {_ _} g s {_} d ↦
+    P.reindex (eqToHom (F.shapeRestr g s).2 ≫ g ≫ eqToHom s.2.symm) d
+
+/-- The pullback of a functorial `BaseArity` is functorial. The two transported
+laws reduce, via `reindex_eqToHom` and `reindex_cast_shape`, to equalities of
+`J`-morphisms built from `eqToHom`s, which cancel. -/
+theorem isFunctorial_pullback (hP : P.IsFunctorial)
+    (F : PresheafPFunctor.{uI, uJ, uA, uB, vI, vJ} I J) :
+    (P.pullback F.toPresheafPFunctorData).IsFunctorial F where
+  restr_id := fun a i ↦ hP.restr_id (F.q a) i
+  restr_comp := by intro a i i' i'' f g; exact hP.restr_comp (F.q a) f g
+  reindex_naturality := by
+    intro j j' g s i i' f
+    exact hP.reindex_naturality (eqToHom (F.shapeRestr g s).2 ≫ g ≫ eqToHom s.2.symm) f
+  reindex_id := by
+    intro j s i d
+    simp only [pullback] at d ⊢
+    rw [show
+      (eqToHom (F.shapeRestr (𝟙 j) s).2 ≫ (𝟙 j) ≫ eqToHom s.2.symm) =
+        eqToHom (((F.shapeRestr (𝟙 j) s).2).trans s.2.symm) by simp,
+      reindex_eqToHom P hP]
+    rfl
+  reindex_comp := by
+    intro j j' j'' g h s i d
+    simp only [pullback] at d ⊢
+    change _ = P.reindex _ (P.reindex _
+      (cast (congrArg (fun u : F.Shape j'' ↦ (P.fam (F.q u.1)).Dir i)
+        (congrFun (F.isFunctorial.shapeRestr_comp g h) s)) d))
+    rw [reindex_cast_shape (hh := congrFun (F.isFunctorial.shapeRestr_comp g h) s),
+      ← reindex_comp_apply P hP]
+    congr 1
+    simp
+
+end BaseArity
+
+end Base
+
+end Delta
+
+section Sigma
+
+variable {I : Type uI} [Category.{vI} I] {J : Type uJ} [Category.{vJ} J]
+
+/-- Objects of the base category of elements of a presheaf `S` on `J`. -/
+abbrev ElObj (S : Jᵒᵖ ⥤ Type uS) : Type (max uJ uS) := Σ j : J, S.obj ⟨j⟩
+
+/-- The base category of elements of `S`: a morphism `x ⟶ y` is a `J`-morphism
+carrying `y`'s element to `x`'s. It is the category of elements of
+[MacLaneMoerdijk1992] Chapter I. Presheaves on it are expected to be the slice
+`PSh(J)/S`, and it is expected to agree with `S.Elementsᵒᵖ`; neither is
+established here. It is written out rather than reused so that the
+`σ` operation below is free of `Opposite` transport. -/
+instance elCategory (S : Jᵒᵖ ⥤ Type uS) : Category.{vJ} (ElObj.{uJ, uS, vJ} S) where
+  Hom x y := {g : x.1 ⟶ y.1 // S.map g.op y.2 = x.2}
+  id x := ⟨𝟙 x.1, by simp⟩
+  comp {x y z} f g := ⟨f.1 ≫ g.1, by
+    rw [op_comp, S.map_comp, types_comp_apply, g.2, f.2]⟩
+  id_comp f := Subtype.ext (Category.id_comp f.1)
+  comp_id f := Subtype.ext (Category.comp_id f.1)
+  assoc f g h := Subtype.ext (Category.assoc f.1 g.1 h.1)
+
+/-- The morphism of `ElObj S` a shape's membership proof turns `g` into, whose
+underlying `J`-morphism is: `g` followed by
+the transport identifying `j` with the base of the shape's output object. -/
+def sigmaLiftHom (S : Jᵒᵖ ⥤ Type uS)
+    (F : PresheafPFunctorData.{uI, max uJ uS, uA, uB, vI, vJ} I (ElObj S))
+    {j j' : J} (g : j' ⟶ j) (s : {a : F.A // (F.q a).1 = j}) :
+    (⟨j', S.map (g ≫ eqToHom s.2.symm).op (F.q s.1).2⟩ : ElObj S) ⟶ F.q s.1 :=
+  ⟨g ≫ eqToHom s.2.symm, rfl⟩
+
+/-- Operations of the `σ` case: push a functor over the base `ElObj S` forward
+to one over `J`. The shapes and arities are unchanged; only the shape-output map
+drops the `S`-component, so the shape presheaf becomes the total space of `S`
+paired with the subfunctor's shapes. -/
+def sigmaPshData (S : Jᵒᵖ ⥤ Type uS)
+    (F : PresheafPFunctorData.{uI, max uJ uS, uA, uB, vI, vJ} I (ElObj S)) :
+    PresheafPFunctorData.{uI, uJ, uA, uB, vI, vJ} I J where
+  A := F.A
+  B := F.B
+  r := F.r
+  q := fun a ↦ (F.q a).1
+  directionRestr := F.directionRestr
+  shapeRestr := fun {_ _} g s ↦
+    ⟨(F.shapeRestr (sigmaLiftHom S F g s) ⟨s.1, rfl⟩).1,
+      congrArg Sigma.fst (F.shapeRestr (sigmaLiftHom S F g s) ⟨s.1, rfl⟩).2⟩
+  reindex := fun {_ _} g s {_} d ↦ F.reindex (sigmaLiftHom S F g s) ⟨s.1, rfl⟩ d
+
+universe uK vK
+
+/-- The underlying `J`-morphism of an identity in the category of elements. -/
+@[simp] theorem elCategory_id_val (S : Jᵒᵖ ⥤ Type uS) (x : ElObj.{uJ, uS, vJ} S) :
+    (𝟙 x : x ⟶ x).1 = 𝟙 x.1 := rfl
+
+/-- The underlying `J`-morphism of a composite in the category of elements. -/
+@[simp] theorem elCategory_comp_val (S : Jᵒᵖ ⥤ Type uS) {x y z : ElObj.{uJ, uS, vJ} S}
+    (f : x ⟶ y) (g : y ⟶ z) : (f ≫ g).1 = f.1 ≫ g.1 := rfl
+
+/-- The underlying `J`-morphism of a transport in the category of elements is
+the transport of the underlying objects. -/
+@[simp]
+theorem elCategory_eqToHom_val (S : Jᵒᵖ ⥤ Type uS) {x y : ElObj.{uJ, uS, vJ} S} (h : x = y) :
+    (eqToHom h : x ⟶ y).1 = eqToHom (congrArg Sigma.fst h) := by
+  cases h
+  rfl
+
+/-- Restricting a shape along a transport is the transport of the shape. -/
+theorem shapeRestr_eqToHom {K : Type uK} [Category.{vK} K]
+    (F : PresheafPFunctor.{uI, uK, uA, uB, vI, vK} I K) {x y : K} (h : x = y) (s : F.Shape y) :
+    F.shapeRestr (eqToHom h) s = cast (congrArg F.Shape h.symm) s := by
+  cases h
+  simpa using congrFun (F.isFunctorial.shapeRestr_id x) s
+
+/-- A transport of shapes leaves the underlying shape alone. -/
+theorem cast_shape_val {K : Type uK} [Category.{vK} K]
+    (F : PresheafPFunctorData.{uI, uK, uA, uB, vI, vK} I K) {x y : K} (h : x = y)
+    (s : F.Shape x) : (cast (congrArg F.Shape h) s).1 = s.1 := by
+  cases h
+  rfl
+
+/-- Restricting along a morphism with a transport prefix leaves the underlying
+shape where restricting along the morphism alone leaves it. -/
+theorem shapeRestr_val_eqToHom_comp {K : Type uK} [Category.{vK} K]
+    (F : PresheafPFunctor.{uI, uK, uA, uB, vI, vK} I K) {x x' y : K} (hx : x = x')
+    (m : x' ⟶ y) (s : F.Shape y) :
+    (F.shapeRestr (eqToHom hx ≫ m) s).1 = (F.shapeRestr m s).1 := by
+  rw [F.isFunctorial.shapeRestr_comp, Function.comp_apply, shapeRestr_eqToHom]
+  exact cast_shape_val F.toPresheafPFunctorData hx.symm _
+
+/-- The transport morphism in the category of elements, defined so that its
+underlying `J`-morphism is definitionally an `eqToHom`. `eqToHom` itself is
+opaque under `rw` and `simp`, which blocks the `J`-level identities the `σ`
+laws reduce to. -/
+def elEqToHom (S : Jᵒᵖ ⥤ Type uS) {x y : ElObj.{uJ, uS, vJ} S} (h : x = y) : x ⟶ y :=
+  ⟨eqToHom (congrArg Sigma.fst h), by cases h; simp⟩
+
+/-- `elEqToHom` is the categorical transport. Deliberately not `@[simp]`: the
+`J`-level identities the `σ` laws reduce to need the `elEqToHom` form. -/
+theorem elEqToHom_eq (S : Jᵒᵖ ⥤ Type uS) {x y : ElObj.{uJ, uS, vJ} S} (h : x = y) :
+    elEqToHom S h = eqToHom h := by
+  cases h
+  rfl
+
+/-- The source of a morphism in the category of elements is determined by its
+base and its underlying `J`-morphism: the element is forced to be the
+restriction of the target's. -/
+theorem elObj_eq_of_hom (S : Jᵒᵖ ⥤ Type uS) {x x' y : ElObj.{uJ, uS, vJ} S}
+    (m : x ⟶ y) (m' : x' ⟶ y) (hb : x.1 = x'.1) (hm : m.1 = eqToHom hb ≫ m'.1) : x = x' := by
+  cases x with
+  | mk xb xe =>
+    cases x' with
+    | mk xb' xe' =>
+      cases hb
+      refine Sigma.ext rfl (heq_of_eq ?_)
+      rw [← m.2, ← m'.2, hm]
+      simp
+
+/-- Two morphisms into the same object with equal underlying `J`-morphisms
+differ by the transport identifying their sources. -/
+theorem elHom_eq_eqToHom_comp (S : Jᵒᵖ ⥤ Type uS) {x x' y : ElObj.{uJ, uS, vJ} S}
+    (m : x ⟶ y) (m' : x' ⟶ y) (hb : x.1 = x'.1) (hm : m.1 = eqToHom hb ≫ m'.1) :
+    m = eqToHom (elObj_eq_of_hom S m m' hb hm) ≫ m' := by
+  refine Subtype.ext ?_
+  rw [hm]
+  change _ = (eqToHom (elObj_eq_of_hom S m m' hb hm) : x ⟶ x').1 ≫ m'.1
+  rw [elCategory_eqToHom_val]
+
+/-- The `σ` operation preserves the shape-restriction identity law. -/
+theorem sigmaPsh_shapeRestr_id (S : Jᵒᵖ ⥤ Type uS)
+    (F : PresheafPFunctor.{uI, max uJ uS, uA, uB, vI, vJ} I (ElObj S)) :
+    (sigmaPshData S F.toPresheafPFunctorData).ShapeRestrId := by
+  intro j
+  funext s
+  obtain ⟨a, rfl⟩ := s
+  refine Subtype.ext ?_
+  have hsrc : (⟨(F.q a).1, S.map (sigmaLiftHom S F.toPresheafPFunctorData
+      (𝟙 ((F.q a).1)) ⟨a, rfl⟩).1.op (F.q a).2⟩ : ElObj S) = F.q a :=
+    Sigma.ext rfl (heq_of_eq (by simp [sigmaLiftHom]))
+  have hval : (eqToHom hsrc : _ ⟶ F.q a).1 = 𝟙 (F.q a).1 := by
+    rw [elCategory_eqToHom_val]
+    simp
+  have hm : sigmaLiftHom S F.toPresheafPFunctorData (𝟙 ((F.q a).1)) ⟨a, rfl⟩
+      = eqToHom hsrc ≫ 𝟙 (F.q a) :=
+    Subtype.ext (by
+      simp only [sigmaLiftHom, eqToHom_refl, op_comp, op_id, Category.comp_id]
+      exact hval.symm)
+  change (F.shapeRestr (sigmaLiftHom S F.toPresheafPFunctorData (𝟙 _) ⟨a, rfl⟩) ⟨a, rfl⟩).1 = a
+  rw [hm]
+  refine Eq.trans (shapeRestr_val_eqToHom_comp F hsrc (𝟙 (F.q a)) ⟨a, rfl⟩) ?_
+  exact congrArg Subtype.val (congrFun (F.isFunctorial.shapeRestr_id (F.q a)) ⟨a, rfl⟩)
+
+/-- The `σ` operation preserves the shape-restriction composition law. -/
+theorem sigmaPsh_shapeRestr_comp (S : Jᵒᵖ ⥤ Type uS)
+    (F : PresheafPFunctor.{uI, max uJ uS, uA, uB, vI, vJ} I (ElObj S)) :
+    (sigmaPshData S F.toPresheafPFunctorData).ShapeRestrComp := by
+  intro j j' j'' g h
+  funext s
+  obtain ⟨a, rfl⟩ := s
+  refine Subtype.ext ?_
+  change (F.shapeRestr (sigmaLiftHom S F.toPresheafPFunctorData (h ≫ g) ⟨a, rfl⟩) ⟨a, rfl⟩).1 =
+    (F.shapeRestr (sigmaLiftHom S F.toPresheafPFunctorData h
+        ((sigmaPshData S F.toPresheafPFunctorData).shapeRestr g ⟨a, rfl⟩))
+      ⟨(F.shapeRestr (sigmaLiftHom S F.toPresheafPFunctorData g ⟨a, rfl⟩) ⟨a, rfl⟩).1, rfl⟩).1
+  set Lg := sigmaLiftHom S F.toPresheafPFunctorData g ⟨a, rfl⟩ with hLgdef
+  set b := F.shapeRestr Lg ⟨a, rfl⟩ with hbdef
+  set Lh := sigmaLiftHom S F.toPresheafPFunctorData h
+    ((sigmaPshData S F.toPresheafPFunctorData).shapeRestr g ⟨a, rfl⟩) with hLhdef
+  have hval : (sigmaLiftHom S F.toPresheafPFunctorData (h ≫ g) ⟨a, rfl⟩).1 =
+      eqToHom (rfl : j'' = j'') ≫ ((Lh ≫ elEqToHom S b.2) ≫ Lg).1 := by
+    simp [hLhdef, hLgdef, sigmaLiftHom, elEqToHom]
+  have hsplit : (F.shapeRestr (Lh ≫ elEqToHom S b.2) b).1 = (F.shapeRestr Lh ⟨b.1, rfl⟩).1 := by
+    refine Eq.trans (congrArg Subtype.val
+      (congrFun (F.isFunctorial.shapeRestr_comp (elEqToHom S b.2) Lh) b)) ?_
+    refine congrArg (fun t ↦ (F.shapeRestr Lh t).1) ?_
+    rw [elEqToHom_eq, shapeRestr_eqToHom]
+    exact Subtype.ext (cast_shape_val F.toPresheafPFunctorData b.2.symm b)
+  rw [elHom_eq_eqToHom_comp S (sigmaLiftHom S F.toPresheafPFunctorData (h ≫ g) ⟨a, rfl⟩)
+      ((Lh ≫ elEqToHom S b.2) ≫ Lg) rfl hval,
+    shapeRestr_val_eqToHom_comp,
+    congrFun (F.isFunctorial.shapeRestr_comp Lg (Lh ≫ elEqToHom S b.2)) ⟨a, rfl⟩,
+    Function.comp_apply]
+  exact hsplit
+
+/-- The `σ` operation preserves the reindexing naturality law: its shapes and
+directions are the subfunctor's unchanged. -/
+theorem sigmaPsh_reindex_naturality (S : Jᵒᵖ ⥤ Type uS)
+    (F : PresheafPFunctor.{uI, max uJ uS, uA, uB, vI, vJ} I (ElObj S)) :
+    (sigmaPshData S F.toPresheafPFunctorData).ReindexNaturality := by
+  intro j j' g s i i' f
+  exact F.isFunctorial.reindex_naturality (sigmaLiftHom S F.toPresheafPFunctorData g s)
+    ⟨s.1, rfl⟩ f
+
+/-- Reindexing along a transport is heterogeneously the identity. -/
+theorem reindex_heq_eqToHom {K : Type uK} [Category.{vK} K]
+    (F : PresheafPFunctor.{uI, uK, uA, uB, vI, vK} I K) {x y : K} {m : x ⟶ y} (h : x = y)
+    (hm : m = eqToHom h) (s : F.Shape y) {i : I}
+    (d : F.Direction (F.shapeRestr m s).1 i) : HEq (F.reindex m s d) d := by
+  cases hm
+  cases h
+  exact HEq.trans (heq_of_eq (F.isFunctorial.reindex_id s d)) (cast_heq _ d)
+
+/-- Reindexing along a composite factors, on heterogeneously equal
+directions. -/
+theorem reindex_eq_of_eq_comp {K : Type uK} [Category.{vK} K]
+    (F : PresheafPFunctor.{uI, uK, uA, uB, vI, vK} I K) {x y z : K} {m : x ⟶ z}
+    (m₁ : x ⟶ y) (m₂ : y ⟶ z) (hm : m = m₁ ≫ m₂) (s : F.Shape z) {i : I}
+    (d : F.Direction (F.shapeRestr m s).1 i)
+    (d' : F.Direction (F.shapeRestr m₁ (F.shapeRestr m₂ s)).1 i) (hd : HEq d d') :
+    F.reindex m s d = F.reindex m₂ s (F.reindex m₁ (F.shapeRestr m₂ s) d') := by
+  cases hm
+  refine Eq.trans (F.isFunctorial.reindex_comp m₂ m₁ s d) ?_
+  exact congrArg (fun z ↦ F.reindex m₂ s (F.reindex m₁ (F.shapeRestr m₂ s) z))
+    (eq_of_heq (HEq.trans (cast_heq _ d) hd))
+
+/-- Reindexing is congruent in the shape, on heterogeneously equal
+directions. -/
+theorem reindex_heq_congr_shape {K : Type uK} [Category.{vK} K]
+    (F : PresheafPFunctor.{uI, uK, uA, uB, vI, vK} I K) {x y : K} (m : x ⟶ y)
+    {s s' : F.Shape y} (hs : s = s') {i : I}
+    (d : F.Direction (F.shapeRestr m s).1 i) (d' : F.Direction (F.shapeRestr m s').1 i)
+    (hd : HEq d d') : HEq (F.reindex m s d) (F.reindex m s' d') := by
+  cases hs
+  cases hd
+  rfl
+
+/-- Reindexing along a composite carrying a transport prefix. -/
+theorem reindex_eq_of_eq_eqToHom_comp {K : Type uK} [Category.{vK} K]
+    (F : PresheafPFunctor.{uI, uK, uA, uB, vI, vK} I K) {w x y z : K} {m : w ⟶ z}
+    (e : w = x) (m₁ : x ⟶ y) (m₂ : y ⟶ z) (hm : m = eqToHom e ≫ (m₁ ≫ m₂)) (s : F.Shape z)
+    {i : I} (d : F.Direction (F.shapeRestr m s).1 i)
+    (d' : F.Direction (F.shapeRestr m₁ (F.shapeRestr m₂ s)).1 i) (hd : HEq d d') :
+    F.reindex m s d = F.reindex m₂ s (F.reindex m₁ (F.shapeRestr m₂ s) d') := by
+  cases hm
+  cases e
+  exact reindex_eq_of_eq_comp F m₁ m₂ (Category.id_comp _) s d d' hd
+
+/-- The `σ` operation preserves the reindexing identity law. -/
+theorem sigmaPsh_reindex_id (S : Jᵒᵖ ⥤ Type uS)
+    (F : PresheafPFunctor.{uI, max uJ uS, uA, uB, vI, vJ} I (ElObj S)) :
+    (sigmaPshData S F.toPresheafPFunctorData).ReindexId (sigmaPsh_shapeRestr_id S F) := by
+  intro j s i d
+  obtain ⟨a, rfl⟩ := s
+  refine eq_of_heq (HEq.trans ?_ (cast_heq _ d).symm)
+  have hsrc : (⟨(F.q a).1, S.map (sigmaLiftHom S F.toPresheafPFunctorData
+      (𝟙 ((F.q a).1)) ⟨a, rfl⟩).1.op (F.q a).2⟩ : ElObj S) = F.q a :=
+    Sigma.ext rfl (heq_of_eq (by simp [sigmaLiftHom]))
+  have hval : (eqToHom hsrc : _ ⟶ F.q a).1 = 𝟙 (F.q a).1 := by
+    rw [elCategory_eqToHom_val]
+    simp
+  have hm : sigmaLiftHom S F.toPresheafPFunctorData (𝟙 ((F.q a).1)) ⟨a, rfl⟩ = eqToHom hsrc :=
+    Subtype.ext (by
+      simp only [sigmaLiftHom, eqToHom_refl, op_comp, op_id, Category.comp_id]
+      exact hval.symm)
+  exact reindex_heq_eqToHom F hsrc hm ⟨a, rfl⟩ d
+
+/-- The `σ` operation preserves the reindexing composition law. The chain
+follows `sigmaPsh_shapeRestr_comp`: decompose the lifted morphism, split the
+reindexing twice, and discard the two transports. -/
+theorem sigmaPsh_reindex_comp (S : Jᵒᵖ ⥤ Type uS)
+    (F : PresheafPFunctor.{uI, max uJ uS, uA, uB, vI, vJ} I (ElObj S)) :
+    (sigmaPshData S F.toPresheafPFunctorData).ReindexComp (sigmaPsh_shapeRestr_comp S F) := by
+  intro j j' j'' g h s i d
+  obtain ⟨a, rfl⟩ := s
+  set Lg := sigmaLiftHom S F.toPresheafPFunctorData g ⟨a, rfl⟩ with hLgdef
+  set b := F.shapeRestr Lg ⟨a, rfl⟩ with hbdef
+  set Lh := sigmaLiftHom S F.toPresheafPFunctorData h
+    ((sigmaPshData S F.toPresheafPFunctorData).shapeRestr g ⟨a, rfl⟩) with hLhdef
+  have hval : (sigmaLiftHom S F.toPresheafPFunctorData (h ≫ g) ⟨a, rfl⟩).1 =
+      eqToHom (rfl : j'' = j'') ≫ ((Lh ≫ elEqToHom S b.2) ≫ Lg).1 := by
+    simp [hLhdef, hLgdef, sigmaLiftHom, elEqToHom]
+  have hm := elHom_eq_eqToHom_comp S (sigmaLiftHom S F.toPresheafPFunctorData (h ≫ g) ⟨a, rfl⟩)
+    ((Lh ≫ elEqToHom S b.2) ≫ Lg) rfl hval
+  have hsh : F.shapeRestr (elEqToHom S b.2) b = ⟨b.1, rfl⟩ := by
+    rw [elEqToHom_eq, shapeRestr_eqToHom]
+    exact Subtype.ext (cast_shape_val F.toPresheafPFunctorData b.2.symm b)
+  have hs1 : (F.shapeRestr (sigmaLiftHom S F.toPresheafPFunctorData (h ≫ g) ⟨a, rfl⟩)
+      ⟨a, rfl⟩).1 = (F.shapeRestr (Lh ≫ elEqToHom S b.2) b).1 := by
+    rw [hm, shapeRestr_val_eqToHom_comp,
+      congrFun (F.isFunctorial.shapeRestr_comp Lg (Lh ≫ elEqToHom S b.2)) ⟨a, rfl⟩,
+      Function.comp_apply]
+  have hs2 : (F.shapeRestr (Lh ≫ elEqToHom S b.2) b).1 =
+      (F.shapeRestr Lh (F.shapeRestr (elEqToHom S b.2) b)).1 :=
+    congrArg Subtype.val (congrFun (F.isFunctorial.shapeRestr_comp (elEqToHom S b.2) Lh) b)
+  refine Eq.trans (reindex_eq_of_eq_eqToHom_comp F _ (Lh ≫ elEqToHom S b.2) Lg hm ⟨a, rfl⟩ d
+    (cast (congrArg (fun x ↦ F.Direction x i) hs1) d) (cast_heq _ d).symm) ?_
+  refine congrArg (F.reindex Lg ⟨a, rfl⟩ (i := i)) ?_
+  refine Eq.trans (reindex_eq_of_eq_comp F Lh (elEqToHom S b.2) rfl b _
+    (cast (congrArg (fun x ↦ F.Direction x i) hs2)
+      (cast (congrArg (fun x ↦ F.Direction x i) hs1) d)) (cast_heq _ _).symm) ?_
+  refine eq_of_heq (HEq.trans (reindex_heq_eqToHom F b.2 (elEqToHom_eq S b.2) b _) ?_)
+  have hs3 : (F.shapeRestr Lh (F.shapeRestr (elEqToHom S b.2) b)).1 =
+      (F.shapeRestr Lh (⟨b.1, rfl⟩ : F.Shape (F.q b.1))).1 :=
+    congrArg (fun t ↦ (F.shapeRestr Lh t).1) hsh
+  refine HEq.trans (reindex_heq_congr_shape F Lh hsh _
+    (cast (congrArg (fun x ↦ F.Direction x i) hs3) _) (cast_heq _ _).symm) ?_
+  refine heq_of_eq (congrArg (F.reindex Lh ⟨b.1, rfl⟩ (i := i)) (eq_of_heq ?_))
+  exact (cast_heq _ _).trans ((cast_heq _ _).trans ((cast_heq _ d).trans (cast_heq _ d).symm))
+
+/-- The `σ` case as a `PresheafPFunctor`: pushing a functor over the base
+`ElObj S` forward along the projection to `J` yields a presheaf p.r.a. functor.
+Its shape presheaf is the total space of `S` paired with the subfunctor's
+shapes, which is what lets a later `δ` adjoin an arity varying over the
+elements of `S`. -/
+def sigmaPsh (S : Jᵒᵖ ⥤ Type uS)
+    (F : PresheafPFunctor.{uI, max uJ uS, uA, uB, vI, vJ} I (ElObj S)) :
+    PresheafPFunctor.{uI, uJ, uA, uB, vI, vJ} I J where
+  toPresheafPFunctorData := sigmaPshData S F.toPresheafPFunctorData
+  isFunctorial :=
+    { directionRestr_id := F.isFunctorial.directionRestr_id
+      directionRestr_comp := F.isFunctorial.directionRestr_comp
+      shapeRestr_id := sigmaPsh_shapeRestr_id S F
+      shapeRestr_comp := sigmaPsh_shapeRestr_comp S F
+      reindex_naturality := sigmaPsh_reindex_naturality S F
+      reindex_id := sigmaPsh_reindex_id S F
+      reindex_comp := sigmaPsh_reindex_comp S F }
+
+end Sigma
+
+section Decoding
+
+variable {I : Type uI} [Category.{vI} I]
+
+/-- A morphism of presheaves on `I`, unbundled. It is the analogue of
+`IR.delta`'s `B → I`, and of the sections `(p : P) → D (i p)` of Section 6 of
+[HancockMcBrideGhaniMalatestaAltenkirch2013]: the decodings `δ`'s continuation
+depends on. `δ` takes one continuation over `ElObj (decPresheaf …)` rather than
+a family indexed by these.
+
+Unbundled for the usual reason: `P ⟶ D` between objects of a presheaf category
+would draw in `Classical.choice`. -/
+@[ext] structure PshMor (G : DomArity.{uI, uD, vI} I) (D : Iᵒᵖ ⥤ Type uD) :
+    Type (max uI uD vI) where
+  /-- The components. -/
+  app : ∀ ⦃i : I⦄, G.Dir i → D.obj ⟨i⟩
+  /-- Naturality. -/
+  naturality : ∀ ⦃i i' : I⦄ (f : i' ⟶ i) (x : G.Dir i),
+    app (G.restr f x) = D.map f.op (app x)
+
+/-- The arity a `δ` adjoins at the decoding `s`: the fibres of `s`, as a
+presheaf on the base `ElObj D`. The fibre over `y` is the elements of `G` at
+`y.1` that `s` sends to `y.2`, and it is `s`'s naturality that makes those
+fibres close under restriction — which is why the decoding must be a presheaf
+morphism and not a bare family.
+
+The carrier is indexed by `ElObj D` with `proj` the projection, rather than
+being the total space of `G` with `proj` computed from `s`, so that a direction
+destructures to its fibre without transporting the element. -/
+@[reducible] def fibreArity {G : DomArity.{uI, uD, vI} I} {D : Iᵒᵖ ⥤ Type uD} (s : PshMor G D) :
+    DomArity.{max uI uD, max uI uD, vI} (ElObj.{uI, uD, vI} D) where
+  carrier := Σ y : ElObj.{uI, uD, vI} D, {x : G.Dir y.1 // s.app x = y.2}
+  proj := Sigma.fst
+  restr := fun {_ y'} f d ↦
+    match d with
+    | ⟨⟨_, p⟩, rfl⟩ =>
+        ⟨⟨y', ⟨G.restr f.1 p.1, by rw [s.naturality, p.2]; exact f.2⟩⟩, rfl⟩
+
+/-- The underlying element of a restricted fibre direction, so that the two
+laws below need not unfold `fibreArity`'s matcher. -/
+theorem fibreArity_restr_val {G : DomArity.{uI, uD, vI} I} {D : Iᵒᵖ ⥤ Type uD}
+    (s : PshMor G D) {y' z : ElObj.{uI, uD, vI} D}
+    (p : {q : G.Dir z.1 // s.app q = z.2}) (f : y' ⟶ z) :
+    (((fibreArity s).restr f ⟨⟨z, p⟩, rfl⟩).1).2.1 = G.restr f.1 p.1 := rfl
+
+/-- The fibre arity is a presheaf: both laws are `G`'s own, the fibre condition
+being carried along by `s`'s naturality. -/
+theorem isFunctorial_fibreArity {G : DomArity.{uI, uD, vI} I} (hG : G.IsFunctorial)
+    {D : Iᵒᵖ ⥤ Type uD} (s : PshMor G D) : (fibreArity s).IsFunctorial where
+  restr_id := by
+    intro y
+    funext d
+    obtain ⟨⟨z, p⟩, rfl⟩ := d
+    refine Subtype.ext (Sigma.ext rfl (heq_of_eq (Subtype.ext ?_)))
+    exact (fibreArity_restr_val s p (𝟙 z)).trans (by
+      simpa using congrFun (hG.restr_id z.1) p.1)
+  restr_comp := by
+    intro y y' y'' f g
+    funext d
+    obtain ⟨⟨z, p⟩, rfl⟩ := d
+    refine Subtype.ext (Sigma.ext rfl (heq_of_eq (Subtype.ext ?_)))
+    refine Eq.trans (fibreArity_restr_val s p (g ≫ f)) ?_
+    refine Eq.trans ?_ (fibreArity_restr_val s
+      (⟨G.restr f.1 p.1, by rw [s.naturality, p.2]; exact f.2⟩ :
+        {q : G.Dir y'.1 // s.app q = y'.2}) g).symm
+    exact congrFun (hG.restr_comp f.1 g.1) p.1
+
+/-- The decoding presheaf of an output-varying arity: over the output object
+`b`, the decodings of the arity there. Restriction along `g : b' ⟶ b` is
+precomposition with `A.reindex g`, which is what makes the decodings vary
+contravariantly and so form a presheaf on `J`.
+
+This is the object that keeps `δ` free of mutuality: a continuation depending
+functorially on the decoding is a single code over `ElObj` of this presheaf,
+not a family of codes indexed by decodings. -/
+def decPresheaf {J : Type uJ} [Category.{vJ} J] (A : BaseArity.{uI, uJ, uD, vI, vJ} I J)
+    (hA : A.IsFunctorial) (D : Iᵒᵖ ⥤ Type uD) : Jᵒᵖ ⥤ Type (max uI uD vI) where
+  obj b := PshMor (A.fam b.unop) D
+  map g := ↾ fun s ↦
+    { app := fun {i} x ↦ s.app (A.reindex g.unop x)
+      naturality := fun {i i'} f x ↦
+        (congrArg (fun y ↦ s.app (i := i') y)
+          (congrFun (hA.reindex_naturality g.unop f) x).symm).trans
+          (s.naturality f (A.reindex g.unop x)) }
+  map_id b := by
+    ext s i x
+    exact congrArg (fun y ↦ s.app (i := i) y) (congrFun (hA.reindex_id b.unop i) x)
+  map_comp g h := by
+    ext s i x
+    exact congrArg (fun y ↦ s.app (i := i) y) (congrFun (hA.reindex_comp g.unop h.unop i) x)
+
+/-- The arity `δ` adjoins, indexed by the objects of `ElObj (decPresheaf …)`.
+Each such object carries its own decoding, so the arity over it is that
+decoding's fibre arity, so the arity varies over the output object. That this
+is a proper generalization of the constant arity of Section 6 of
+[HancockMcBrideGhaniMalatestaAltenkirch2013] is not established here.
+
+Reindexing along a morphism of elements applies `A.reindex` to the fibre
+element; the morphism's own condition says the two decodings agree after that,
+so no transport is needed. -/
+def decArity {J : Type uJ} [Category.{vJ} J] (A : BaseArity.{uI, uJ, uD, vI, vJ} I J)
+    (hA : A.IsFunctorial) (D : Iᵒᵖ ⥤ Type uD) :
+    BaseArity.{max uI uD, max uI uJ uD vI, max uI uD, vI, vJ}
+      (ElObj.{uI, uD, vI} D) (ElObj.{uJ, max uI uD vI, vJ} (decPresheaf A hA D)) where
+  fam y := fibreArity y.2
+  reindex := fun {y y'} f z d ↦
+    match d with
+    | ⟨⟨_, ⟨x, hx⟩⟩, rfl⟩ =>
+        ⟨⟨z, ⟨A.reindex f.1 x, by rw [show y.2.app (A.reindex f.1 x) = y'.2.app x from
+          congrArg (fun t : PshMor (A.fam y'.1) D ↦ t.app x) f.2, hx]⟩⟩, rfl⟩
+
+/-- The underlying fibre element of a reindexed `decArity` direction, so the
+laws below need not unfold the matcher. -/
+theorem decArity_reindex_val {J : Type uJ} [Category.{vJ} J]
+    (A : BaseArity.{uI, uJ, uD, vI, vJ} I J) (hA : A.IsFunctorial) (D : Iᵒᵖ ⥤ Type uD)
+    {y y' : ElObj.{uJ, max uI uD vI, vJ} (decPresheaf A hA D)} (f : y' ⟶ y)
+    {z : ElObj.{uI, uD, vI} D} (x : (A.fam y'.1).Dir z.1) (hx : y'.2.app x = z.2) :
+    (((decArity A hA D).reindex f ⟨⟨z, ⟨x, hx⟩⟩, rfl⟩).1).2.1 = A.reindex f.1 x := rfl
+
+/-- The adjoined arity is functorial: the fibre laws are `A`'s own, and the
+reindexing laws are `A.reindex`'s. -/
+theorem isFunctorial_decArity {J : Type uJ} [Category.{vJ} J]
+    (A : BaseArity.{uI, uJ, uD, vI, vJ} I J) (hA : A.IsFunctorial) (D : Iᵒᵖ ⥤ Type uD) :
+    (decArity A hA D).IsFunctorial where
+  restr_id := fun y ↦ (isFunctorial_fibreArity ⟨hA.restr_id y.1, hA.restr_comp y.1⟩ y.2).restr_id
+  restr_comp := by
+    intro y i i' i'' f g
+    exact (isFunctorial_fibreArity ⟨hA.restr_id y.1, hA.restr_comp y.1⟩ y.2).restr_comp f g
+  reindex_id := by
+    intro y z
+    funext d
+    obtain ⟨⟨w, ⟨x, hx⟩⟩, rfl⟩ := d
+    refine Subtype.ext (Sigma.ext rfl (heq_of_eq (Subtype.ext ?_)))
+    exact (decArity_reindex_val A hA D (𝟙 y) x hx).trans (congrFun (hA.reindex_id y.1 w.1) x)
+  reindex_comp := by
+    intro y y' y'' g h z
+    funext d
+    obtain ⟨⟨w, ⟨x, hx⟩⟩, rfl⟩ := d
+    refine Subtype.ext (Sigma.ext rfl (heq_of_eq (Subtype.ext ?_)))
+    refine Eq.trans (decArity_reindex_val A hA D (h ≫ g) x hx) ?_
+    exact congrFun (hA.reindex_comp g.1 h.1 w.1) x
+  reindex_naturality := by
+    intro y y' g z z' f
+    funext d
+    obtain ⟨⟨w, ⟨x, hx⟩⟩, rfl⟩ := d
+    refine Subtype.ext (Sigma.ext rfl (heq_of_eq (Subtype.ext ?_)))
+    exact congrFun (hA.reindex_naturality g.1 f.1) x
+
+/-- The `δ` rule: an arity that varies over the output object, whose
+continuation depends on the decoding. It is the presheaf reading of the `δ`
+rule of Section 6 of [HancockMcBrideGhaniMalatestaAltenkirch2013] with both
+features present at once.
+
+It decomposes as `sigmaPsh (decPresheaf A hA D) ∘ adjoinArity`: the inner
+factor adjoins the directions and the outer one takes the coproduct over the
+decodings, `decPresheaf` at `b` being the decodings at `b`. That coproduct is
+the shape half of [DybjerSetzer1999]'s `δ` under the regrouping
+`Σ_{g : P → X} ⟦F (f ∘ g)⟧ = Σ_{d : P → D} (sections of f over d) × ⟦F d⟧`.
+That regrouping is stated here and nowhere established as an equation.
+
+No `A` field grows in the process, and that is not an accident. A shape
+presheaf here is a total space `A` fibred by `q`, so a coproduct over the
+fibres of a discrete fibration is a *re-fibring* of the same total space, not
+an enlargement of it: `sigmaPsh` leaves `A` untouched, and `Σ_{s ∈ S j} F.Shape
+⟨j, s⟩` and `F.A` over `ElObj S` are the same total space — stated here and
+established by no declaration. A coproduct indexed by a bare type rather than
+by the fibres of a fibration would enlarge `A`; no operation here takes one.
+
+It needs no operation beyond those already proved. Over the base
+`ElObj (decPresheaf A hA D)` every object carries its own decoding, so
+`decArity` is an ordinary `BaseArity` there and `BaseArity.pullback` turns it
+into the shape-indexed arity `adjoinArity` consumes; `sigmaPsh` then pushes the
+result forward to `J`. In particular the continuation `F` is a single code's
+interpretation over that base, not a family of them indexed by decodings, so
+nothing is defined simultaneously with anything else. -/
+def delta {J : Type uJ} [Category.{vJ} J] (A : BaseArity.{uI, uJ, uD, vI, vJ} I J)
+    (hA : A.IsFunctorial) (D : Iᵒᵖ ⥤ Type uD)
+    (F : PresheafPFunctor.{max uI uD, max uI uJ uD vI, uA, max uI uD, vI, vJ}
+      (ElObj.{uI, uD, vI} D) (ElObj.{uJ, max uI uD vI, vJ} (decPresheaf A hA D))) :
+    PresheafPFunctor.{max uI uD, uJ, uA, max uI uD, vI, vJ} (ElObj.{uI, uD, vI} D) J :=
+  sigmaPsh (decPresheaf A hA D)
+    (adjoinArity F ((decArity A hA D).pullback F.toPresheafPFunctorData)
+      ((decArity A hA D).isFunctorial_pullback (isFunctorial_decArity A hA D) F))
+
+end Decoding
+
+section WorkedExample
+
+/-!
+A worked instance of `δ` at an arity that varies over the output object: over
+the walking arrow, empty over `0` and inhabited over `1`.
+`interp_deltaCodeVaries` in § CodeType is the check that the rule and its code
+compute at it.
+-/
+
+/-- The decoding target on `Fin 1` with every fibre a singleton,
+so the decodings of any arity into it are expected to form a singleton and the
+recursion to degenerate; nothing here states that. -/
+def termPsh : (Fin 1)ᵒᵖ ⥤ Type where
+  obj _ := PUnit
+  map _ := ↾ fun _ ↦ PUnit.unit
+
+/-- An output-varying arity over the walking arrow: empty over `0`, inhabited
+over `1`, reindexed along `0 ⟶ 1` by the map out of the empty type. The base of
+the worked example below. -/
+def arityVariesBase : BaseArity.{0, 0, 0, 0, 0} (Fin 1) (Fin 2) where
+  fam b :=
+    { carrier := ArityB b
+      proj := fun _ ↦ 0
+      restr := fun {_ _} _f d ↦ ⟨d.1, Subsingleton.elim _ _⟩ }
+  reindex := fun {_ _} g {_} d ↦
+    ⟨⟨Fin.castLE (leOfHom g) d.1.down⟩, Subsingleton.elim _ _⟩
+
+/-- Each fibre of `arityVariesBase` has at most one element. -/
+theorem arityVariesBase_dir_ext (b : Fin 2) (i : Fin 1)
+    (x y : (arityVariesBase.fam b).Dir i) : x = y :=
+  Subtype.ext (Subsingleton.elim (α := ArityB b) x.1 y.1)
+
+/-- The arity is functorial; its content is the variation of the fibres, not
+the laws. -/
+theorem isFunctorial_arityVariesBase : arityVariesBase.IsFunctorial where
+  restr_id := by intro b i; funext d; exact arityVariesBase_dir_ext _ _ _ _
+  restr_comp := by intro b i i' i'' f g; funext d; exact arityVariesBase_dir_ext _ _ _ _
+  reindex_id := by intro b i; funext d; exact arityVariesBase_dir_ext _ _ _ _
+  reindex_comp := by intro b b' b'' g h i; funext d; exact arityVariesBase_dir_ext _ _ _ _
+  reindex_naturality := by
+    intro b b' g i i' f
+    funext d
+    exact arityVariesBase_dir_ext _ _ _ _
+
+/-- A decoding into `termPsh`. Every fibre of `termPsh` is a singleton, so this
+is the only one, though nothing here states that. -/
+def decUnit (b : Fin 2) : PshMor (arityVariesBase.fam b) termPsh where
+  app := fun {_} _ ↦ PUnit.unit
+  naturality := by intros; rfl
+
+/-- The element of the decoding presheaf that the continuation is taken at:
+the arity is inhabited over `1`, where reindexing is the map out of the empty
+type. -/
+def decVariesElt :
+    ElObj.{0, 0, 0} (decPresheaf arityVariesBase isFunctorial_arityVariesBase termPsh) :=
+  ⟨1, decUnit 1⟩
+
+/-- The `δ` at an output-varying arity, its continuation the constant functor
+at the representable `y decVariesElt`. -/
+def deltaVaries : PresheafPFunctor.{0, 0, 0, 0, 0, 0} (ElObj.{0, 0, 0} termPsh) (Fin 2) :=
+  delta arityVariesBase isFunctorial_arityVariesBase termPsh
+    (iotaPresheaf (I := ElObj.{0, 0, 0} termPsh) decVariesElt)
+
+end WorkedExample
+
+section CodeType
+
+variable (I : Type u) [Category.{u} I] (D : Iᵒᵖ ⥤ Type u)
+
+/-- The shape of a code node over the base category `𝔹`: a presheaf p.r.a.
+functor over `𝔹` taken as it stands (`pra`), or an output-varying arity `A`
+adjoined with the continuation over the category of elements of its decoding
+presheaf (`δ`).
+
+`pra` stands where small induction recursion has `ι` and `σ`. There the target
+— slice polynomial functors — is reached by generators, and the correspondence
+with the codes is a theorem. Here the target is already a type, so the codes
+take it as their leaf; the interpretation is then surjective on objects by
+construction and the content sits in `δ` being an operation on presheaf p.r.a.
+functors at all, which is the content of `delta`'s type. That what a code
+records beyond its interpretation is a derivation is a reading, established by
+no declaration here.
+
+`δ` carries the recursion: a continuation depending functorially on the
+decoding is one code over `ElObj (decPresheaf …)`, not a family of codes
+indexed by decodings. The index is therefore a parameter, and nothing is
+defined simultaneously with anything else.
+
+The input side is the fixed pair `(I, D)`; the interpretation's input base is
+`ElObj D`. Universes are pinned so that `Cat.{v, u}` is closed under the
+continuation step. -/
+def CodeShape (𝔹 : Cat.{v, u}) : Type (max (u + 1) (v + 1)) :=
+  PresheafPFunctor.{u, u, max u v, u, u, v} (ElObj.{u, u, u} D) 𝔹 ⊕
+    {A : BaseArity.{u, u, u, u, v} I 𝔹 // A.IsFunctorial}
+
+/-- The subcode slots of a code shape: none for `pra`, one for `δ`. -/
+def CodeDir (𝔹 : Cat.{v, u}) : CodeShape I D 𝔹 → Type
+  | Sum.inl _ => PEmpty.{1}
+  | Sum.inr _ => PUnit.{1}
+
+/-- The base category the subcode of a code shape lives over: the category of
+elements of the decoding presheaf of the adjoined arity. `Cat` is closed under
+that step, which is what lets the codes be an ordinary W-type. -/
+def CodeNext (𝔹 : Cat.{v, u}) : (sh : CodeShape I D 𝔹) → CodeDir I D 𝔹 sh → Cat.{v, u}
+  | Sum.inl _, b => PEmpty.elim b
+  | Sum.inr ⟨A, hA⟩, _ => Cat.of (ElObj.{u, u, v} (decPresheaf A hA D))
+
+/-- The slice polynomial functor on `Cat` whose W-type is the type of codes. -/
+def codePFunctor :
+    SlicePFunctor.{max (u + 1) (v + 1), 0,
+      max (u + 1) (v + 1), max (u + 1) (v + 1)} Cat.{v, u} Cat.{v, u} where
+  toPFunctor := ⟨Σ 𝔹 : Cat.{v, u}, CodeShape I D 𝔹, fun x ↦ CodeDir I D x.1 x.2⟩
+  r := fun x ↦ CodeNext I D x.1.1 x.1.2 x.2
+  q := fun x ↦ x.1
+
+/-- The type of codes: the W-type of `codePFunctor`, fibred over `Cat` by the
+base category its root sits over. -/
+def Code : Type (max (u + 1) (v + 1)) :=
+  (codePFunctor.{u, v} I D).W
+
+/-- The target of the interpretation: a presheaf p.r.a. functor on the input
+base `ElObj D`, together with the base category it lands in. -/
+def Interp : Type (max (u + 1) (v + 1)) :=
+  Σ 𝔹 : Cat.{v, u}, PresheafPFunctor.{u, u, max u v, u, u, v} (ElObj.{u, u, u} D) 𝔹
+
+/-- The interpretation of one code node, given its subcode's interpretation
+already at the base its slot prescribes: `pra` is the injected functor itself,
+`δ` is the rule at its arity. -/
+def codeAlgOn (𝔹 : Cat.{v, u}) :
+    (sh : CodeShape I D 𝔹) →
+      ((b : CodeDir I D 𝔹 sh) →
+        PresheafPFunctor.{u, u, max u v, u, u, v} (ElObj.{u, u, u} D) (CodeNext I D 𝔹 sh b)) →
+      PresheafPFunctor.{u, u, max u v, u, u, v} (ElObj.{u, u, u} D) 𝔹
+  | Sum.inl F, _ => F
+  | Sum.inr ⟨A, hA⟩, c => delta A hA D (c PUnit.unit)
+
+/-- The slice algebra the interpretation folds with. -/
+def codeAlg :
+    (codePFunctor.{u, v} I D).toSliceDomPFunctor.Obj
+        (Sigma.fst : Interp.{u, v} I D → Cat.{v, u}) →
+      Interp.{u, v} I D :=
+  fun x ↦ ⟨x.1.1.1, codeAlgOn I D x.1.1.1 x.1.1.2 fun b ↦
+    cast (congrArg (fun 𝔻 : Cat.{v, u} ↦
+        PresheafPFunctor.{u, u, max u v, u, u, v} (ElObj.{u, u, u} D) 𝔻)
+      (((codePFunctor.{u, v} I D).toSliceDomPFunctor.compatible_iff _ _ _).mp x.2 b))
+      (x.1.2 b).2⟩
+
+/-- The interpretation of a code, as the fold of `codeAlg`. -/
+def interp : Code.{u, v} I D → Interp.{u, v} I D :=
+  SlicePFunctor.W.elim (codePFunctor.{u, v} I D) (Interp.{u, v} I D) Sigma.fst
+    (codeAlg.{u, v} I D) rfl
+
+/-- The `pra` code over `𝔹` at a presheaf p.r.a. functor: the leaf that injects
+the semantics. -/
+def praCode (𝔹 : Cat.{v, u})
+    (F : PresheafPFunctor.{u, u, max u v, u, u, v} (ElObj.{u, u, u} D) 𝔹) :
+    Code.{u, v} I D :=
+  SlicePFunctor.W.mk
+    ⟨⟨⟨𝔹, Sum.inl F⟩, fun b ↦ PEmpty.elim b⟩, funext fun b ↦ PEmpty.elim b⟩
+
+/-- The `δ` code over `𝔹`: adjoin the output-varying arity `A`, the subcode
+being one over the category of elements of `A`'s decoding presheaf.
+
+`hK` aligns the subcode's fibre with that base as a strict equality of bundled
+categories, which is what `SlicePFunctor.W.mk` needs — a constraint of the
+W-type presentation, not of the mathematics. Whether a code exists over an
+equivalent base is not settled here. -/
+def deltaCode (𝔹 : Cat.{v, u}) (A : BaseArity.{u, u, u, u, v} I 𝔹) (hA : A.IsFunctorial)
+    (K : Code.{u, v} I D)
+    (hK : (codePFunctor.{u, v} I D).wIndex K =
+      Cat.of (ElObj.{u, u, v} (decPresheaf A hA D))) :
+    Code.{u, v} I D :=
+  SlicePFunctor.W.mk
+    ⟨⟨⟨𝔹, Sum.inr ⟨A, hA⟩⟩, fun _ ↦ K⟩, funext fun _ ↦ hK⟩
+
+/-- The interpretation of a `pra` code is the injected functor, so `praCode`
+is a section of `interp` and the interpretation is surjective on objects. -/
+theorem interp_praCode (𝔹 : Cat.{v, u})
+    (F : PresheafPFunctor.{u, u, max u v, u, u, v} (ElObj.{u, u, u} D) 𝔹) :
+    interp.{u, v} I D (praCode I D 𝔹 F) = ⟨𝔹, F⟩ := rfl
+
+/-- Every code has the interpretation of a one-node code, so `δ` adds no
+functor that `pra` does not already supply. That what a code carries beyond
+its interpretation is a derivation is a reading and is established nowhere.
+Equivalently,
+`fun K ↦ praCode (interp K).1 (interp K).2` leaves `interp` unchanged. It does
+not say that the two codes differ, and for a `pra` code they do not. -/
+theorem interp_praCode_interp (K : Code.{u, v} I D) :
+    interp.{u, v} I D (praCode I D (interp I D K).1 (interp I D K).2) =
+      interp.{u, v} I D K := rfl
+
+/-- The index of a code is the base its interpretation lands in. -/
+theorem interp_fst (K : Code.{u, v} I D) :
+    (interp I D K).1 = (codePFunctor.{u, v} I D).wIndex K :=
+  congrFun (SlicePFunctor.W.comp_elim (codePFunctor.{u, v} I D) (Interp.{u, v} I D)
+    Sigma.fst (codeAlg I D) rfl) K
+
+/-- The interpretation of a `δ` code is the rule at its arity. -/
+theorem interp_deltaCode (𝔹 : Cat.{v, u}) (A : BaseArity.{u, u, u, u, v} I 𝔹)
+    (hA : A.IsFunctorial) (K : Code.{u, v} I D)
+    (hK : (codePFunctor.{u, v} I D).wIndex K =
+      Cat.of (ElObj.{u, u, v} (decPresheaf A hA D))) :
+    interp I D (deltaCode I D 𝔹 A hA K hK) =
+      ⟨𝔹, delta A hA D (cast (congrArg (fun 𝔻 : Cat.{v, u} ↦
+        PresheafPFunctor.{u, u, max u v, u, u, v} (ElObj.{u, u, u} D) 𝔻)
+        ((interp_fst I D K).trans hK)) (interp I D K).2)⟩ := rfl
+
+/-- A `δ` code at an output-varying arity, with `interp_deltaCodeVaries` below
+the check that `interp_deltaCode`'s transports reduce at a closed instance. It
+says nothing about what a constant-arity rule admits: no such rule is built
+here, and this code type's leaf admits every presheaf p.r.a. functor. -/
+def deltaCodeVaries : Code.{0, 0} (Fin 1) termPsh :=
+  deltaCode (Fin 1) termPsh (Cat.of (Fin 2)) arityVariesBase isFunctorial_arityVariesBase
+    (praCode (Fin 1) termPsh
+      (Cat.of (ElObj.{0, 0, 0} (decPresheaf arityVariesBase isFunctorial_arityVariesBase
+        termPsh)))
+      (iotaPresheaf (I := ElObj.{0, 0, 0} termPsh) decVariesElt)) rfl
+
+/-- Its interpretation is the `δ` at the output-varying arity. -/
+theorem interp_deltaCodeVaries :
+    interp (Fin 1) termPsh deltaCodeVaries = ⟨Cat.of (Fin 2), deltaVaries⟩ := rfl
+
+/-- The leaf as a function of what it denotes: `praCode` uncurried over
+`Interp`. It is a section of `interp`, which is what
+`leftInverse_interp_praCodeOf` states. -/
+def praCodeOf (p : Interp.{u, v} I D) : Code.{u, v} I D :=
+  praCode I D p.1 p.2
+
+/-- The interpretation retracts onto the leaf: interpreting the leaf code of a
+presheaf p.r.a. functor returns that functor, paired with the base it lands in.
+Definitional, `interp`'s leaf clause being the identity and `Interp` a `Sigma`,
+so structure eta supplies `⟨p.1, p.2⟩ = p`. -/
+theorem leftInverse_interp_praCodeOf :
+    Function.LeftInverse (interp.{u, v} I D) (praCodeOf.{u, v} I D) :=
+  fun _ ↦ rfl
+
+/-- So the codes denote exactly the presheaf p.r.a. functors over `ElObj D` at
+the universes `CodeShape` pins: every one of them has a code, and by
+`interp_praCode_interp` `δ` supplies none that the leaf does not. -/
+theorem surjective_interp : Function.Surjective (interp.{u, v} I D) :=
+  (leftInverse_interp_praCodeOf.{u, v} I D).surjective
+
+end CodeType
+
+end GebProto

--- a/geb-lean/vendor/geb-mathlib/Geb/Internal/PresheafIRProto/Functor.lean
+++ b/geb-lean/vendor/geb-mathlib/Geb/Internal/PresheafIRProto/Functor.lean
@@ -1,0 +1,122 @@
+/-
+Copyright (c) 2026 Terence Rokop. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Terence Rokop
+-/
+-- Modified from geb-mathlib by scripts/geb-mathlib-backport.patch.
+module
+
+public import Geb.Internal.PresheafIRProto.Basic
+public import Geb.Internal.PresheafIRProto.Codes
+
+/-!
+# Prototype: the parts that write in a functor category
+
+Collects what the choice-free core (`PresheafIRProto.Basic`,
+`PresheafIRProto.Codes`) cannot state. Writing `⟶` between two objects of a
+presheaf category, or `⥤` into one, invokes
+`CategoryTheory.Functor.category`, which is `Classical.choice`-dependent, so
+every declaration needing either lives here and this module alone is on
+`GebMeta.classicalAllowedModules`.
+
+Five things sit here. The p.r.a. formula `T Z ≃ Σ a, Hom(E(a), Z)` with its
+hom written as `arityPresheaf F a ⟶ Z`, obtained by transporting the core's
+`GebProto.objEquivSigmaArityHom` along the bundling isomorphism
+`arityHomEquivNatTrans` — a `CategoryTheory.NatTrans` is its `app` field
+together with `naturality`, and `GebProto.ArityHom` is that data unbundled, so
+the isomorphism is the identity on both sides and no part of the formula is
+re-proved. The two universe-formability demonstrations recording where the
+bundled hom is formable. And `BaseArity.functor`, the output-indexed arity
+bundled as a functor into the presheaf category, whose two functor laws are
+proved here rather than transported.
+
+## Main definitions
+
+* `GebProto.arityHomEquivNatTrans` — the bundling isomorphism between the
+  unbundled arity hom and the functor-category hom.
+* `GebProto.objEquivSigmaHom` — the p.r.a. formula of [Weber2007] with the
+  presheaf hom bundled.
+* `GebProto.arityPresheafHomAtUB` / `GebProto.arityPresheafHomULifted` — the
+  universes at which the bundled hom is formable.
+* `GebProto.BaseArity.functor` — an output-indexed arity as a functor
+  `J ⥤ (Iᵒᵖ ⥤ Type uB)`, the output base to discrete fibrations over the
+  input base.
+
+## References
+
+* [Weber2007]
+
+## Tags
+
+prototype, presheaf, parametric right adjoint, functor category
+-/
+
+@[expose] public section
+
+universe uI uJ uA uB uZ vI vJ
+
+open CategoryTheory
+
+namespace GebProto
+
+section CoproductOfRepresentables
+
+variable {I : Type uI} [Category.{vI} I] {J : Type uJ} [Category.{vJ} J]
+
+/-- The bundling isomorphism: an unbundled arity hom is a natural
+transformation `E(a) ⟶ Z`. Forward is `natTransOfArityHom`, backward reads off
+the components and re-states naturality elementwise; both round trips are
+definitional. -/
+def arityHomEquivNatTrans (F : PresheafPFunctor.{uI, uJ, uA, uB, vI, vJ} I J) (a : F.A)
+    (Z : Iᵒᵖ ⥤ Type uB) : ArityHom F a Z ≃ (arityPresheaf F a ⟶ Z) where
+  toFun μ := natTransOfArityHom F a μ
+  invFun α := ⟨fun i ↦ α.app ⟨i⟩, fun _ _ f b ↦ FunctorToTypes.naturality _ _ α f.op b⟩
+  left_inv _ := rfl
+  right_inv _ := rfl
+
+/-- The p.r.a. formula: the domain-restricted interpretation of `F` at `Z` is
+the coproduct over shapes of the representables on the arity presheaves. The
+core `objEquivSigmaArityHom` transported fibrewise along the bundling
+isomorphism. -/
+def objEquivSigmaHom (F : PresheafPFunctor.{uI, uJ, uA, uB, vI, vJ} I J) (Z : Iᵒᵖ ⥤ Type uB) :
+    F.toPresheafDomPFunctorData.obj Z ≃ Σ a : F.A, (arityPresheaf F a ⟶ Z) :=
+  (objEquivSigmaArityHom F Z).trans
+    (Equiv.sigmaCongrRight fun a ↦ arityHomEquivNatTrans F a Z)
+
+/-- At `uZ := uB` the arity presheaf and the input presheaf are objects of one
+category, so the hom the p.r.a. formula needs is formable with no transport. -/
+def arityPresheafHomAtUB (F : PresheafPFunctor.{uI, uJ, uA, uB, vI, vJ} I J) (a : F.A)
+    (Z : Iᵒᵖ ⥤ Type uB) : Type (max uI uB) :=
+  arityPresheaf F a ⟶ Z
+
+/-- At an unrelated `uZ` the hom is formable after `ULift`ing both sides into
+`Type (max uB uZ)`; `max` is commutative on levels, so the two composites are
+objects of one category. -/
+def arityPresheafHomULifted (F : PresheafPFunctor.{uI, uJ, uA, uB, vI, vJ} I J) (a : F.A)
+    (Z : Iᵒᵖ ⥤ Type uZ) : Type (max uI uB uZ) :=
+  (arityPresheaf F a ⋙ uliftFunctor.{uZ, uB}) ⟶ (Z ⋙ uliftFunctor.{uB, uZ})
+
+end CoproductOfRepresentables
+
+/-- A functorial `BaseArity` is a functor from the output base to presheaves on
+the input base — equivalently, to discrete fibrations over it. This is the
+`δ` rule's arity datum in bundled form: `famPresheaf` is the object part,
+`reindexHom` the morphism part, and the remaining two clauses of
+`BaseArity.IsFunctorial` are the functor laws.
+
+Kept here rather than in the choice-free core because the target
+`Iᵒᵖ ⥤ Type uB` is a functor category, whose `Category` instance is
+`Classical.choice`-dependent. -/
+def BaseArity.functor {I : Type uI} [Category.{vI} I] {J : Type uJ} [Category.{vJ} J]
+    (P : BaseArity.{uI, uJ, uB, vI, vJ} I J) (hP : P.IsFunctorial) :
+    J ⥤ (Iᵒᵖ ⥤ Type uB) where
+  obj j := P.famPresheaf hP j
+  map g := P.reindexHom hP g
+  map_id j := by
+    ext i d
+    exact congrFun (hP.reindex_id j i.unop) d
+  map_comp g h := by
+    ext i d
+    exact congrFun (hP.reindex_comp h g i.unop) d
+
+end GebProto

--- a/geb-lean/vendor/geb-mathlib/Geb/Internal/ReadableSExpr.lean
+++ b/geb-lean/vendor/geb-mathlib/Geb/Internal/ReadableSExpr.lean
@@ -1,0 +1,488 @@
+/-
+Copyright (c) 2026 Terence Rokop. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Terence Rokop
+-/
+module
+
+public import Geb.Internal.ConcreteSyntax
+
+/-!
+# A readable spelling of the rose syntax
+
+`Geb.Csexp.print` and `Geb.Ast.printViaRose` are both [RFC9804]
+canonical: length-prefixed and whitespace-free, so neither has a
+readable form. This module spells the same `Rose k` as parenthesized
+text, a node's label followed by its children, so that
+`fork (leaf 0) (fork (leaf 1) (leaf 2))` reads as `(0 (1 2))`.
+
+The fragment lies inside [R7RS] `<datum>`: a reader conforming to that
+grammar accepts it without new code, and tools operating on
+parenthesized text apply to it directly. Labels are decimal numerals,
+which the [RFC9804] advanced form cannot spell as tokens — § 4.3
+requires a token not begin with a digit — where [R7RS] and [EDN] read a
+digit-initial token as a number.
+
+## Main definitions
+
+* `Rsexp.print` — the readable spelling of a `Rose k`.
+* `Rsexp.parse` — the parser matching it, built from `Rsexp.parseStep`,
+  `Rsexp.parseAux` and the shared `Rose.parseChildren`.
+* `Rsexp.skipWs` — the whitespace skip the stripping discipline runs.
+* `Rsexp.printViaRose`, `Rsexp.parseViaRose` — the composites with the
+  rose bijection, spelling an `Ast k`.
+
+## Main statements
+
+* `Rsexp.parse_print`, `Rsexp.parseViaRose_printViaRose` — the
+  retraction law, on `Rose` and on `Ast`, with `Rsexp.format_idem` and
+  `Rsexp.print_injective` instantiating the generic corollaries.
+
+## Implementation notes
+
+The parser strips whitespace on return rather than on entry:
+`parseStep` is called on stripped input and returns a stripped
+remainder. That discipline is what lets `Rose.parseChildren` be reused
+verbatim — the loop tests its input's head against `')'` immediately,
+so it must be called on already-stripped input — and what lets `parse`
+match `some (r, [])` syntactically rather than testing a remainder for
+whitespace.
+
+A childless node prints as a bare numeral, so a printed tree can end in
+a digit and `parseAux_print` carries a delimiting side condition on the
+caller's remainder. Always parenthesizing would remove the obligation
+and the spelling; `Csexp.readDigits_append` carries the same condition
+for the same reason.
+
+## References
+
+* [R7RS] §§ 4.1.3, 7.1.1, 7.1.2 — the datum grammar this fragment lies
+  inside.
+* [EDN] — the second readable format the spelling agrees with.
+* [RFC9804] §§ 4.3, 6, 8 — the token rule that rules out the advanced
+  form, and the conformance of declining it.
+* [RFC8259] § 2 — the `ws` production this whitespace class matches.
+
+## Tags
+
+concrete syntax, s-expression, parser, retraction, rose tree
+-/
+
+@[expose] public section
+
+namespace Geb
+namespace Rsexp
+
+/-! ## Whitespace -/
+
+/-- The whitespace class this syntax admits: space, horizontal tab,
+carriage return and line feed. It is a subset of the class [R7RS]
+§ 7.1.1 fixes, and admits the same four characters as [RFC8259]
+§ 2's `ws`. -/
+def isWs (c : Char) : Bool :=
+  c = ' ' || c = '\t' || c = '\r' || c = '\n'
+
+/-- Drop a leading run of whitespace. Carried by `List.rec` rather than
+by structural recursion, per the recursor rule. -/
+def skipWs : List Char → List Char :=
+  List.rec [] fun c cs ih ↦ if isWs c then ih else c :: cs
+
+@[simp] theorem skipWs_nil : skipWs [] = [] := rfl
+
+theorem skipWs_cons (c : Char) (cs : List Char) :
+    skipWs (c :: cs) = if isWs c then skipWs cs else c :: cs := rfl
+
+/-! ## Printer -/
+
+/-- The readable spelling: a childless node is its label, a node with
+children is its label and their spellings, parenthesized and each
+preceded by one space. The uniform space is what makes every element of
+the child block a cons, which the arity bound and the whitespace skip
+both use. -/
+def print {k : Nat} : Rose k → List Char :=
+  WType.elim (List Char) fun x ↦
+    match x with
+    | ⟨(i, 0), _⟩ => Csexp.decOf i.val
+    | ⟨(i, _ + 1), ch⟩ =>
+      '(' :: (Csexp.decOf i.val
+        ++ (((List.ofFn ch).map (fun s ↦ ' ' :: s)).flatten ++ [')']))
+
+@[simp] theorem print_zero {k : Nat} (i : Fin k) (f : Fin 0 → Rose k) :
+    print (Rose.node i f) = Csexp.decOf i.val := rfl
+
+theorem print_succ {k n : Nat} (i : Fin k) (f : Fin (n + 1) → Rose k) :
+    print (Rose.node i f)
+      = '(' :: (Csexp.decOf i.val
+          ++ (((List.ofFn f).map (fun t ↦ ' ' :: print t)).flatten
+              ++ [')'])) := by
+  unfold print Rose.node
+  rw [WType.elim_mk]
+  -- reduce the match `WType.elim_mk` exposed, picking the `n.succ` arm
+  simp only []
+  rw [List.map_ofFn, List.map_ofFn]
+  rfl
+
+/-! ## Character facts -/
+
+/-- The two parentheses are distinct characters. -/
+theorem open_ne_close : ('(' : Char) ≠ ')' := by decide
+
+/-- An opening parenthesis is not whitespace, so the whitespace skip
+stops at the head of a parenthesized spelling. -/
+theorem open_not_ws : isWs '(' = false := by decide
+
+/-- A closing parenthesis is not whitespace, so the whitespace skip
+stops at a child block's terminator. -/
+theorem close_not_ws : isWs ')' = false := by decide
+
+/-- A space is whitespace, so the whitespace skip consumes the separator
+the printer emits before each child. -/
+theorem space_is_ws : isWs ' ' = true := by decide
+
+/-! ## The decimal layer -/
+
+/-- A printed numeral reads back whole, and leaves exactly what followed
+it. The delimiting hypothesis on the remainder is what a
+non-parenthesizing spelling of a childless node costs; it is the same
+condition `Csexp.readDigits_append` carries. -/
+theorem readNat_append (n : Nat) (rest : List Char)
+    (h : ∀ c cs, rest = c :: cs → Csexp.charDigit c = none) :
+    Csexp.readNat (Csexp.decOf n ++ rest) = some (n, rest) := by
+  unfold Csexp.readNat
+  rw [Csexp.readDigits_append _ _ (Csexp.decOf_all_digits n) h]
+  simp [Csexp.decOf_ne_nil n, Csexp.digitsVal_decOf, List.isEmpty_iff]
+
+/-- A digit is not whitespace. The conclusion is `isWs c = false` rather
+than a disequality because the whitespace class has four members. -/
+theorem digit_not_ws {c : Char} (h : (Csexp.charDigit c).isSome) :
+    isWs c = false := by
+  unfold isWs
+  have h1 : ¬ c = ' ' := by rintro rfl; exact absurd h (by decide)
+  have h2 : ¬ c = '\t' := by rintro rfl; exact absurd h (by decide)
+  have h3 : ¬ c = '\r' := by rintro rfl; exact absurd h (by decide)
+  have h4 : ¬ c = '\n' := by rintro rfl; exact absurd h (by decide)
+  simp [h1, h2, h3, h4]
+
+/-- A digit is not an opening parenthesis. -/
+theorem digit_not_open {c : Char} (h : (Csexp.charDigit c).isSome) :
+    c ≠ '(' := by
+  rintro rfl
+  exact absurd h (by decide)
+
+/-- A digit is not a closing parenthesis. -/
+theorem digit_not_close {c : Char} (h : (Csexp.charDigit c).isSome) :
+    c ≠ ')' := by
+  rintro rfl
+  exact absurd h (by decide)
+
+/-- `Csexp.decOf_ne_nil` in the form its consumers use: a shortest-form
+decimal has a head. -/
+theorem decOf_eq_cons (n : Nat) : ∃ c cs, Csexp.decOf n = c :: cs :=
+  List.exists_cons_of_ne_nil (Csexp.decOf_ne_nil n)
+
+/-- The head of a shortest-form decimal is a digit. -/
+theorem decOf_head_digit (n : Nat) :
+    ∀ c cs, Csexp.decOf n = c :: cs → (Csexp.charDigit c).isSome := by
+  intro c cs hc
+  refine Csexp.decOf_all_digits n c ?_
+  rw [hc]
+  simp
+
+/-- A numeral is already stripped: the whitespace skip is the identity on
+a printed decimal and whatever follows it. -/
+theorem skipWs_decOf_append (n : Nat) (rest : List Char) :
+    skipWs (Csexp.decOf n ++ rest) = Csexp.decOf n ++ rest := by
+  obtain ⟨c, cs, hc⟩ := decOf_eq_cons n
+  rw [hc, List.cons_append, skipWs_cons,
+    if_neg (by simp [digit_not_ws (decOf_head_digit n c cs hc)])]
+
+/-! ## The head of a spelling -/
+
+/-- Every spelling begins with an opening parenthesis or with a digit,
+according to whether the node has children. This is the readable
+counterpart of `Rose.exists_print_eq_cons`, which has only the
+parenthesized case. -/
+theorem print_head {k : Nat} (r : Rose k) :
+    ∃ c cs, print r = c :: cs ∧ (c = '(' ∨ (Csexp.charDigit c).isSome) := by
+  obtain ⟨⟨i, n⟩, f⟩ := r
+  cases n with
+  | zero =>
+    obtain ⟨c, cs, hc⟩ := decOf_eq_cons i.val
+    exact ⟨c, cs, (print_zero i f).trans hc, Or.inr (decOf_head_digit i.val c cs hc)⟩
+  | succ n => exact ⟨'(', _, print_succ i f, Or.inl rfl⟩
+
+/-- A spelling is already stripped: neither possible head is whitespace,
+so the skip is the identity on a spelling followed by anything. -/
+theorem skipWs_print_append {k : Nat} (r : Rose k) (rest : List Char) :
+    skipWs (print r ++ rest) = print r ++ rest := by
+  obtain ⟨c, cs, hc, hd⟩ := print_head r
+  have hw : isWs c = false := by
+    rcases hd with rfl | hd
+    · exact open_not_ws
+    · exact digit_not_ws hd
+  rw [hc, List.cons_append, skipWs_cons, if_neg (by simp [hw])]
+
+/-- The `rest = []` instance of `skipWs_print_append`, which is the form
+the entry point uses. -/
+theorem skipWs_print {k : Nat} (r : Rose k) : skipWs (print r) = print r := by
+  have h := skipWs_print_append r []
+  rwa [List.append_nil] at h
+
+/-- A child block with its terminator never begins with a digit: it
+begins with the terminator when empty and with a separating space
+otherwise. Stating it over the terminated block is what makes the empty
+case true. -/
+theorem block_append_head_not_digit {k : Nat} (ts : List (Rose k))
+    (rest : List Char) :
+    ∀ c cs, (ts.map (fun t ↦ ' ' :: print t)).flatten ++ ')' :: rest
+        = c :: cs → Csexp.charDigit c = none := by
+  intro c cs h
+  cases ts with
+  | nil =>
+    simp only [List.map_nil, List.flatten_nil, List.nil_append] at h
+    injection h with h1 _
+    subst h1
+    decide
+  | cons t ts =>
+    simp only [List.map_cons, List.flatten_cons, List.cons_append] at h
+    injection h with h1 _
+    subst h1
+    decide
+
+/-! ## Parser -/
+
+/-- One layer of the recursive descent. A tree is a bare numeral or a
+parenthesized list, so this branches on the first character. It strips
+whitespace at four sites: after `(`, after the label in each branch,
+and after the child list. The strip after the parenthesized branch's
+label is the one the grammar makes least obvious:
+`Rose.parseChildren` tests its input's head against `')'` immediately,
+so it must be called on stripped input or `(0 1 2)` fails at its first
+child. `parseStep` is called on stripped input and returns a stripped
+remainder; that invariant is what lets the shared loop be reused. -/
+def parseStep (k : Nat) (childParse : List Char → Option (Rose k × List Char))
+    (loopFuel : Nat) : List Char → Option (Rose k × List Char)
+  | [] => none
+  | c :: cs =>
+    if c = '(' then
+      match Csexp.readNat (skipWs cs) with
+      | some (m, cs1) =>
+        if h : m < k then
+          (Rose.parseChildren childParse loopFuel (skipWs cs1)).map
+            fun p ↦ (Rose.ofList ⟨m, h⟩ p.1, skipWs p.2)
+        else none
+      | none => none
+    else
+      match Csexp.readNat (c :: cs) with
+      | some (m, cs1) =>
+        if h : m < k then some (Rose.node ⟨m, h⟩ Fin.elim0, skipWs cs1)
+        else none
+      | none => none
+
+/-- Recursive descent over the readable spelling. The `Nat` bounds the
+recursion and serves in two roles at each layer: undecremented as the
+child loop's bound, and decremented as the child parser's fuel. -/
+def parseAux (k : Nat) : Nat → List Char → Option (Rose k × List Char) :=
+  Nat.rec (motive := fun _ ↦ List Char → Option (Rose k × List Char))
+    (fun _ ↦ none) fun f ih ↦ parseStep k ih (f + 1)
+
+@[simp] theorem parseAux_succ (k f : Nat) :
+    parseAux k (f + 1) = parseStep k (parseAux k f) (f + 1) := rfl
+
+/-- The parser of the readable spelling, rejecting trailing input. The
+leading strip and the stripping invariant together are what let a
+leading indent and a trailing newline parse. -/
+def parse (k : Nat) (cs : List Char) : Option (Rose k) :=
+  match parseAux k cs.length (skipWs cs) with
+  | some (r, []) => some r
+  | _ => none
+
+theorem parseStep_open (k : Nat)
+    (childParse : List Char → Option (Rose k × List Char))
+    (loopFuel : Nat) (cs : List Char) :
+    parseStep k childParse loopFuel ('(' :: cs)
+      = match Csexp.readNat (skipWs cs) with
+        | some (m, cs1) =>
+          if h : m < k then
+            (Rose.parseChildren childParse loopFuel (skipWs cs1)).map
+              fun p ↦ (Rose.ofList ⟨m, h⟩ p.1, skipWs p.2)
+          else none
+        | none => none := rfl
+
+theorem parseStep_other (k : Nat)
+    (childParse : List Char → Option (Rose k × List Char))
+    (loopFuel : Nat) (c : Char) (cs : List Char) (hc : c ≠ '(') :
+    parseStep k childParse loopFuel (c :: cs)
+      = match Csexp.readNat (c :: cs) with
+        | some (m, cs1) =>
+          if h : m < k then some (Rose.node ⟨m, h⟩ Fin.elim0, skipWs cs1)
+          else none
+        | none => none := if_neg hc
+
+/-! ## The retraction law -/
+
+/-- The child loop reads back a printed child sequence, given a child
+parser that reads back each child from its own spelling and returns the
+stripped remainder, and one unit of fuel per child plus one for the
+closing parenthesis. The loop's input is stripped, as every call site's
+is; the remainder it returns is not, since `parseStep` strips what it
+returns. -/
+theorem parseChildren_print {k : Nat}
+    (childParse : List Char → Option (Rose k × List Char)) :
+    ∀ (ts : List (Rose k)) (fuel : Nat) (rest : List Char),
+      (∀ t ∈ ts, ∀ r : List Char,
+        (∀ c cs, r = c :: cs → Csexp.charDigit c = none) →
+        childParse (print t ++ r) = some (t, skipWs r)) →
+      ts.length < fuel →
+      Rose.parseChildren childParse fuel
+          (skipWs ((ts.map (fun t ↦ ' ' :: print t)).flatten ++ ')' :: rest))
+        = some (ts, rest) :=
+  List.rec (motive := fun ts ↦ ∀ (fuel : Nat) (rest : List Char),
+      (∀ t ∈ ts, ∀ r : List Char,
+        (∀ c cs, r = c :: cs → Csexp.charDigit c = none) →
+        childParse (print t ++ r) = some (t, skipWs r)) →
+      ts.length < fuel →
+      Rose.parseChildren childParse fuel
+          (skipWs ((ts.map (fun t ↦ ' ' :: print t)).flatten ++ ')' :: rest))
+        = some (ts, rest))
+    (fun fuel rest _ hfuel ↦ by
+      obtain ⟨g, rfl⟩ : ∃ g, fuel = g + 1 := ⟨fuel - 1, by omega⟩
+      rw [List.map_nil, List.flatten_nil, List.nil_append, skipWs_cons,
+        if_neg (by simp [close_not_ws]), Rose.parseChildren_succ_close])
+    (fun t ts ih fuel rest hchild hfuel ↦ by
+      obtain ⟨g, rfl⟩ : ∃ g, fuel = g + 1 := ⟨fuel - 1, by omega⟩
+      obtain ⟨c, cs, hc, hd⟩ := print_head t
+      have hlt : ts.length < g := by simp at hfuel; omega
+      have hne : c ≠ ')' := by
+        rcases hd with rfl | hd
+        · exact open_ne_close
+        · exact digit_not_close hd
+      have hcons : ∀ u : List Char, print t ++ u = c :: (cs ++ u) := fun u ↦ by
+        rw [hc, List.cons_append]
+      rw [List.map_cons, List.flatten_cons, List.append_assoc, List.cons_append,
+        skipWs_cons, if_pos (by simp [space_is_ws]), skipWs_print_append, hcons,
+        Rose.parseChildren_succ_cons _ _ _ _ hne, ← hcons,
+        hchild t (by simp) _ (block_append_head_not_digit ts rest),
+        Option.bind_some, ih g rest (fun x hx ↦ hchild x (by simp [hx])) hlt,
+        Option.map_some])
+
+/-- The parser inverts the printer on printed input, given fuel at least
+the printed length. The remainder returned is the caller's stripped: a
+childless node's spelling ends in a digit, so the delimiting hypothesis
+on the remainder is what keeps the label from running on, and the
+stripping invariant makes what comes back `skipWs rest` rather than
+`rest`. -/
+theorem parseAux_print {k : Nat} (r : Rose k) :
+    ∀ (f : Nat) (rest : List Char), (print r).length ≤ f →
+      (∀ c cs, rest = c :: cs → Csexp.charDigit c = none) →
+      parseAux k f (print r ++ rest) = some (r, skipWs rest) :=
+  WType.rec (motive := fun r ↦ ∀ (f : Nat) (rest : List Char),
+      (print r).length ≤ f →
+      (∀ c cs, rest = c :: cs → Csexp.charDigit c = none) →
+      parseAux k f (print r ++ rest) = some (r, skipWs rest))
+    (fun s ch ih f rest hf hrest ↦ by
+      obtain ⟨i, n⟩ := s
+      change (print (Rose.node i ch)).length ≤ f at hf
+      change parseAux k f (print (Rose.node i ch) ++ rest)
+        = some (Rose.node i ch, skipWs rest)
+      cases n with
+      | zero =>
+        rw [print_zero] at hf ⊢
+        obtain ⟨c, cs, hc⟩ := decOf_eq_cons i.val
+        obtain ⟨g, rfl⟩ : ∃ g, f = g + 1 :=
+          ⟨f - 1, by rw [hc] at hf; simp only [List.length_cons] at hf; omega⟩
+        rw [parseAux_succ, hc, List.cons_append,
+          parseStep_other _ _ _ _ _
+            (digit_not_open (decOf_head_digit i.val c cs hc)),
+          ← List.cons_append, ← hc, readNat_append _ _ hrest]
+        -- reduce the match on the `some` just produced, exposing the label-bound check
+        simp only []
+        rw [dif_pos i.isLt]
+        exact congrArg (fun t ↦ some (t, skipWs rest))
+          (congrArg (Rose.node i) (funext fun j ↦ j.elim0))
+      | succ m =>
+        rw [print_succ] at hf ⊢
+        cases f with
+        | zero => simp at hf
+        | succ g =>
+          have hlen : (Csexp.decOf i.val).length
+              + (((List.ofFn ch).map (fun t ↦ ' ' :: print t)).flatten).length
+                + 2 ≤ g + 1 := by
+            simp only [List.length_cons, List.length_append] at hf
+            omega
+          have hL : (((List.ofFn ch).map (fun t ↦ ' ' :: print t)).flatten).length
+              ≤ g := by omega
+          have hchild : ∀ t ∈ List.ofFn ch, ∀ r : List Char,
+              (∀ c cs, r = c :: cs → Csexp.charDigit c = none) →
+              parseAux k g (print t ++ r) = some (t, skipWs r) := by
+            intro t ht r' hr'
+            obtain ⟨j, rfl⟩ := List.mem_ofFn.mp ht
+            refine ih j g r' ?_ hr'
+            have hmem : ' ' :: print (ch j)
+                ∈ (List.ofFn ch).map (fun t ↦ ' ' :: print t) :=
+              List.mem_map_of_mem (List.mem_ofFn.mpr ⟨j, rfl⟩)
+            have hsub : (' ' :: print (ch j)).length
+                ≤ (((List.ofFn ch).map (fun t ↦ ' ' :: print t)).flatten).length :=
+              (List.sublist_flatten_of_mem hmem).length_le
+            simp only [List.length_cons] at hsub
+            omega
+          have hfuel : (List.ofFn ch).length < g + 1 := by
+            have hpos : ∀ x ∈ ((List.ofFn ch).map (fun t ↦ ' ' :: print t)).map
+                List.length, 1 ≤ x := by
+              intro x hx
+              obtain ⟨y, hy, rfl⟩ := List.mem_map.mp hx
+              obtain ⟨t, _, rfl⟩ := List.mem_map.mp hy
+              simp
+            have h := List.length_le_sum_of_one_le _ hpos
+            rw [List.length_map, List.length_map, ← List.length_flatten] at h
+            omega
+          rw [List.cons_append, parseAux_succ, parseStep_open]
+          simp only [List.append_assoc, List.singleton_append]
+          rw [skipWs_decOf_append,
+            readNat_append _ _ (block_append_head_not_digit (List.ofFn ch) rest)]
+          -- reduce the match on the `some` just produced, exposing the label-bound check
+          simp only []
+          rw [dif_pos i.isLt,
+            parseChildren_print _ (List.ofFn ch) (g + 1) rest hchild hfuel,
+            Option.map_some, Rose.ofList_ofFn]) r
+
+/-- The retraction law for the readable spelling: printing a rose tree
+and parsing the result returns that tree. -/
+theorem parse_print {k : Nat} (r : Rose k) : parse k (print r) = some r := by
+  unfold parse
+  rw [skipWs_print, show print r = print r ++ [] by simp,
+    parseAux_print r _ [] (by simp) (by simp), skipWs_nil]
+
+/-! ## The generic corollaries, instantiated here -/
+
+/-- `Geb.Retraction` at the readable spelling. -/
+theorem retraction (k : Nat) : Retraction (parse k) (print (k := k)) :=
+  parse_print
+
+/-- `Geb.format_idem` at the readable spelling. -/
+theorem format_idem (k : Nat) (c : List Char) :
+    (format (parse k) print c).bind (format (parse k) print)
+      = format (parse k) print c :=
+  Geb.format_idem _ _ (retraction k) c
+
+/-- `Geb.print_injective` at the readable spelling. -/
+theorem print_injective (k : Nat) : Function.Injective (print (k := k)) :=
+  Geb.print_injective _ _ (retraction k)
+
+/-! ## The `Ast` composites -/
+
+/-- The readable spelling of an `Ast k`, through the rose bijection. -/
+def printViaRose {k : Nat} (a : Ast k) : List Char := print a.toRose
+
+/-- The parser matching `printViaRose`. -/
+def parseViaRose (k : Nat) (cs : List Char) : Option (Ast k) :=
+  (parse k cs).map Ast.ofRose
+
+/-- The retraction law for the `Ast` composites, transported along the
+rose retraction by `Ast.ofRose_toRose`. -/
+theorem parseViaRose_printViaRose {k : Nat} (a : Ast k) :
+    parseViaRose k (printViaRose a) = some a := by
+  rw [parseViaRose, printViaRose, parse_print, Option.map_some, Ast.ofRose_toRose]
+
+end Rsexp
+end Geb

--- a/geb-lean/vendor/geb-mathlib/Geb/Mathlib.lean
+++ b/geb-lean/vendor/geb-mathlib/Geb/Mathlib.lean
@@ -6,6 +6,7 @@ Authors: Terence Rokop
 module
 
 public import Geb.Mathlib.CategoryTheory
+public import Geb.Mathlib.Computability
 public import Geb.Mathlib.Data
 public import Geb.Mathlib.Logic
 

--- a/geb-lean/vendor/geb-mathlib/Geb/Mathlib/Computability.lean
+++ b/geb-lean/vendor/geb-mathlib/Geb/Mathlib/Computability.lean
@@ -1,0 +1,12 @@
+/-
+Copyright (c) 2026 Terence Rokop. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Terence Rokop
+-/
+module
+
+public import Geb.Mathlib.Computability.BellantoniCook
+
+/-!
+# Computability — index
+-/

--- a/geb-lean/vendor/geb-mathlib/Geb/Mathlib/Computability/BellantoniCook.lean
+++ b/geb-lean/vendor/geb-mathlib/Geb/Mathlib/Computability/BellantoniCook.lean
@@ -1,0 +1,13 @@
+/-
+Copyright (c) 2026 Terence Rokop. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Terence Rokop
+-/
+module
+
+public import Geb.Mathlib.Computability.BellantoniCook.Basic
+public import Geb.Mathlib.Computability.BellantoniCook.Tree
+
+/-!
+# BellantoniCook — index
+-/

--- a/geb-lean/vendor/geb-mathlib/Geb/Mathlib/Computability/BellantoniCook/Basic.lean
+++ b/geb-lean/vendor/geb-mathlib/Geb/Mathlib/Computability/BellantoniCook/Basic.lean
@@ -1,0 +1,275 @@
+/-
+Copyright (c) 2026 Terence Rokop. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Terence Rokop
+-/
+module
+
+public import Geb.Mathlib.Data.PFunctor.Slice.W
+public import Geb.Mathlib.Data.PFunctor.Univariate.Finitary
+public import Mathlib.Logic.Equiv.Fin.Basic
+
+/-!
+# The function class `B` of Bellantoni and Cook
+
+The syntax of the function class `B` and its interpretation, following
+[HeraudNowak2011] § 3.2. Terms of `B` are built from a constant zero,
+projections, two successors, a predecessor and a conditional, and are closed
+under a composition and a recursion that distinguish normal from safe
+argument positions; the distinction is what bounds the growth rate of the
+definable functions.
+
+The class defined here is the reformulation of § 3.2, not the class of
+[BellantoniCook1992]. Two differences: the conditional takes four safe
+arguments and branches three ways, on the empty, odd and even bitstrings,
+where the original branches two ways on parity and treats the empty
+bitstring as even; and the base case of the recursion is the empty
+bitstring, where the original's is every bitstring denoting zero.
+
+The two sources transpose the conditional's last two safe arguments. The
+order here follows the authors' Coq development, that being the artifact
+against which the paper's theorems were machine-checked.
+
+## Main definitions
+
+* `BellantoniCook.Shape` — the seven constructor forms, with their arities
+  as parameters.
+* `BellantoniCook.Direction` — the subterm positions of a shape.
+* `BellantoniCook.rc` — the arity each subterm position must carry.
+* `BellantoniCook.q` — the arity a shape produces.
+* `BellantoniCook.sig` — the signature, as a slice polynomial functor over
+  `ℕ × ℕ`.
+* `BellantoniCook.compChildren` — a `comp` node's children in the order
+  `Direction` gives them.
+* `BellantoniCook.BC` — an expression of `B`: a `sig`-tree whose every node
+  respects `rc`.
+* `BellantoniCook.BC.arity` — its pair of normal and safe arities.
+* `BellantoniCook.BCOf` — the expressions of a given arity pair.
+* `BellantoniCook.Sem` — the meaning of an arity pair: a function of a
+  normal and a safe environment.
+* `BellantoniCook.transport` — transport of a meaning along an equality of
+  arity pairs.
+* `BellantoniCook.evalRec` — the recursion on the consumed bitstring.
+* `BellantoniCook.evalValue` — the meaning of one node from its children's.
+* `BellantoniCook.evalStep` — `evalValue` as a slice algebra.
+* `BellantoniCook.BC.eval` — the interpretation, by the slice W-type's
+  eliminator.
+
+## Implementation notes
+
+This repository expresses all recursion through recursors, admitting
+neither a self-referential `inductive` nor a self-calling `def`, so the
+arity-indexed syntax is the slice W-type of `sig` and the interpretation is
+one application of `SlicePFunctor.W.elim`. `Shape` is itself non-recursive
+and so is the shape set of a `PFunctor`, not a datatype the rule reaches.
+
+`evalValue` is separate from `evalStep` because the match on `Shape` must
+generalize the compatibility hypothesis, which arrives bundled in
+`SliceDomPFunctor.Obj`. A child's meaning carries the index it was built at
+rather than the index `rc` prescribes, equal but not definitionally so;
+`transport` carries it across, with the motive of `▸` fixed once instead of
+at each of the six sites.
+
+`Direction`, `rc` and `q` are `@[reducible]`. Instance search does not
+delta-reduce a semireducible definition, and every numeral in `evalValue`
+elaborates against `Fin (q a).1` or `Direction a`.
+
+`Mathlib.Logic.Equiv.Fin.Basic` is imported for `finSumFinEquiv`. It
+transitively supplies `Mathlib.Data.Fin.Tuple.Basic`, the source of
+`Fin.cons`, `Fin.tail` and `Fin.append` used here, and
+`Mathlib.Data.Fin.VecNotation`, reached the same way by the test module's
+`![…]` notation. Neither is imported by name, so that `lake shake` does not
+report either as a redundant import.
+
+`finEnumFin` and `finEnumCompDirection` are `scoped`, and hand-built:
+mathlib's `FinEnum` instances depend on `Classical.choice`, which
+`lake lint` rejects, and an unscoped instance at the head symbol `FinEnum
+(Fin _)` would compete with `FinEnum.fin` wherever `Geb` is imported.
+
+## References
+
+* [HeraudNowak2011]
+* [BellantoniCook1992]
+
+## Tags
+
+Bellantoni-Cook, polytime, implicit computational complexity, safe
+recursion, W-type, polynomial functor
+-/
+
+namespace BellantoniCook
+
+public section
+
+/-- The seven constructor forms of `B`, each carrying its arities as
+parameters: `zero` the constant empty bitstring; `proj n s i` the `i`th of
+`n` normal and `s` safe variables; `succ b` the successor appending the bit
+`b`; `pred` the predecessor; `cond` the four-argument conditional;
+`safeRec n s` the recursion producing arity `(n + 1, s)`; and `comp n s m k`
+the composition of an expression of arity `(m, k)` with `m` normal and `k`
+safe argument expressions of arity `(n, 0)` and `(n, s)`. -/
+inductive Shape
+  | zero
+  | proj (n s : ℕ) (i : Fin (n + s))
+  | succ (b : Bool)
+  | pred
+  | cond
+  | safeRec (n s : ℕ)
+  | comp (n s m k : ℕ)
+
+/-- The subterm positions of a shape. The five base forms have none;
+`safeRec` has three, its base and its two step expressions; `comp` has its
+head, its `m` normal arguments and its `k` safe arguments. -/
+@[expose, reducible] def Direction : Shape → Type
+  | .zero => Fin 0
+  | .proj _ _ _ => Fin 0
+  | .succ _ => Fin 0
+  | .pred => Fin 0
+  | .cond => Fin 0
+  | .safeRec _ _ => Fin 3
+  | .comp _ _ m k => Unit ⊕ Fin m ⊕ Fin k
+
+/-- The arity each subterm position must carry: the hypotheses of the
+arity relation of [HeraudNowak2011] § 3.2. -/
+@[expose, reducible] def rc : (a : Shape) → Direction a → ℕ × ℕ
+  | .zero, i => i.elim0
+  | .proj _ _ _, i => i.elim0
+  | .succ _, i => i.elim0
+  | .pred, i => i.elim0
+  | .cond, i => i.elim0
+  | .safeRec n s, ⟨0, _⟩ => (n, s)
+  | .safeRec n s, _ => (n + 1, s + 1)
+  | .comp _ _ m k, .inl () => (m, k)
+  | .comp n _ _ _, .inr (.inl _) => (n, 0)
+  | .comp n s _ _, .inr (.inr _) => (n, s)
+
+/-- The arity a shape produces: the conclusions of the arity relation of
+[HeraudNowak2011] § 3.2. -/
+@[expose, reducible] def q : Shape → ℕ × ℕ
+  | .zero => (0, 0)
+  | .proj n s _ => (n, s)
+  | .succ _ => (0, 1)
+  | .pred => (0, 1)
+  | .cond => (0, 4)
+  | .safeRec n s => (n + 1, s)
+  | .comp n s _ _ => (n, s)
+
+/-- The signature of `B` as a slice polynomial functor over `ℕ × ℕ`, the
+index being the pair of normal and safe arities. -/
+@[expose] def sig : SlicePFunctor (ℕ × ℕ) (ℕ × ℕ) where
+  A := Shape
+  B := Direction
+  r := fun x ↦ rc x.1 x.2
+  q := q
+
+/-- A choice-free `FinEnum (Fin n)`: the cardinality is `n` and the
+enumeration is the identity. `scoped`, so that it does not compete with
+mathlib's `FinEnum.fin` at the same head symbol outside this namespace. -/
+scoped instance finEnumFin (n : ℕ) :
+    FinEnum (Fin n) where
+  card := n
+  equiv := Equiv.refl _
+  decEq := inferInstance
+
+/-- A choice-free `FinEnum` for `comp`'s directions. `scoped`, for the same
+reason as `finEnumFin`. -/
+scoped instance finEnumCompDirection (m k : ℕ) :
+    FinEnum (Unit ⊕ Fin m ⊕ Fin k) where
+  card := 1 + (m + k)
+  equiv := (Equiv.sumCongr finOneEquiv.symm finSumFinEquiv).trans finSumFinEquiv
+  decEq := inferInstance
+
+/-- Every shape has finitely many directions, which is what makes
+admissibility of a `sig`-tree decidable. The branches ascribe their
+instances explicitly: instance search stops at reducible transparency on the
+projection `sig.B a`, so a bare `inferInstance` does not find them. -/
+instance sigFinitary : sig.toPFunctor.Finitary
+  | .zero => inferInstanceAs (FinEnum (Fin 0))
+  | .proj _ _ _ => inferInstanceAs (FinEnum (Fin 0))
+  | .succ _ => inferInstanceAs (FinEnum (Fin 0))
+  | .pred => inferInstanceAs (FinEnum (Fin 0))
+  | .cond => inferInstanceAs (FinEnum (Fin 0))
+  | .safeRec _ _ => inferInstanceAs (FinEnum (Fin 3))
+  | .comp _ _ m k => inferInstanceAs (FinEnum (Unit ⊕ Fin m ⊕ Fin k))
+
+/-- The children of a `comp` node, in the order `Direction` gives them:
+the head, then the normal arguments, then the safe arguments. -/
+@[expose] def compChildren {m k : ℕ} (h : sig.toPFunctor.W)
+    (gN : Fin m → sig.toPFunctor.W) (gS : Fin k → sig.toPFunctor.W) :
+    Unit ⊕ Fin m ⊕ Fin k → sig.toPFunctor.W :=
+  Sum.elim (fun _ ↦ h) (Sum.elim gN gS)
+
+/-- An expression of `B`: a `sig`-tree every node of which carries children
+at the indices `rc` prescribes. -/
+@[expose] def BC : Type := sig.W
+
+/-- The arity pair of an expression: its normal and safe arities. -/
+@[expose] def BC.arity : BC → ℕ × ℕ := sig.wIndex
+
+/-- The expressions of arity `(n, s)`, which is the arity relation of
+[HeraudNowak2011] § 3.2 as a type rather than a side condition. -/
+@[expose] def BCOf (n s : ℕ) : Type := { e : BC // e.arity = (n, s) }
+
+/-- The meaning of an arity pair: a function of a normal and a safe
+environment, each a tuple of bitstrings, returning a bitstring. -/
+@[expose] def Sem : ℕ × ℕ → Type :=
+  fun i ↦ (Fin i.1 → List Bool) → (Fin i.2 → List Bool) → List Bool
+
+/-- Transport of a meaning along an equality of arity pairs. Named so that
+the motive of `▸` is fixed once rather than inferred at each use in
+`evalValue`. -/
+@[expose] def transport {i j : ℕ × ℕ} (h : i = j) (v : Sem i) : Sem j := h ▸ v
+
+/-- The recursion `safeRec` performs on its first normal argument, by
+`List.rec`. The base case is the empty bitstring; a step consumes the low
+bit `b`, passes the remaining bitstring `v` as the new first normal
+argument, and passes the recursive value in safe position. -/
+@[expose] def evalRec {n s : ℕ} (g : Sem (n, s))
+    (h₀ h₁ : Sem (n + 1, s + 1)) : List Bool → Sem (n, s) :=
+  List.rec g (fun b v ih x y ↦
+    (if b then h₁ else h₀) (Fin.cons v x) (Fin.cons (ih x y) y))
+
+/-- The meaning of one node, from its children's meanings and the proof that
+each child's index is the one `rc` prescribes. A separate definition from
+`evalStep` because the match on `Shape` must generalize that proof.
+
+`cond` reads its first safe argument and returns the second, third or fourth
+according as it is empty, odd or even — the ordering of the authors' Coq
+development. `comp` applies its head's meaning to the normal arguments'
+meanings, each in the empty safe environment, and to the safe arguments'. -/
+@[expose] def evalValue : (a : Shape) → (c : Direction a → Σ i, Sem i) →
+    (∀ b, (c b).1 = rc a b) → Sem (q a)
+  | .zero, _, _ => fun _ _ ↦ []
+  | .proj _ _ i, _, _ => fun x y ↦ Fin.append x y i
+  | .succ b, _, _ => fun _ y ↦ b :: y 0
+  | .pred, _, _ => fun _ y ↦ (y 0).tail
+  | .cond, _, _ => fun _ y ↦
+      match y 0 with
+      | [] => y 1
+      | true :: _ => y 2
+      | false :: _ => y 3
+  | .safeRec _ _, c, h => fun x y ↦
+      evalRec (transport (h 0) (c 0).2) (transport (h 1) (c 1).2)
+        (transport (h 2) (c 2).2) (x 0) (Fin.tail x) y
+  | .comp _ _ _ _, c, h => fun x y ↦
+      transport (h (.inl ())) (c (.inl ())).2
+        (fun i ↦ transport (h (.inr (.inl i))) (c (.inr (.inl i))).2 x Fin.elim0)
+        (fun j ↦ transport (h (.inr (.inr j))) (c (.inr (.inr j))).2 x y)
+
+/-- `evalValue` as an algebra for `sig` in the slice over `ℕ × ℕ`. Returning
+the shape's own output index as the first component makes the eliminator's
+coherence obligation hold by `rfl`. -/
+@[expose] def evalStep :
+    sig.toSliceDomPFunctor.Obj (Sigma.fst (β := Sem)) → Σ i, Sem i :=
+  fun z ↦ ⟨sig.q z.1.1,
+    evalValue z.1.1 z.1.2
+      ((sig.toSliceDomPFunctor.compatible_iff _ z.1.1 z.1.2).mp z.2)⟩
+
+/-- The interpretation of an expression: its arity pair together with its
+meaning at that pair, by the slice W-type's eliminator. -/
+@[expose] def BC.eval : BC → Σ i, Sem i :=
+  SlicePFunctor.W.elim sig (Σ i, Sem i) (Sigma.fst (β := Sem)) evalStep rfl
+
+end
+
+end BellantoniCook

--- a/geb-lean/vendor/geb-mathlib/Geb/Mathlib/Computability/BellantoniCook/Tree.lean
+++ b/geb-lean/vendor/geb-mathlib/Geb/Mathlib/Computability/BellantoniCook/Tree.lean
@@ -1,0 +1,335 @@
+/-
+Copyright (c) 2026 Terence Rokop. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Terence Rokop
+-/
+module
+
+public import Geb.Mathlib.Computability.BellantoniCook.Basic
+public import Geb.Mathlib.Data.PFunctor.Slice.Decidable
+public import Geb.Mathlib.Data.Tree.Preorder
+
+/-!
+# A tree recognizer in the Bellantoni-Cook class
+
+Three expressions of `B` deciding whether a bitstring is the preorder spelling
+of a binary tree, and their correctness against the `Valid` predicate of the
+encoding. Composed with `BinTree.valid_iff_exists_print`,
+`isTreeSem_eq_singleton_iff_exists_print` states that an expression of `B`
+accepts exactly the spellings of trees. `B` is a characterization of the
+polynomial-time functions [BellantoniCook1992], which is used and not proved
+here, so the membership test lies in that class without a separate complexity
+argument.
+
+The recognizer is a single right-to-left scan rather than a recursive
+descent. A descent would parse the second subtree from a remainder the
+first call computes, which sits in safe position, and recursion on a safe
+argument is what the class forbids.
+
+## Main definitions
+
+* `BellantoniCook.zeroAtRaw`, `BellantoniCook.oneAtRaw` — the empty
+  bitstring and the one-bit string `[true]` at an arbitrary arity.
+* `BellantoniCook.falseAtRaw` — the one-bit string `[false]` at an
+  arbitrary arity.
+* `BellantoniCook.comb` — the stack depth and the underflow verdict in a
+  single value, of arity `(1, 0)`.
+* `BellantoniCook.eqOne` — whether a bitstring has length one, of arity
+  `(0, 1)`.
+* `BellantoniCook.isTree` — the recognizer, of arity `(1, 0)`.
+* `BellantoniCook.combSem`, `BellantoniCook.eqOneSem` and
+  `BellantoniCook.isTreeSem` — the meaning of each of the three at its
+  arity, over which every statement of the module is stated.
+
+## Main statements
+
+* `BellantoniCook.combSem_eq` — the scan computes `BinTree.depth` in
+  unary, offset by one, while `BinTree.ok` holds, and `[false]` once it
+  has failed.
+* `BellantoniCook.eqOneSem_eq` — `eqOne` accepts exactly the bitstrings
+  of length one.
+* `BellantoniCook.isTreeSem_eq_singleton_iff_valid` — `isTree` accepts
+  exactly the words satisfying `BinTree.Valid`.
+* `BellantoniCook.isTreeSem_eq_singleton_iff_exists_print` —
+  equivalently, exactly the spellings of trees.
+
+## Implementation notes
+
+The scan carries the stack depth and the underflow verdict in one
+recursive value, told apart by its head. While no node bit has been read
+below depth two the value is the depth in unary offset by one, so its
+head is `true`; once one has been, the value is `[false]`, which the node
+step reproduces, that value's two predecessors being empty. Each bit is
+read once.
+
+Each unfolding lemma is stated per constructor with the recursive value
+exposed on the right. `Sem` is a function type, so `evalRec` recurses at
+a function motive and every eliminator in the chain sits there;
+eliminators at function motives reduce only when their scrutinee is a
+constructor, so a symbolic-bit or fold-shaped statement is not
+definitional.
+
+Every unfolding lemma closes by `rfl` across the module boundary, and so
+depends on the `@[expose]` attributes `Basic.lean` carries on `Direction`,
+`rc`, `q`, `sig`, `compChildren`, `BC`, `evalRec`, `evalValue`, `evalStep` and
+`BC.eval`. Removing any of them leaves those lemmas stuck; the failure is
+silent at the language server and appears at `lake build`.
+
+`combSem`, `eqOneSem` and `isTreeSem` name each meaning at its arity, so
+that the arity pair is reduced and rewriting under it type-checks. A
+meaning taken through the `Sigma` projection instead has a type headed by
+that projection rather than by an arrow, and `rw` under it fails as not
+type-correct at `implicit` transparency.
+
+## References
+
+* [BellantoniCook1992]
+
+## Tags
+
+Bellantoni-Cook, polytime, implicit computational complexity, safe
+recursion, binary tree, preorder, recognizer
+-/
+
+namespace BellantoniCook
+
+public section
+
+/-- The empty bitstring at an arbitrary arity. -/
+@[expose] def zeroAtRaw (n s : ℕ) : sig.toPFunctor.W :=
+  WType.mk (.comp n s 0 0)
+    (compChildren (WType.mk .zero Fin.elim0) Fin.elim0 Fin.elim0)
+
+/-- The one-bit string `[true]` at an arbitrary arity. -/
+@[expose] def oneAtRaw (n s : ℕ) : sig.toPFunctor.W :=
+  WType.mk (.comp n s 0 1)
+    (compChildren (WType.mk (.succ true) Fin.elim0) Fin.elim0 ![zeroAtRaw n s])
+
+/-- The one-bit string `[false]` at an arbitrary arity. -/
+@[expose] def falseAtRaw (n s : ℕ) : sig.toPFunctor.W :=
+  WType.mk (.comp n s 0 1)
+    (compChildren (WType.mk (.succ false) Fin.elim0) Fin.elim0 ![zeroAtRaw n s])
+
+/-- Prepend `true` to the recursive value. -/
+@[expose] def incRaw : sig.toPFunctor.W :=
+  WType.mk (.comp 1 1 0 1)
+    (compChildren (WType.mk (.succ true) Fin.elim0) Fin.elim0
+      ![WType.mk (.proj 1 1 1) Fin.elim0])
+
+/-- Drop the low bit of the recursive value. -/
+@[expose] def decRaw : sig.toPFunctor.W :=
+  WType.mk (.comp 1 1 0 1)
+    (compChildren (WType.mk .pred Fin.elim0) Fin.elim0
+      ![WType.mk (.proj 1 1 1) Fin.elim0])
+
+/-- The guard of the node step: the recursive value with two bits
+dropped. It is empty exactly when the value is the failure flag, whose
+two predecessors truncate to the empty bitstring, or a depth below
+two. -/
+@[expose] def predPredRaw : sig.toPFunctor.W :=
+  WType.mk (.comp 1 1 0 1)
+    (compChildren (WType.mk .pred Fin.elim0) Fin.elim0 ![decRaw])
+
+/-- The leaf step: push a level onto a live value, whose head is `true`,
+and return the failure flag on a value that is empty or has head
+`false`. -/
+@[expose] def combFalseStepRaw : sig.toPFunctor.W :=
+  WType.mk (.comp 1 1 0 4)
+    (compChildren (WType.mk .cond Fin.elim0) Fin.elim0
+      ![WType.mk (.proj 1 1 1) Fin.elim0, falseAtRaw 1 1, incRaw,
+        falseAtRaw 1 1])
+
+/-- The node step: pop a level when at least two remain, and return the
+failure flag otherwise. An existing failure propagates, its guard being
+empty. -/
+@[expose] def combTrueStepRaw : sig.toPFunctor.W :=
+  WType.mk (.comp 1 1 0 4)
+    (compChildren (WType.mk .cond Fin.elim0) Fin.elim0
+      ![predPredRaw, falseAtRaw 1 1, decRaw, decRaw])
+
+/-- The raw tree of the scan. The base is `[true]`, the empty bitstring
+having depth zero and satisfying `ok`. -/
+@[expose] def combRaw : sig.toPFunctor.W :=
+  WType.mk (.safeRec 0 0) ![oneAtRaw 0 0, combFalseStepRaw, combTrueStepRaw]
+
+/-- The stack depth and the underflow verdict of a bitstring in one
+value: the depth in unary, offset by one so that a live value is
+non-empty with head `true`, and `[false]` once a node bit has been read
+below depth two. -/
+@[expose] def comb : BC := ⟨combRaw, by decide⟩
+
+/-- The inner conditional of `eqOne`: whether the predecessor of the
+argument is empty. The even branch is unreachable only under this
+module's own use, where the argument is always a unary numeral; the
+expression and its characterization are stated for an arbitrary
+bitstring, over which the branch is reached. -/
+@[expose] def eqOneInnerRaw : sig.toPFunctor.W :=
+  WType.mk (.comp 0 1 0 4)
+    (compChildren (WType.mk .cond Fin.elim0) Fin.elim0
+      ![WType.mk (.comp 0 1 0 1)
+          (compChildren (WType.mk .pred Fin.elim0) Fin.elim0
+            ![WType.mk (.proj 0 1 0) Fin.elim0]),
+        oneAtRaw 0 1, zeroAtRaw 0 1, zeroAtRaw 0 1])
+
+/-- The raw tree of the one-test: empty is not one, and otherwise the
+argument is one exactly when its predecessor is empty. -/
+@[expose] def eqOneRaw : sig.toPFunctor.W :=
+  WType.mk (.comp 0 1 0 4)
+    (compChildren (WType.mk .cond Fin.elim0) Fin.elim0
+      ![WType.mk (.proj 0 1 0) Fin.elim0, zeroAtRaw 0 1, eqOneInnerRaw,
+        eqOneInnerRaw])
+
+/-- Whether a bitstring has length one, returning `[true]` or `[]`. -/
+@[expose] def eqOne : BC := ⟨eqOneRaw, by decide⟩
+
+/-- The raw tree of the recognizer: the scan's predecessor has length
+one. -/
+@[expose] def isTreeRaw : sig.toPFunctor.W :=
+  WType.mk (.comp 1 0 0 1)
+    (compChildren eqOneRaw Fin.elim0
+      ![WType.mk (.comp 1 0 0 1)
+          (compChildren (WType.mk .pred Fin.elim0) Fin.elim0 ![combRaw])])
+
+/-- The recognizer: whether a bitstring is the preorder spelling of a
+binary tree. The output is `[true]` or `[]`, so correctness is an
+equation rather than a disequation. -/
+@[expose] def isTree : BC := ⟨isTreeRaw, by decide⟩
+
+/-- `comb` at its declared arity. Elaborating this is the assertion that
+`BC.arity comb` is `(1, 0)`. -/
+@[expose] def combOf : BCOf 1 0 := ⟨comb, rfl⟩
+
+/-- `eqOne` at its declared arity. -/
+@[expose] def eqOneOf : BCOf 0 1 := ⟨eqOne, rfl⟩
+
+/-- `isTree` at its declared arity. -/
+@[expose] def isTreeOf : BCOf 1 0 := ⟨isTree, rfl⟩
+
+/-- The scan's meaning at its arity, ascribed so that the arity pair is
+reduced and rewriting under it type-checks. -/
+@[expose] def combSem :
+    (Fin 1 → List Bool) → (Fin 0 → List Bool) → List Bool := (BC.eval comb).2
+
+/-- The one-test's meaning at its arity, ascribed likewise. -/
+@[expose] def eqOneSem :
+    (Fin 0 → List Bool) → (Fin 1 → List Bool) → List Bool := (BC.eval eqOne).2
+
+/-- The recognizer's meaning at its arity, ascribed likewise. -/
+@[expose] def isTreeSem :
+    (Fin 1 → List Bool) → (Fin 0 → List Bool) → List Bool := (BC.eval isTree).2
+
+/-- The scan's value on the empty bitstring: depth zero, offset by
+one. -/
+theorem combSem_nil : combSem ![[]] ![] = [true] := rfl
+
+/-- A leaf bit pushes a level onto a live value, and is absorbed by a
+failure. -/
+theorem combSem_cons_false (v : List Bool) :
+    combSem ![false :: v] ![] =
+      (match combSem ![v] ![] with
+       | [] => [false]
+       | true :: _ => true :: combSem ![v] ![]
+       | false :: _ => [false]) := rfl
+
+/-- A node bit pops a level when at least two remain, and fails
+otherwise. The guard is the value with two bits dropped, so a failure,
+whose two predecessors are empty, propagates. -/
+theorem combSem_cons_true (v : List Bool) :
+    combSem ![true :: v] ![] =
+      (match (combSem ![v] ![]).tail.tail with
+       | [] => [false]
+       | true :: _ => (combSem ![v] ![]).tail
+       | false :: _ => (combSem ![v] ![]).tail) := rfl
+
+/-- The scan computes the stack depth in unary, offset by one, while
+`ok` holds, and the absorbing value `[false]` once it has failed. -/
+theorem combSem_eq (w : List Bool) :
+    combSem ![w] ![] =
+      if BinTree.ok w then List.replicate (BinTree.depth w + 1) true
+      else [false] := by
+  refine List.rec (motive := fun u ↦ combSem ![u] ![] =
+    if BinTree.ok u then List.replicate (BinTree.depth u + 1) true else [false])
+    rfl ?_ w
+  intro b v ih
+  cases hok : BinTree.ok v
+  · have hv : combSem ![v] ![] = [false] := by rw [ih, hok]; rfl
+    cases b
+    · rw [combSem_cons_false, hv, BinTree.ok_cons_false, hok]; rfl
+    · rw [combSem_cons_true, hv, BinTree.ok_cons_true, hok]; rfl
+  · have hv : combSem ![v] ![] = List.replicate (BinTree.depth v + 1) true := by
+      rw [ih, hok]; rfl
+    cases b
+    · rw [combSem_cons_false, hv, BinTree.ok_cons_false, hok,
+        BinTree.depth_cons_false]
+      rfl
+    · rw [combSem_cons_true, hv, BinTree.ok_cons_true, hok,
+        BinTree.depth_cons_true]
+      -- the guard's two predecessors reduce only on a numeral of at
+      -- least that size, so the depth is split into constructor forms
+      have hsplit : ∀ d : ℕ, d = 0 ∨ d = 1 ∨ ∃ m, d = m + 2 := fun d ↦
+        match d with
+        | 0 => Or.inl rfl
+        | 1 => Or.inr (Or.inl rfl)
+        | (m + 2) => Or.inr (Or.inr ⟨m, rfl⟩)
+      obtain (h0 | h1 | ⟨m, hm⟩) := hsplit (BinTree.depth v)
+      · rw [h0]; rfl
+      · rw [h1]; rfl
+      · rw [hm]; rfl
+
+/-- The one-test at an arbitrary environment is the test at the canonical
+one. -/
+theorem eqOneSem_env (f : Fin 0 → List Bool) (g : Fin 1 → List Bool) :
+    eqOneSem f g = eqOneSem ![] ![g 0] := by
+  have hf : f = ![] := Subsingleton.elim _ _
+  have hg : g = ![g 0] := funext fun i ↦ match i with | ⟨0, _⟩ => rfl
+  conv_lhs => rw [hf, hg]
+
+/-- The one-test accepts exactly the bitstrings of length one. It is not
+a recursion, so its three cases are decided by matching. -/
+theorem eqOneSem_eq (u : List Bool) :
+    eqOneSem ![] ![u] = if u.length = 1 then [true] else [] := by
+  match u with
+  | [] => rfl
+  | [b] => cases b <;> rfl
+  | b :: c :: v =>
+    cases b <;> cases c <;>
+      (change ([] : List Bool) = _
+       rw [if_neg (by simp only [List.length_cons]; omega)])
+
+/-- One step of the recognizer: the one-test on the scan's predecessor.
+The scan's value is `[false]` on failure, whose predecessor is empty, and
+otherwise the depth in unary offset by one, whose predecessor has length
+the depth. -/
+theorem isTreeSem_apply (w : List Bool) :
+    isTreeSem ![w] ![] =
+      eqOneSem (fun _ ↦ []) (fun _ ↦ (combSem ![w] ![]).tail) := rfl
+
+/-- The recognizer accepts exactly the words satisfying `BinTree.Valid`. -/
+theorem isTreeSem_eq_singleton_iff_valid (w : List Bool) :
+    isTreeSem ![w] ![] = [true] ↔ BinTree.Valid w := by
+  rw [isTreeSem_apply, eqOneSem_env]
+  simp only [eqOneSem_eq, combSem_eq]
+  by_cases h : BinTree.ok w = true
+  · rw [if_pos h]
+    simp only [List.tail_replicate, List.length_replicate, Nat.add_sub_cancel]
+    by_cases hd : BinTree.depth w = 1
+    · rw [if_pos hd]
+      exact ⟨fun _ ↦ ⟨h, hd⟩, fun _ ↦ rfl⟩
+    · rw [if_neg hd]
+      refine ⟨fun hw ↦ absurd hw (by nofun), ?_⟩
+      rintro ⟨-, hd'⟩
+      exact absurd hd' hd
+  · rw [if_neg h, if_neg (by decide : ¬ ([false] : List Bool).tail.length = 1)]
+    refine ⟨fun hw ↦ absurd hw (by nofun), ?_⟩
+    rintro ⟨h', -⟩
+    exact absurd h' h
+
+/-- The recognizer accepts exactly the preorder spellings of binary
+trees. -/
+theorem isTreeSem_eq_singleton_iff_exists_print (w : List Bool) :
+    isTreeSem ![w] ![] = [true] ↔ ∃ t, BinTree.print t = w :=
+  (isTreeSem_eq_singleton_iff_valid w).trans (BinTree.valid_iff_exists_print w)
+
+end
+
+end BellantoniCook

--- a/geb-lean/vendor/geb-mathlib/Geb/Mathlib/Data.lean
+++ b/geb-lean/vendor/geb-mathlib/Geb/Mathlib/Data.lean
@@ -9,6 +9,7 @@ public import Geb.Mathlib.Data.Fin
 public import Geb.Mathlib.Data.FinEnum
 public import Geb.Mathlib.Data.List
 public import Geb.Mathlib.Data.PFunctor
+public import Geb.Mathlib.Data.Tree
 public import Geb.Mathlib.Data.UnionFind
 public import Geb.Mathlib.Data.Vector
 public import Geb.Mathlib.Data.W

--- a/geb-lean/vendor/geb-mathlib/Geb/Mathlib/Data/Tree.lean
+++ b/geb-lean/vendor/geb-mathlib/Geb/Mathlib/Data/Tree.lean
@@ -1,0 +1,13 @@
+/-
+Copyright (c) 2026 Terence Rokop. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Terence Rokop
+-/
+module
+
+public import Geb.Mathlib.Data.Tree.Binary
+public import Geb.Mathlib.Data.Tree.Preorder
+
+/-!
+# Tree — index
+-/

--- a/geb-lean/vendor/geb-mathlib/Geb/Mathlib/Data/Tree/Binary.lean
+++ b/geb-lean/vendor/geb-mathlib/Geb/Mathlib/Data/Tree/Binary.lean
@@ -1,0 +1,119 @@
+/-
+Copyright (c) 2026 Terence Rokop. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Terence Rokop
+-/
+module
+
+public import Mathlib.Data.W.Basic
+
+/-!
+# Unlabelled binary trees as a W-type
+
+The initial algebra of `F X = 1 + X × X`, presented as the W-type on a
+two-element shape type. The presentation is the one this repository uses
+for every self-referential datatype: a non-recursive shape type, a
+direction family, and the W-type of that family, so that all recursion is
+carried by `WType.elim` and `WType.rec`.
+
+## Main definitions
+
+* `BinTree.Shape` — the two node forms.
+* `BinTree.Direction` — the child index type of each shape.
+* `BinTree` — the trees themselves.
+* `BinTree.leaf`, `BinTree.node` — the two constructors.
+* `BinTree.size` — the number of nodes, leaves included.
+
+## Main statements
+
+* `BinTree.induction` — induction in the two-constructor presentation.
+
+## Implementation notes
+
+`Direction` names the child index family, following the convention of
+this repository's polynomial-functor modules, where a shape's fibre is
+its `Direction`.
+
+`Direction` is `@[expose]`. The module system does not unfold a
+non-exposed definition, so without it `WType.mk .leaf Fin.elim0` does not
+elaborate: `Fin.elim0` cannot be checked against `Direction Shape.leaf`.
+
+`Direction` sends `leaf` to `Fin 0` rather than to `Empty`, so that both
+fibres lie in one family.
+
+## Tags
+
+binary tree, W-type, initial algebra, polynomial functor
+-/
+
+namespace BinTree
+
+public section
+
+/-- The node forms of an unlabelled binary tree. -/
+inductive Shape
+  /-- A leaf, with no children. -/
+  | leaf
+  /-- A node, with two children. -/
+  | node
+
+/-- The child index type of each shape: a leaf has none, a node has two. -/
+@[expose] def Direction : Shape → Type
+  | .leaf => Fin 0
+  | .node => Fin 2
+
+end
+
+end BinTree
+
+/-- Unlabelled binary trees: the initial algebra of `F X = 1 + X × X`. -/
+@[expose] public def BinTree : Type := WType BinTree.Direction
+
+namespace BinTree
+
+public section
+
+/-- The leaf. -/
+@[expose] def leaf : BinTree := WType.mk .leaf Fin.elim0
+
+/-- The node with left child `l` and right child `r`. -/
+@[expose] def node (l r : BinTree) : BinTree :=
+  WType.mk .node fun b : Fin 2 ↦ Fin.cases l (fun _ ↦ r) b
+
+/-- The number of nodes, leaves included. Extracted upstream this would
+sit beside `BinaryTree.numNodes`, `BinaryTree.numLeaves` and
+`BinaryTree.height`, and it is none of the three: it is
+`numNodes + numLeaves`. -/
+@[expose] def size : BinTree → ℕ :=
+  WType.elim ℕ fun x ↦
+    match x with
+    | ⟨.leaf, _⟩ => 1
+    | ⟨.node, ch⟩ => ch (0 : Fin 2) + ch (1 : Fin 2) + 1
+
+/-- Induction in the two-constructor presentation, so that a proof driven
+by it need not mention the underlying shape and direction families. -/
+theorem induction {motive : BinTree → Prop} (hleaf : motive leaf)
+    (hnode : ∀ l r, motive l → motive r → motive (node l r)) :
+    ∀ t, motive t :=
+  WType.rec (motive := motive) fun s f ih ↦
+    match s, f, ih with
+    | .leaf, f, _ => by
+        have : f = Fin.elim0 := funext (fun e ↦ e.elim0)
+        subst this; exact hleaf
+    | .node, f, ih => by
+        have : (fun b : Fin 2 ↦ Fin.cases (f (0 : Fin 2))
+            (fun _ ↦ f (1 : Fin 2)) b) = f :=
+          funext fun b ↦ match b with
+            | ⟨0, _⟩ => rfl
+            | ⟨1, _⟩ => rfl
+        exact this ▸ hnode (f (0 : Fin 2)) (f (1 : Fin 2))
+          (ih (0 : Fin 2)) (ih (1 : Fin 2))
+
+@[simp] theorem size_leaf : leaf.size = 1 := rfl
+
+@[simp] theorem size_node (l r : BinTree) :
+    (node l r).size = l.size + r.size + 1 := rfl
+
+end
+
+end BinTree

--- a/geb-lean/vendor/geb-mathlib/Geb/Mathlib/Data/Tree/Preorder.lean
+++ b/geb-lean/vendor/geb-mathlib/Geb/Mathlib/Data/Tree/Preorder.lean
@@ -1,0 +1,347 @@
+/-
+Copyright (c) 2026 Terence Rokop. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Terence Rokop
+-/
+module
+
+public import Geb.Mathlib.Data.Tree.Binary
+
+/-!
+# The preorder encoding of binary trees as bitstrings
+
+A leaf is spelled by one `false` bit, a node by a `true` bit followed by
+its two children's spellings. The encoding is a bijection onto the
+bitstrings satisfying `Valid`, the condition that the stack depth read
+right to left reads every node bit at depth at least two, and ends at
+one.
+
+The idea is that of prefix notation, in which a symbol is followed by
+exactly as many operands as its arity. Here the two unlabelled shapes
+play those roles, the node bit taking two operands and the leaf bit
+none.
+
+`Valid` is stated as two conditions, in the manner of mathlib's
+`DyckWord`, whose fields `count_U_eq_count_D` and `count_D_le_count_U`
+play the roles that `depth w = 1` and `ok` play here, and in the
+direction a single right-to-left pass carrying a counter can scan.
+
+## Main definitions
+
+* `BinTree.print` — the encoding.
+* `BinTree.parseStep`, `BinTree.parseAux`, `BinTree.parse` — the
+  fuel-bounded recursive-descent decoding.
+* `BinTree.depth` — the stack depth, read right to left, truncated at
+  zero.
+* `BinTree.ok` — every node bit is read at depth at least two.
+* `BinTree.Valid` — the two conditions together.
+
+## Main statements
+
+* `BinTree.parse_print` — the retraction law.
+* `BinTree.parseAux_eq_some` — whatever the descent reads, it reads a
+  spelling.
+* `BinTree.parse_eq_some_iff` — the decoding is the inverse of the
+  encoding, on the nose.
+* `BinTree.print_injective` — distinct trees have distinct spellings.
+* `BinTree.valid_print` — every spelling is valid.
+* `BinTree.valid_iff_exists_print` — the valid words are exactly the
+  spellings.
+* `BinTree.valid_iff_isSome_parse` — `parse` decides `Valid`.
+
+## Implementation notes
+
+`parseAux` recurses on an explicit `ℕ` bound rather than on its input:
+the second child is parsed from a remainder the first call computes,
+which is not a structural subterm. `parse` supplies the input's length,
+and `length_print` shows that bound admits every tree `print` emits.
+
+Fuel exhaustion is not a rejection mechanism of its own, beyond the
+three the parser has: empty input and a child's failure, both from
+`parseStep`, and the trailing input `parse` rejects. Each `parseStep`
+layer consumes at least the head bit before delegating to the next, so
+the invariant `fuel ≥ remaining length` holds from `parse`'s initial
+`w.length` all the way down; when the fuel reaches zero the remaining
+input is already empty, and `parseStep []` returns `none` whatever fuel
+it is given.
+
+`exists_print_append_of_ok_of_one_le_depth` is likewise bounded by an
+explicit `ℕ` and driven by `Nat.rec`. Its node case applies the
+hypothesis to a proper suffix and then to a suffix of that; both uses sit
+at the same bound, so no well-founded recursion is needed.
+
+## Tags
+
+binary tree, preorder, prefix notation, encoding, retraction
+-/
+
+namespace BinTree
+
+public section
+
+/-- The preorder encoding: a leaf is one `false` bit, a node a `true` bit
+followed by its two children's encodings. -/
+@[expose] def print : BinTree → List Bool :=
+  WType.elim (List Bool) fun x ↦
+    match x with
+    | ⟨.leaf, _⟩ => [false]
+    | ⟨.node, ch⟩ => true :: (ch (0 : Fin 2) ++ ch (1 : Fin 2))
+
+@[simp] theorem print_leaf : print leaf = [false] := rfl
+
+@[simp] theorem print_node (l r : BinTree) :
+    print (node l r) = true :: (print l ++ print r) := rfl
+
+/-- One layer of the recursive descent: read one tree, delegating each
+child to `child`, and return it with the unconsumed remainder. -/
+@[expose] def parseStep (child : List Bool → Option (BinTree × List Bool)) :
+    List Bool → Option (BinTree × List Bool)
+  | [] => none
+  | false :: rest => some (leaf, rest)
+  | true :: rest =>
+    match child rest with
+    | none => none
+    | some (l, rest₁) =>
+      match child rest₁ with
+      | none => none
+      | some (r, rest₂) => some (node l r, rest₂)
+
+/-- Recursive descent bounded by an explicit `ℕ`. -/
+@[expose] def parseAux : ℕ → List Bool → Option (BinTree × List Bool) :=
+  Nat.rec (fun _ ↦ none) fun _ ih ↦ parseStep ih
+
+theorem parseAux_succ (f : ℕ) :
+    parseAux (f + 1) = parseStep (parseAux f) := rfl
+
+/-- The decoding, rejecting trailing input. -/
+@[expose] def parse (w : List Bool) : Option BinTree :=
+  match parseAux w.length w with
+  | some (t, []) => some t
+  | _ => none
+
+/-- The stack depth of a bitstring read right to left: a leaf bit pushes,
+a node bit pops two and pushes one. Subtraction is truncated at zero;
+`ok` is the separate condition under which each pop has two operands. -/
+@[expose] def depth : List Bool → ℕ :=
+  List.rec 0 fun b _ ih ↦ if b then ih - 1 else ih + 1
+
+@[simp] theorem depth_nil : depth [] = 0 := rfl
+
+@[simp] theorem depth_cons_false (v : List Bool) :
+    depth (false :: v) = depth v + 1 := rfl
+
+@[simp] theorem depth_cons_true (v : List Bool) :
+    depth (true :: v) = depth v - 1 := rfl
+
+/-- Every node bit is read at a depth of at least two, so that popping
+two operands is defined. This is strictly stronger than absence of
+truncation: `[true, false]` truncates nowhere, since `depth [false] = 1`
+and `1 - 1` is exact, yet fails `ok`. -/
+@[expose] def ok : List Bool → Bool :=
+  List.rec true fun b v ih ↦ ih && (if b then decide (2 ≤ depth v) else true)
+
+@[simp] theorem ok_nil : ok [] = true := rfl
+
+@[simp] theorem ok_cons_false (v : List Bool) : ok (false :: v) = ok v := by
+  simp [ok]
+
+@[simp] theorem ok_cons_true (v : List Bool) :
+    ok (true :: v) = (ok v && decide (2 ≤ depth v)) := rfl
+
+/-- A bitstring spells a tree: `ok` holds of it, and it leaves a single
+tree on the stack. The tree is unique, by `print_injective`. -/
+@[expose] def Valid (w : List Bool) : Prop := ok w = true ∧ depth w = 1
+
+/-- A spelling's length is the tree's node count, so the input length is
+fuel enough for `parseAux` to read anything `print` emits. -/
+theorem length_print (t : BinTree) : (print t).length = t.size :=
+  BinTree.induction (motive := fun t ↦ (print t).length = t.size)
+    rfl
+    (fun l r ihl ihr ↦ by
+      simp only [print_node, List.length_cons, List.length_append, ihl, ihr,
+        size_node]) t
+
+/-- The parser inverts the printer on printed input, given fuel at least
+the tree's node count, and returns the unconsumed remainder. -/
+theorem parseAux_print (t : BinTree) :
+    ∀ (f : ℕ) (rest : List Bool), t.size ≤ f →
+      parseAux f (print t ++ rest) = some (t, rest) :=
+  BinTree.induction (motive := fun t ↦ ∀ (f : ℕ) (rest : List Bool), t.size ≤ f →
+      parseAux f (print t ++ rest) = some (t, rest))
+    (fun f rest hf ↦ by
+      cases f with
+      | zero => simp at hf
+      | succ f => simp [parseAux_succ, parseStep])
+    (fun l r ihl ihr f rest hf ↦ by
+      cases f with
+      | zero => simp at hf
+      | succ f =>
+        have hl : l.size ≤ f := by simp at hf; omega
+        have hr : r.size ≤ f := by simp at hf; omega
+        simp only [print_node, List.cons_append, parseAux_succ, parseStep,
+          List.append_assoc]
+        rw [ihl f _ hl]
+        -- reduce the match on the `some` just produced, exposing the
+        -- second child
+        simp only []
+        rw [ihr f _ hr]) t
+
+/-- Whatever the descent reads, it reads a spelling: the tree returned,
+spelled and followed by the remainder, is the input. -/
+theorem parseAux_eq_some : ∀ (f : ℕ) (w : List Bool) (t : BinTree)
+    (rest : List Bool), parseAux f w = some (t, rest) → print t ++ rest = w :=
+  Nat.rec
+    (fun _ _ _ h ↦ nomatch h)
+    (fun f ih w t rest h ↦ by
+      match w with
+      | [] =>
+        rw [parseAux_succ, parseStep] at h
+        contradiction
+      | false :: v =>
+        rw [parseAux_succ, parseStep] at h
+        have h' := Option.some.inj h
+        injection h' with ht hrest
+        subst ht; subst hrest
+        rfl
+      | true :: v =>
+        rw [parseAux_succ, parseStep] at h
+        split at h
+        · contradiction
+        · rename_i l rest₁ h₁
+          split at h
+          · contradiction
+          · rename_i r rest₂ h₂
+            have h' := Option.some.inj h
+            injection h' with ht hrest
+            subst ht; subst hrest
+            rw [print_node, List.cons_append, List.append_assoc,
+              ih rest₁ r rest₂ h₂, ih v l rest₁ h₁])
+
+/-- The retraction law: the parser recovers every tree the printer
+spells. -/
+theorem parse_print (t : BinTree) : parse (print t) = some t := by
+  have h := parseAux_print t (print t).length [] (le_of_eq (length_print t).symm)
+  rw [List.append_nil] at h
+  simp [parse, h]
+
+/-- The parser succeeds exactly on the spellings, returning the tree
+spelled: `parse` and `print` are mutually inverse. -/
+theorem parse_eq_some_iff {w : List Bool} {t : BinTree} :
+    parse w = some t ↔ print t = w := by
+  refine ⟨fun h ↦ ?_, fun h ↦ h ▸ parse_print t⟩
+  rw [parse] at h
+  split at h
+  · rename_i t' hp
+    rw [← Option.some.inj h]
+    simpa using parseAux_eq_some w.length w t' [] hp
+  · contradiction
+
+/-- Distinct trees have distinct spellings. -/
+theorem print_injective : Function.Injective print := by
+  intro a b h
+  have ha := parse_print a
+  rw [h, parse_print b] at ha
+  exact (Option.some.inj ha).symm
+
+/-- A spelling followed by anything leaves the depth one higher. -/
+theorem depth_print (t : BinTree) :
+    ∀ rest : List Bool, depth (print t ++ rest) = depth rest + 1 :=
+  BinTree.induction (motive := fun t ↦ ∀ rest : List Bool,
+      depth (print t ++ rest) = depth rest + 1)
+    (fun rest ↦ by simp)
+    (fun l r ihl ihr rest ↦ by
+      simp only [print_node, List.cons_append, List.append_assoc,
+        depth_cons_true, ihl, ihr]
+      omega) t
+
+/-- A spelling followed by anything satisfies `ok` exactly when what
+follows it does. -/
+theorem ok_print (t : BinTree) :
+    ∀ rest : List Bool, ok (print t ++ rest) = ok rest :=
+  BinTree.induction (motive := fun t ↦ ∀ rest : List Bool,
+      ok (print t ++ rest) = ok rest)
+    (fun rest ↦ by simp)
+    (fun l r ihl ihr rest ↦ by
+      simp only [print_node, List.cons_append, List.append_assoc,
+        ok_cons_true, ihl, ihr, depth_print]
+      simp) t
+
+/-- A word satisfying `ok` that carries at least one tree has a complete
+tree as a prefix. -/
+theorem exists_print_append_of_ok_of_one_le_depth :
+    ∀ (n : ℕ) (w : List Bool), w.length ≤ n → ok w = true →
+      1 ≤ depth w → ∃ t rest, print t ++ rest = w ∧ depth rest + 1 = depth w ∧
+        ok rest = true :=
+  Nat.rec
+    (fun w hw _ hd ↦ by
+      have hnil : w = [] := List.eq_nil_of_length_eq_zero (Nat.le_zero.mp hw)
+      subst hnil; simp at hd)
+    (fun n ih w hw hok hd ↦ by
+      match w with
+      | [] => simp at hd
+      | false :: v => exact ⟨leaf, v, by simp, by simp, by simpa using hok⟩
+      | true :: v =>
+        rw [ok_cons_true] at hok
+        rw [depth_cons_true] at hd
+        have hokv : ok v = true := (Bool.and_eq_true _ _ |>.mp hok).1
+        have hdv : 2 ≤ depth v := by
+          have := (Bool.and_eq_true _ _ |>.mp hok).2
+          simpa using this
+        have hwv : v.length ≤ n := by simp at hw; omega
+        obtain ⟨l, rest₁, hl, hd₁, hok₁⟩ := ih v hwv hokv (by omega)
+        have hrest₁ : rest₁.length ≤ n := by
+          have : rest₁.length ≤ v.length := by
+            rw [← hl, List.length_append]; omega
+          omega
+        obtain ⟨r, rest₂, hr, hd₂, hok₂⟩ :=
+          ih rest₁ hrest₁ hok₁ (by omega)
+        refine ⟨node l r, rest₂, ?_, by rw [depth_cons_true]; omega, hok₂⟩
+        rw [print_node, List.cons_append, List.append_assoc, hr, hl])
+
+/-- A word satisfying `ok` that carries no tree is empty. -/
+theorem eq_nil_of_ok_of_depth_eq_zero (w : List Bool) (h : ok w = true)
+    (hd : depth w = 0) : w = [] := by
+  match w with
+  | [] => rfl
+  | false :: v => simp at hd
+  | true :: v =>
+    rw [ok_cons_true] at h
+    have := (Bool.and_eq_true _ _ |>.mp h).2
+    simp only [decide_eq_true_eq] at this
+    rw [depth_cons_true] at hd
+    omega
+
+/-- Every valid word is a spelling: the converse of `valid_print`. -/
+theorem exists_print_of_valid {w : List Bool} (h : Valid w) :
+    ∃ t, print t = w := by
+  obtain ⟨hok, hd⟩ := h
+  obtain ⟨t, rest, he, hd', hok'⟩ :=
+    exists_print_append_of_ok_of_one_le_depth w.length w le_rfl hok (by omega)
+  have hz : depth rest = 0 := by omega
+  have hnil : rest = [] := eq_nil_of_ok_of_depth_eq_zero rest hok' hz
+  subst hnil
+  exact ⟨t, by simpa using he⟩
+
+/-- Every spelling is valid. -/
+theorem valid_print (t : BinTree) : Valid (print t) := by
+  constructor
+  · have := ok_print t []; rw [List.append_nil] at this; simp [this]
+  · have := depth_print t []; rw [List.append_nil] at this; simp [this]
+
+/-- The encoding's image is exactly the valid words: the characterization
+the recognizer's correctness is stated against. -/
+theorem valid_iff_exists_print (w : List Bool) : Valid w ↔ ∃ t, print t = w :=
+  ⟨exists_print_of_valid, fun ⟨t, ht⟩ ↦ ht ▸ valid_print t⟩
+
+/-- `parse` decides `Valid`: a word is valid exactly when the parser
+accepts it. -/
+theorem valid_iff_isSome_parse (w : List Bool) : Valid w ↔ (parse w).isSome := by
+  rw [valid_iff_exists_print]
+  refine ⟨fun ⟨t, ht⟩ ↦ ?_, fun h ↦ ?_⟩
+  · rw [← ht, parse_print]; rfl
+  · obtain ⟨t, ht⟩ := Option.isSome_iff_exists.mp h
+    exact ⟨t, parse_eq_some_iff.mp ht⟩
+
+end
+
+end BinTree

--- a/geb-lean/vendor/geb-mathlib/PROVENANCE.md
+++ b/geb-lean/vendor/geb-mathlib/PROVENANCE.md
@@ -1,6 +1,6 @@
 # Vendored geb-mathlib provenance
 
 - Source: https://github.com/rokopt/geb-mathlib.git
-- Source commit: 19092b7fda67028e568b6b8dc3928d7a05b327d3
-- Back-port patch: scripts/geb-mathlib-backport.patch (sha256 059586c6ce57ca832fdb4e285ff3dc4b302c6ac65f68582d428fb9e2b70ffe64)
+- Source commit: f600ebe4b2e2879acc605c06609993f1a8663370
+- Back-port patch: scripts/geb-mathlib-backport.patch (sha256 c3395ccef5eaa8e862d113ed201d9236ac90198839de10df6286a2a46c6dc294)
 - The files under `Geb/` are an unmodified mirror of the source commit except where the back-port patch changes them; modified files carry a change notice in their header comment.


### PR DESCRIPTION
The refresh ingests Geb/Internal (concrete syntax, S-expression readers, and the presheaf-IR prototype) and the Bellantoni-Cook and Data/Tree material under Geb/Mathlib. Six new v4.29 incompatibilities appear in the newly-ingested modules; extend back-port categories 3, 4, 7, and 8 to cover them and add category 10.

Category 3 (the Type-category coercion layer): replace the ConcreteCategory.comp_apply step in PresheafIRProto/Basic.lean's postcompArityHom and the NatTrans.naturality_apply term in PresheafIRProto/Functor.lean's arityHomEquivNatTrans with FunctorToTypes.naturality, and drop the TypeCat.Fun coercion-stripping simp in PresheafIRProto/Codes.lean's BaseArity.reindexHom.

Category 4: prepend beta_reduce to ConcreteSyntax.lean's ofRose_toRose minor premise.

Category 7: append rfl to isFunctorial_pullback's reindex_id.

Category 8: nolint the derived Ann Repr instance's precedence argument.

Category 10 (new): simp leaves a cast's proof argument unfolded, so isFunctorial_pullback's reindex_comp needs a change restating the cast at reindex_cast_shape's motive before the rewrite can match.