### PR TITLE
Refresh vendored geb-mathlib

### DIFF
--- a/geb-lean/docs/geb-mathlib-backport-notes.md
+++ b/geb-lean/docs/geb-mathlib-backport-notes.md
@@ -20,6 +20,8 @@
 - [Updating the patch for a new upstream](#updating-the-patch-for-a-new-upstream)
   - [The no-op condition](#the-no-op-condition)
 - [Module exclusion](#module-exclusion)
+  - [Mechanism](#mechanism)
+  - [Current exclusions](#current-exclusions)
 - [Tooling notes](#tooling-notes)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
@@ -333,8 +335,9 @@ genuinely new (decide the adaptation, add a category here).
 
 ## Updating the patch for a new upstream
 
-The vendored tree is a pure function of two committed inputs: the
-upstream `geb-mathlib` commit and this patch.
+The vendored tree is a pure function of three committed inputs: the
+upstream `geb-mathlib` commit, this patch, and the exclusion list in
+`scripts/refresh-geb-mathlib.sh` (see [Module exclusion](#module-exclusion)).
 `scripts/refresh-geb-mathlib.sh` recomputes it by re-cloning upstream
 and re-applying the patch with `git apply`. A patch hunk's context
 lines are tied to the upstream revision it was generated against; when
@@ -389,13 +392,47 @@ does not exist in `v4.29.0-rc6` (a genuinely new result, not a rename),
 no patch hunk can supply it and `sorry`/`admit` are banned. Such a module
 is dropped from the vendored copy via the refresh script's exclusion list
 until either `geb-lean` is forward-migrated to `v4.33.0-rc1` or the
-consuming exploration is deferred. No module has yet met that condition,
-so the script carries no exclusion list.
+consuming exploration is deferred. The same applies to a dependency on
+`Cslib`, pinned alongside mathlib at `v4.29.0-rc6`.
 
 A reference to an unknown module does not necessarily require a module to be
 excluded: a  declaration that moved between modules or namespaces is a rename,
 and category 9 is the worked case. Before excluding a module, locate each
 name it needs in the v4.29 tree and compare signatures.
+
+### Mechanism
+
+`EXCLUDED_MODULES` in `scripts/refresh-geb-mathlib.sh` names modules in
+Lean dotted form. For each entry the script removes the module's own
+file and its submodule directory, then deletes every `import` of the
+entry or of one of its submodules from the surviving files, so that no
+bad import remains. The removal runs after `git apply`, so each patch
+hunk still anchors against the pristine upstream text it was generated
+from. `PROVENANCE.md` records the list, the vendored tree being a
+function of it as well as of the upstream commit and the patch.
+
+An entry names the narrowest module carrying the unavailable
+dependency rather than an ancestor namespace: a sibling added upstream
+under an excluded ancestor would be dropped without a signal, whereas
+under a retained ancestor it is ingested and any incompatibility of its
+own surfaces in the refresh workflow's build.
+
+### Current exclusions
+
+- `Geb.Internal.Computability.TreeScanner` (and its `Machine`, `Steps`,
+  and `Bound` submodules) imports
+  `Cslib.Computability.Machines.Turing.MultiTape.Deterministic` and
+  `Cslib.Computability.Machines.Turing.MultiTape.TapeLemmas`, and uses
+  the `Turing.MultiTapeTM` namespace those modules introduce. Neither
+  module exists at the pinned cslib revision `9a159ac`
+  (`v4.29.0-rc6`), whose only Turing-machine material is
+  `Cslib.Computability.Machines.SingleTapeTuring.Basic`.
+  `git log --follow --name-status` over cslib records both as additions —
+  `MultiTape/Deterministic.lean` in cslib PR #384 and
+  `MultiTape/TapeLemmas.lean` in cslib PR #768 — not as renames of
+  anything present at the pin, and the pinned tree contains no
+  occurrence of `MultiTape`. Lifting the exclusion requires advancing
+  the cslib pin, which the mathlib and toolchain pins govern.
 
 ## Tooling notes
 

--- a/geb-lean/scripts/refresh-geb-mathlib.sh
+++ b/geb-lean/scripts/refresh-geb-mathlib.sh
@@ -5,6 +5,19 @@ set -euo pipefail
 
 REPO_URL="https://github.com/rokopt/geb-mathlib.git"
 SRC_REV="${1:-main}"
+
+# Modules dropped from the vendored copy, each with its submodules and
+# every import of it. A module qualifies when it depends on a definition
+# absent from the pinned toolchain's dependencies and no patch hunk can
+# supply it. See docs/geb-mathlib-backport-notes.md § Module exclusion.
+#
+# Name the narrowest module that carries the dependency, so that a
+# sibling added upstream later is ingested rather than silently dropped.
+#
+# Geb.Internal.Computability.TreeScanner: imports
+# Cslib.Computability.Machines.Turing.MultiTape.{Deterministic,TapeLemmas},
+# added to cslib after the pinned v4.29.0-rc6 revision.
+EXCLUDED_MODULES=(Geb.Internal.Computability.TreeScanner)
 ROOT="$(cd "$(dirname "$0")/.." && pwd)"   # geb-lean package root
 VENDOR="$ROOT/vendor/geb-mathlib"
 PATCH="$ROOT/scripts/geb-mathlib-backport.patch"
@@ -21,6 +34,7 @@ git -C "$TMP/gm" checkout --quiet "$SRC_REV"
 # itself when the patch and PROVENANCE.md change in the same commit.
 SRC_SHA="$(git -C "$TMP/gm" rev-parse HEAD)"
 PATCH_SHA256="$(sha256sum "$PATCH" | cut -d' ' -f1)"
+EXCLUDED_RENDERED="${EXCLUDED_MODULES[*]:-(none)}"
 
 # Complete overwrite of the Geb namespace (no orphaned files).
 rm -f "$VENDOR/Geb.lean"; rm -rf "$VENDOR/Geb"
@@ -34,7 +48,8 @@ cat > "$VENDOR/PROVENANCE.md" <<EOF
 - Source: $REPO_URL
 - Source commit: $SRC_SHA
 - Back-port patch: scripts/geb-mathlib-backport.patch (sha256 $PATCH_SHA256)
-- The files under \`Geb/\` are an unmodified mirror of the source commit except where the back-port patch changes them; modified files carry a change notice in their header comment.
+- Excluded modules: $EXCLUDED_RENDERED. Each is dropped along with its submodules and every import of it; see scripts/refresh-geb-mathlib.sh.
+- The files under \`Geb/\` are an unmodified mirror of the source commit except where the back-port patch changes them and where the exclusion above removes them; modified files carry a change notice in their header comment.
 EOF
 
 # Apply the back-port patch; a rejection is a hard, reportable failure.
@@ -44,6 +59,17 @@ EOF
 GIT_ROOT="$(git -C "$ROOT" rev-parse --show-toplevel)"
 REL="$(realpath --relative-to="$GIT_ROOT" "$ROOT")"
 ( cd "$GIT_ROOT" && git apply -p1 --directory="$REL" "$PATCH" )
+
+# Drop excluded modules after patching, so every hunk still anchors
+# against the pristine upstream text it was generated from.
+for mod in "${EXCLUDED_MODULES[@]}"; do
+  rm -f "$VENDOR/${mod//.//}.lean"
+  rm -rf "$VENDOR/${mod//.//}"
+  # An import of an excluded module or of any of its submodules would
+  # leave the surviving tree with a bad import.
+  find "$VENDOR" -name '*.lean' -exec \
+    sed -i -E "/^(public )?import ${mod}(\.|\$)/d" {} +
+done
 
 # A refresh that changes no vendored content (an upstream revision
 # touching none of the mirrored files) leaves at most PROVENANCE.md

--- a/geb-lean/vendor/geb-mathlib/Geb/Internal.lean
+++ b/geb-lean/vendor/geb-mathlib/Geb/Internal.lean
@@ -6,6 +6,7 @@ Authors: Terence Rokop
 module
 
 public import Geb.Internal.CanonicalSExpr
+public import Geb.Internal.Computability
 public import Geb.Internal.ConcreteSyntax
 public import Geb.Internal.PresheafIRProto
 public import Geb.Internal.ReadableSExpr

--- a/geb-lean/vendor/geb-mathlib/Geb/Internal/Computability.lean
+++ b/geb-lean/vendor/geb-mathlib/Geb/Internal/Computability.lean
@@ -1,0 +1,13 @@
+/-
+Copyright (c) 2026 Terence Rokop. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Terence Rokop
+-/
+module
+
+
+/-!
+# Computability
+
+Index for the computability modules.
+-/

--- a/geb-lean/vendor/geb-mathlib/PROVENANCE.md
+++ b/geb-lean/vendor/geb-mathlib/PROVENANCE.md
@@ -1,6 +1,7 @@
 # Vendored geb-mathlib provenance
 
 - Source: https://github.com/rokopt/geb-mathlib.git
-- Source commit: 871cfad06b5fa588b35994e5e724dad66e70517d
+- Source commit: a3e78987794b27e82f0c6047dd5f8457ecb5ba32
 - Back-port patch: scripts/geb-mathlib-backport.patch (sha256 02e9b21570d91c0c04a917b12ba6d53d89ded5c46e9c827344cbe0fa4616f82d)
-- The files under `Geb/` are an unmodified mirror of the source commit except where the back-port patch changes them; modified files carry a change notice in their header comment.
+- Excluded modules: Geb.Internal.Computability.TreeScanner. Each is dropped along with its submodules and every import of it; see scripts/refresh-geb-mathlib.sh.
+- The files under `Geb/` are an unmodified mirror of the source commit except where the back-port patch changes them and where the exclusion above removes them; modified files carry a change notice in their header comment.


### PR DESCRIPTION
In this case the new code built on cslib infrastructure (Turing machines and computational complexity) not available in our older version, so we simply exclude it from vendoring.