### PR TITLE
IR universes as arrow presheaves

### DIFF
--- a/geb-idris/src/LanguageDef/Test/PolyIndTypesTest.idr
+++ b/geb-idris/src/LanguageDef/Test/PolyIndTypesTest.idr
@@ -398,6 +398,40 @@ mutual
 
 mutual
   public export
+  partial
+  data IRCode' : Type where
+    IRCnat' :
+      IRCode'
+    IRCsigma' :
+      (u : IRCode') -> ((t : IRTerm ** IRfib t = u) -> IRCode') -> IRCode'
+    IRCpi' :
+      (u : IRCode') -> ((t : IRTerm ** IRfib t = u) -> IRCode') -> IRCode'
+
+  public export
+  partial
+  data IRTerm : Type where
+    IRTnat :
+      Nat -> IRTerm
+    IRTsigma :
+      (u : IRCode') -> (v : (t : IRTerm ** IRfib t = u) -> IRCode') ->
+      (t : IRTerm) -> (e : IRfib t = u) ->
+      (t' : IRTerm) -> (IRfib t' = v (t ** e)) ->
+      IRTerm
+    IRTpi :
+      (u : IRCode') -> (v : (t : IRTerm ** IRfib t = u) -> IRCode') ->
+      ((t : IRTerm) -> (e : IRfib t = u) ->
+       (t' : IRTerm ** (IRfib t' = v (t ** e)))) ->
+      IRTerm
+
+  public export
+  partial
+  IRfib : IRTerm -> IRCode'
+  IRfib (IRTnat _) = IRCnat'
+  IRfib (IRTsigma u v _ _ _ _) = IRCsigma' u v
+  IRfib (IRTpi u v _) = IRCpi' u v
+
+mutual
+  public export
   T0StarterT : Type
   T0StarterT = Unit
 

--- a/geb-idris/src/LanguageDef/Test/PolyIndTypesTest.idr
+++ b/geb-idris/src/LanguageDef/Test/PolyIndTypesTest.idr
@@ -430,6 +430,701 @@ mutual
   IRfib (IRTsigma u v _ _ _ _) = IRCsigma' u v
   IRfib (IRTpi u v _) = IRCpi' u v
 
+-------------------------------
+-------------------------------
+---- The fibres of `IRfib` ----
+-------------------------------
+-------------------------------
+
+-- The fibre of `IRfib` over a code:  the terms which `IRfib` assigns
+-- that code.  This is the inductive-inductive formulation's stand-in
+-- for the inductive-recursive formulation's `IRdecode`.
+public export
+partial
+IRFib : IRCode' -> Type
+IRFib u = (t : IRTerm ** IRfib t = u)
+
+
+---------------------------------------
+---------------------------------------
+---- A lawful isomorphism of types ----
+---------------------------------------
+---------------------------------------
+
+-- `IdrisCategories` has the predicate half of this (`ExtInverse`), but
+-- no bundle; the four-field record is what the proofs below want.
+public export
+record TIso (0 a, b : Type) where
+  constructor MkTIso
+  tiTo : a -> b
+  tiFrom : b -> a
+  tiFromTo : (x : a) -> tiFrom (tiTo x) = x
+  tiToFrom : (y : b) -> tiTo (tiFrom y) = y
+
+public export
+tisoTrans : {0 a, b, c : Type} -> TIso a b -> TIso b c -> TIso a c
+tisoTrans i j =
+  MkTIso
+    (tiTo j . tiTo i)
+    (tiFrom i . tiFrom j)
+    (\x => trans (cong (tiFrom i) (tiFromTo j (tiTo i x))) (tiFromTo i x))
+    (\z => trans (cong (tiTo j) (tiToFrom i (tiFrom j z))) (tiToFrom j z))
+
+
+---------------------------
+---------------------------
+---- Equality plumbing ----
+---------------------------
+---------------------------
+
+-- Transporting a fibre element backwards along `p` and repairing the
+-- base element recovers the original dependent pair.
+public export
+dpSymReplaceEq : {0 a : Type} -> {0 b : a -> Type} -> {0 x, x' : a} ->
+  (p : x' = x) -> (y : b x) ->
+  MkDPair {p=b} x' (replace {p=b} (sym p) y) = MkDPair {p=b} x y
+dpSymReplaceEq Refl _ = Refl
+
+-- The same, but where the base equality is available only after
+-- applying `g`, so the transport proof `r` need not be the one we hold:
+-- matching it against `Refl` is the UIP step which identifies them.
+public export
+dpCongEq : {0 a, a' : Type} -> {0 g : a' -> a} -> {0 b : a -> Type} ->
+  {0 w, w' : a'} -> (q : w' = w) -> (r : g w' = g w) -> (z : b (g w)) ->
+  MkDPair {p=(\v => b (g v))} w' (replace {p=b} (sym r) z) =
+    MkDPair {p=(\v => b (g v))} w z
+dpCongEq Refl Refl _ = Refl
+
+public export
+replaceApp : {0 a : Type} -> {0 b : a -> Type} -> {0 x, x' : a} ->
+  (p : x' = x) -> (g : (w : a) -> b w) -> replace {p=b} p (g x') = g x
+replaceApp Refl _ = Refl
+
+public export
+replaceCongApp : {0 a, a' : Type} -> {0 g : a' -> a} ->
+  {0 b : a -> Type} -> {0 w, w' : a'} ->
+  (q : w' = w) -> (r : g w' = g w) -> (h : (v : a') -> b (g v)) ->
+  replace {p=b} r (h w') = h w
+replaceCongApp Refl Refl _ = Refl
+
+
+----------------------------------------------------------
+----------------------------------------------------------
+---- Dependent sums and products along an isomorphism ----
+----------------------------------------------------------
+----------------------------------------------------------
+
+public export
+sigmaCongFrom : {0 a, a' : Type} -> (i : TIso a a') -> (0 b : a -> Type) ->
+  TIso (Sigma {a} b) (Sigma {a=a'} (\w => b (tiFrom i w)))
+sigmaCongFrom i b =
+  MkTIso
+    (\x =>
+      MkDPair {p=(\w => b (tiFrom i w))} (tiTo i (fst x))
+        (replace {p=b} (sym (tiFromTo i (fst x))) (snd x)))
+    (\z => MkDPair {p=b} (tiFrom i (fst z)) (snd z))
+    (\x =>
+      trans
+        (dpSymReplaceEq {b} (tiFromTo i (fst x)) (snd x))
+        (sym $ dpEqPat {p=b} {dp=x}))
+    (\z =>
+      trans
+        (dpCongEq {g=(tiFrom i)} {b}
+          (tiToFrom i (fst z)) (tiFromTo i (tiFrom i (fst z))) (snd z))
+        (sym $ dpEqPat {p=(\w => b (tiFrom i w))} {dp=z}))
+
+public export
+piCongFrom : FunExt -> {0 a, a' : Type} -> (i : TIso a a') ->
+  (0 b : a -> Type) ->
+  TIso (Pi {a} b) (Pi {a=a'} (\w => b (tiFrom i w)))
+piCongFrom fext i b =
+  MkTIso
+    (\g, w => g (tiFrom i w))
+    (\h, x => replace {p=b} (tiFromTo i x) (h (tiTo i x)))
+    (\g => funExt $ \x => replaceApp {b} (tiFromTo i x) g)
+    (\h =>
+      funExt $ \w =>
+        replaceCongApp {g=(tiFrom i)} {b}
+          (tiToFrom i w) (tiFromTo i (tiFrom i w)) h)
+
+
+----------------------------------------------
+----------------------------------------------
+---- The fibre over a natural-number code ----
+----------------------------------------------
+----------------------------------------------
+
+public export
+partial
+natFibTo : Nat -> IRFib IRCnat'
+natFibTo n = (IRTnat n ** Refl)
+
+public export
+partial
+natFibFrom : IRFib IRCnat' -> Nat
+natFibFrom (IRTnat n ** _) = n
+
+public export
+partial
+natFibToFrom : (z : IRFib IRCnat') -> natFibTo (natFibFrom z) = z
+natFibToFrom (IRTnat _ ** Refl) = Refl
+
+public export
+partial
+natFibIso : TIso Nat (IRFib IRCnat')
+natFibIso = MkTIso natFibTo natFibFrom (\_ => Refl) natFibToFrom
+
+
+---------------------------------------------
+---------------------------------------------
+---- The fibre over a dependent-sum code ----
+---------------------------------------------
+---------------------------------------------
+
+public export
+partial
+sigmaPair : (u : IRCode') -> (v : IRFib u -> IRCode') ->
+  (x : IRFib u) -> IRFib (v x) -> IRFib (IRCsigma' u v)
+sigmaPair u v (t ** e) (t' ** e') = (IRTsigma u v t e t' e' ** Refl)
+
+-- Matching the equality proof against `Refl` is what inverts the
+-- constructor:  it forces the (higher-order) index `v` as well as `u`.
+public export
+partial
+sigmaFst : (u : IRCode') -> (v : IRFib u -> IRCode') ->
+  IRFib (IRCsigma' u v) -> IRFib u
+sigmaFst u v (IRTsigma u v t e _ _ ** Refl) = (t ** e)
+
+public export
+partial
+sigmaSnd : (u : IRCode') -> (v : IRFib u -> IRCode') ->
+  (z : IRFib (IRCsigma' u v)) -> IRFib (v (sigmaFst u v z))
+sigmaSnd u v (IRTsigma u v _ _ t' e' ** Refl) = (t' ** e')
+
+public export
+partial
+sigmaEta : (u : IRCode') -> (v : IRFib u -> IRCode') ->
+  (z : IRFib (IRCsigma' u v)) ->
+  sigmaPair u v (sigmaFst u v z) (sigmaSnd u v z) = z
+sigmaEta u v (IRTsigma u v _ _ _ _ ** Refl) = Refl
+
+public export
+partial
+sigmaFibTo : (u : IRCode') -> (v : IRFib u -> IRCode') ->
+  (0 b : IRFib u -> Type) ->
+  (j : (w : IRFib u) -> TIso (b w) (IRFib (v w))) ->
+  Sigma {a=(IRFib u)} b -> IRFib (IRCsigma' u v)
+sigmaFibTo u v b j x = sigmaPair u v (fst x) (tiTo (j (fst x)) (snd x))
+
+public export
+partial
+sigmaFibFrom : (u : IRCode') -> (v : IRFib u -> IRCode') ->
+  (0 b : IRFib u -> Type) ->
+  (j : (w : IRFib u) -> TIso (b w) (IRFib (v w))) ->
+  IRFib (IRCsigma' u v) -> Sigma {a=(IRFib u)} b
+sigmaFibFrom u v b j z =
+  MkDPair {p=b} (sigmaFst u v z)
+    (tiFrom (j (sigmaFst u v z)) (sigmaSnd u v z))
+
+public export
+partial
+sigmaFibFromPair : (u : IRCode') -> (v : IRFib u -> IRCode') ->
+  (0 b : IRFib u -> Type) ->
+  (j : (w : IRFib u) -> TIso (b w) (IRFib (v w))) ->
+  (x : IRFib u) -> (y : IRFib (v x)) ->
+  sigmaFibFrom u v b j (sigmaPair u v x y) =
+    MkDPair {p=b} x (tiFrom (j x) y)
+sigmaFibFromPair u v b j (_ ** _) (_ ** _) = Refl
+
+public export
+partial
+sigmaFibFromTo : (u : IRCode') -> (v : IRFib u -> IRCode') ->
+  (0 b : IRFib u -> Type) ->
+  (j : (w : IRFib u) -> TIso (b w) (IRFib (v w))) ->
+  (x : Sigma {a=(IRFib u)} b) ->
+  sigmaFibFrom u v b j (sigmaFibTo u v b j x) = x
+sigmaFibFromTo u v b j x =
+  trans
+    (sigmaFibFromPair u v b j (fst x) (tiTo (j (fst x)) (snd x)))
+    (trans
+      (cong (MkDPair {p=b} (fst x)) (tiFromTo (j (fst x)) (snd x)))
+      (sym $ dpEqPat {p=b} {dp=x}))
+
+public export
+partial
+sigmaFibToFrom : (u : IRCode') -> (v : IRFib u -> IRCode') ->
+  (0 b : IRFib u -> Type) ->
+  (j : (w : IRFib u) -> TIso (b w) (IRFib (v w))) ->
+  (z : IRFib (IRCsigma' u v)) ->
+  sigmaFibTo u v b j (sigmaFibFrom u v b j z) = z
+sigmaFibToFrom u v b j z =
+  trans
+    (cong (sigmaPair u v (sigmaFst u v z))
+      (tiToFrom (j (sigmaFst u v z)) (sigmaSnd u v z)))
+    (sigmaEta u v z)
+
+public export
+partial
+sigmaFibIso : (u : IRCode') -> (v : IRFib u -> IRCode') ->
+  (0 b : IRFib u -> Type) ->
+  (j : (w : IRFib u) -> TIso (b w) (IRFib (v w))) ->
+  TIso (Sigma {a=(IRFib u)} b) (IRFib (IRCsigma' u v))
+sigmaFibIso u v b j =
+  MkTIso (sigmaFibTo u v b j) (sigmaFibFrom u v b j)
+    (sigmaFibFromTo u v b j) (sigmaFibToFrom u v b j)
+
+
+-------------------------------------------------
+-------------------------------------------------
+---- The fibre over a dependent-product code ----
+-------------------------------------------------
+-------------------------------------------------
+
+public export
+partial
+piLam : (u : IRCode') -> (v : IRFib u -> IRCode') ->
+  ((x : IRFib u) -> IRFib (v x)) -> IRFib (IRCpi' u v)
+piLam u v g = (IRTpi u v (\t, e => g (t ** e)) ** Refl)
+
+public export
+partial
+piApp : (u : IRCode') -> (v : IRFib u -> IRCode') ->
+  IRFib (IRCpi' u v) -> (x : IRFib u) -> IRFib (v x)
+piApp u v (IRTpi u v g ** Refl) (t ** e) = g t e
+
+public export
+partial
+piBeta : (u : IRCode') -> (v : IRFib u -> IRCode') ->
+  (g : (x : IRFib u) -> IRFib (v x)) -> (x : IRFib u) ->
+  piApp u v (piLam u v g) x = g x
+piBeta u v g (_ ** _) = Refl
+
+public export
+partial
+piEta : (u : IRCode') -> (v : IRFib u -> IRCode') ->
+  (h : IRFib (IRCpi' u v)) -> piLam u v (piApp u v h) = h
+piEta u v (IRTpi u v _ ** Refl) = Refl
+
+public export
+partial
+piFibTo : (u : IRCode') -> (v : IRFib u -> IRCode') ->
+  (0 b : IRFib u -> Type) ->
+  (j : (w : IRFib u) -> TIso (b w) (IRFib (v w))) ->
+  Pi {a=(IRFib u)} b -> IRFib (IRCpi' u v)
+piFibTo u v b j g = piLam u v (\w => tiTo (j w) (g w))
+
+public export
+partial
+piFibFrom : (u : IRCode') -> (v : IRFib u -> IRCode') ->
+  (0 b : IRFib u -> Type) ->
+  (j : (w : IRFib u) -> TIso (b w) (IRFib (v w))) ->
+  IRFib (IRCpi' u v) -> Pi {a=(IRFib u)} b
+piFibFrom u v b j h w = tiFrom (j w) (piApp u v h w)
+
+public export
+partial
+piFibFromTo : FunExt -> (u : IRCode') -> (v : IRFib u -> IRCode') ->
+  (0 b : IRFib u -> Type) ->
+  (j : (w : IRFib u) -> TIso (b w) (IRFib (v w))) ->
+  (g : Pi {a=(IRFib u)} b) ->
+  piFibFrom u v b j (piFibTo u v b j g) = g
+piFibFromTo fext u v b j g =
+  funExt $ \w =>
+    trans
+      (cong (tiFrom (j w)) (piBeta u v (\w' => tiTo (j w') (g w')) w))
+      (tiFromTo (j w) (g w))
+
+public export
+partial
+piFibToFrom : FunExt -> (u : IRCode') -> (v : IRFib u -> IRCode') ->
+  (0 b : IRFib u -> Type) ->
+  (j : (w : IRFib u) -> TIso (b w) (IRFib (v w))) ->
+  (h : IRFib (IRCpi' u v)) ->
+  piFibTo u v b j (piFibFrom u v b j h) = h
+piFibToFrom fext u v b j h =
+  trans
+    (cong (piLam u v)
+      (funExt {f=(\w => tiTo (j w) (tiFrom (j w) (piApp u v h w)))}
+              {g=(piApp u v h)}
+        (\w => tiToFrom (j w) (piApp u v h w))))
+    (piEta u v h)
+
+public export
+partial
+piFibIso : FunExt -> (u : IRCode') -> (v : IRFib u -> IRCode') ->
+  (0 b : IRFib u -> Type) ->
+  (j : (w : IRFib u) -> TIso (b w) (IRFib (v w))) ->
+  TIso (Pi {a=(IRFib u)} b) (IRFib (IRCpi' u v))
+piFibIso fext u v b j =
+  MkTIso (piFibTo u v b j) (piFibFrom u v b j)
+    (piFibFromTo fext u v b j) (piFibToFrom fext u v b j)
+
+
+-------------------------------------------------------
+-------------------------------------------------------
+---- The translation, and the decoding isomorphism ----
+-------------------------------------------------------
+-------------------------------------------------------
+
+-- `IRtoC` translates an inductive-recursive code to an
+-- inductive-inductive one, and `IRdecIso` simultaneously exhibits the
+-- decoding of a code as the fibre of `IRfib` over its translation.
+-- The two must be defined together:  translating `IRCsigma u f`
+-- requires reindexing `f` along the inverse of the isomorphism at `u`.
+mutual
+  public export
+  partial
+  IRtoC : FunExt -> IRCode -> IRCode'
+  IRtoC fext IRCnat = IRCnat'
+  IRtoC fext (IRCsigma u f) =
+    IRCsigma' (IRtoC fext u)
+      (\w => IRtoC fext (f (tiFrom (IRdecIso fext u) w)))
+  IRtoC fext (IRCpi u f) =
+    IRCpi' (IRtoC fext u)
+      (\w => IRtoC fext (f (tiFrom (IRdecIso fext u) w)))
+
+  public export
+  partial
+  IRdecIso : (fext : FunExt) -> (u : IRCode) ->
+    TIso (IRdecode u) (IRFib (IRtoC fext u))
+  IRdecIso fext IRCnat = natFibIso
+  IRdecIso fext (IRCsigma u f) =
+    tisoTrans
+      (sigmaCongFrom (IRdecIso fext u) (\x => IRdecode (f x)))
+      (sigmaFibIso
+        (IRtoC fext u)
+        (\w => IRtoC fext (f (tiFrom (IRdecIso fext u) w)))
+        (\w => IRdecode (f (tiFrom (IRdecIso fext u) w)))
+        (\w => IRdecIso fext (f (tiFrom (IRdecIso fext u) w))))
+  IRdecIso fext (IRCpi u f) =
+    tisoTrans
+      (piCongFrom fext (IRdecIso fext u) (\x => IRdecode (f x)))
+      (piFibIso fext
+        (IRtoC fext u)
+        (\w => IRtoC fext (f (tiFrom (IRdecIso fext u) w)))
+        (\w => IRdecode (f (tiFrom (IRdecIso fext u) w)))
+        (\w => IRdecIso fext (f (tiFrom (IRdecIso fext u) w))))
+
+
+---------------------------------------------------------------
+---------------------------------------------------------------
+---- Disjointness and injectivity of the code constructors ----
+---------------------------------------------------------------
+---------------------------------------------------------------
+
+public export
+partial
+isNatC : IRCode' -> Bool
+isNatC IRCnat' = True
+isNatC (IRCsigma' _ _) = False
+isNatC (IRCpi' _ _) = False
+
+public export
+partial
+isSigmaC : IRCode' -> Bool
+isSigmaC IRCnat' = False
+isSigmaC (IRCsigma' _ _) = True
+isSigmaC (IRCpi' _ _) = False
+
+public export
+partial
+sigmaCodeInjFst : (a1 : IRCode') -> (v1 : IRFib a1 -> IRCode') ->
+  (a2 : IRCode') -> (v2 : IRFib a2 -> IRCode') ->
+  IRCsigma' a1 v1 = IRCsigma' a2 v2 -> a1 = a2
+sigmaCodeInjFst _ _ _ _ Refl = Refl
+
+public export
+partial
+sigmaCodeInjSnd : (a1 : IRCode') -> (v1 : IRFib a1 -> IRCode') ->
+  (a2 : IRCode') -> (v2 : IRFib a2 -> IRCode') ->
+  (p : IRCsigma' a1 v1 = IRCsigma' a2 v2) -> (w : IRFib a1) ->
+  v1 w = v2 (replace {p=IRFib} (sigmaCodeInjFst a1 v1 a2 v2 p) w)
+sigmaCodeInjSnd _ _ _ _ Refl _ = Refl
+
+public export
+partial
+piCodeInjFst : (a1 : IRCode') -> (v1 : IRFib a1 -> IRCode') ->
+  (a2 : IRCode') -> (v2 : IRFib a2 -> IRCode') ->
+  IRCpi' a1 v1 = IRCpi' a2 v2 -> a1 = a2
+piCodeInjFst _ _ _ _ Refl = Refl
+
+public export
+partial
+piCodeInjSnd : (a1 : IRCode') -> (v1 : IRFib a1 -> IRCode') ->
+  (a2 : IRCode') -> (v2 : IRFib a2 -> IRCode') ->
+  (p : IRCpi' a1 v1 = IRCpi' a2 v2) -> (w : IRFib a1) ->
+  v1 w = v2 (replace {p=IRFib} (piCodeInjFst a1 v1 a2 v2 p) w)
+piCodeInjSnd _ _ _ _ Refl _ = Refl
+
+
+-----------------------------------------------
+-----------------------------------------------
+---- Congruences for the code constructors ----
+-----------------------------------------------
+-----------------------------------------------
+
+public export
+partial
+sigmaCodeCong : FunExt -> (a1 : IRCode') -> (v1 : IRFib a1 -> IRCode') ->
+  (a2 : IRCode') -> (v2 : IRFib a2 -> IRCode') -> (p : a1 = a2) ->
+  ((w : IRFib a1) -> v1 w = v2 (replace {p=IRFib} p w)) ->
+  IRCsigma' a1 v1 = IRCsigma' a2 v2
+sigmaCodeCong fext a v1 a v2 Refl q = cong (IRCsigma' a) (funExt q)
+
+public export
+partial
+piCodeCong : FunExt -> (a1 : IRCode') -> (v1 : IRFib a1 -> IRCode') ->
+  (a2 : IRCode') -> (v2 : IRFib a2 -> IRCode') -> (p : a1 = a2) ->
+  ((w : IRFib a1) -> v1 w = v2 (replace {p=IRFib} p w)) ->
+  IRCpi' a1 v1 = IRCpi' a2 v2
+piCodeCong fext a v1 a v2 Refl q = cong (IRCpi' a) (funExt q)
+
+public export
+IRCsigmaCong : FunExt -> (u1 : IRCode) -> (f1 : IRdecode u1 -> IRCode) ->
+  (u2 : IRCode) -> (f2 : IRdecode u2 -> IRCode) -> (p : u1 = u2) ->
+  ((x : IRdecode u1) -> f1 x = f2 (replace {p=IRdecode} p x)) ->
+  IRCsigma u1 f1 = IRCsigma u2 f2
+IRCsigmaCong fext u f1 u f2 Refl q = cong (IRCsigma u) (funExt q)
+
+public export
+IRCpiCong : FunExt -> (u1 : IRCode) -> (f1 : IRdecode u1 -> IRCode) ->
+  (u2 : IRCode) -> (f2 : IRdecode u2 -> IRCode) -> (p : u1 = u2) ->
+  ((x : IRdecode u1) -> f1 x = f2 (replace {p=IRdecode} p x)) ->
+  IRCpi u1 f1 = IRCpi u2 f2
+IRCpiCong fext u f1 u f2 Refl q = cong (IRCpi u) (funExt q)
+
+
+------------------------------
+------------------------------
+---- A section of `IRtoC` ----
+------------------------------
+------------------------------
+
+-- `IRcodeInv` picks, for each inductive-inductive code, an
+-- inductive-recursive code translating to it; `IRcodeInvEq` is the
+-- proof.  Together they say that `IRtoC` is (split) surjective.
+mutual
+  public export
+  partial
+  IRcodeInv : FunExt -> IRCode' -> IRCode
+  IRcodeInv fext IRCnat' = IRCnat
+  IRcodeInv fext (IRCsigma' a v) =
+    IRCsigma (IRcodeInv fext a)
+      (\x => IRcodeInv fext
+        (v (replace {p=IRFib} (IRcodeInvEq fext a)
+             (tiTo (IRdecIso fext (IRcodeInv fext a)) x))))
+  IRcodeInv fext (IRCpi' a v) =
+    IRCpi (IRcodeInv fext a)
+      (\x => IRcodeInv fext
+        (v (replace {p=IRFib} (IRcodeInvEq fext a)
+             (tiTo (IRdecIso fext (IRcodeInv fext a)) x))))
+
+  public export
+  partial
+  IRcodeInvEq : (fext : FunExt) -> (a : IRCode') ->
+    IRtoC fext (IRcodeInv fext a) = a
+  IRcodeInvEq fext IRCnat' = Refl
+  IRcodeInvEq fext (IRCsigma' a v) =
+    sigmaCodeCong fext
+      (IRtoC fext (IRcodeInv fext a))
+      (\w => IRtoC fext
+        (IRcodeInv fext
+          (v (replace {p=IRFib} (IRcodeInvEq fext a)
+               (tiTo (IRdecIso fext (IRcodeInv fext a))
+                 (tiFrom (IRdecIso fext (IRcodeInv fext a)) w))))))
+      a v
+      (IRcodeInvEq fext a)
+      (\w =>
+        trans
+          (IRcodeInvEq fext
+            (v (replace {p=IRFib} (IRcodeInvEq fext a)
+                 (tiTo (IRdecIso fext (IRcodeInv fext a))
+                   (tiFrom (IRdecIso fext (IRcodeInv fext a)) w)))))
+          (cong (\w' => v (replace {p=IRFib} (IRcodeInvEq fext a) w'))
+            (tiToFrom (IRdecIso fext (IRcodeInv fext a)) w)))
+  IRcodeInvEq fext (IRCpi' a v) =
+    piCodeCong fext
+      (IRtoC fext (IRcodeInv fext a))
+      (\w => IRtoC fext
+        (IRcodeInv fext
+          (v (replace {p=IRFib} (IRcodeInvEq fext a)
+               (tiTo (IRdecIso fext (IRcodeInv fext a))
+                 (tiFrom (IRdecIso fext (IRcodeInv fext a)) w))))))
+      a v
+      (IRcodeInvEq fext a)
+      (\w =>
+        trans
+          (IRcodeInvEq fext
+            (v (replace {p=IRFib} (IRcodeInvEq fext a)
+                 (tiTo (IRdecIso fext (IRcodeInv fext a))
+                   (tiFrom (IRdecIso fext (IRcodeInv fext a)) w)))))
+          (cong (\w' => v (replace {p=IRFib} (IRcodeInvEq fext a) w'))
+            (tiToFrom (IRdecIso fext (IRcodeInv fext a)) w)))
+
+
+------------------------------
+------------------------------
+---- `IRtoC` is injective ----
+------------------------------
+------------------------------
+
+-- The decoding isomorphisms are coherent with any equality of codes:
+-- transporting a decoding along `pu` agrees with transporting the
+-- corresponding fibre element along `pc`.  The two proofs need not be
+-- related a priori -- matching both against `Refl` is the UIP step
+-- which identifies them.
+public export
+partial
+IRdecIsoCoh : (fext : FunExt) -> (u1, u2 : IRCode) -> (pu : u1 = u2) ->
+  (pc : IRtoC fext u1 = IRtoC fext u2) -> (x : IRdecode u1) ->
+  tiFrom (IRdecIso fext u2)
+    (replace {p=IRFib} pc (tiTo (IRdecIso fext u1) x)) =
+      replace {p=IRdecode} pu x
+IRdecIsoCoh fext u u Refl Refl x = tiFromTo (IRdecIso fext u) x
+
+mutual
+  public export
+  partial
+  IRtoCinj : (fext : FunExt) -> (u1, u2 : IRCode) ->
+    IRtoC fext u1 = IRtoC fext u2 -> u1 = u2
+  IRtoCinj fext IRCnat IRCnat _ = Refl
+  IRtoCinj fext IRCnat (IRCsigma _ _) eq = absurd (cong isNatC eq)
+  IRtoCinj fext IRCnat (IRCpi _ _) eq = absurd (cong isNatC eq)
+  IRtoCinj fext (IRCsigma _ _) IRCnat eq = absurd (cong isNatC eq)
+  IRtoCinj fext (IRCpi _ _) IRCnat eq = absurd (cong isNatC eq)
+  IRtoCinj fext (IRCsigma _ _) (IRCpi _ _) eq = absurd (cong isSigmaC eq)
+  IRtoCinj fext (IRCpi _ _) (IRCsigma _ _) eq = absurd (cong isSigmaC eq)
+  IRtoCinj fext (IRCsigma u1 f1) (IRCsigma u2 f2) eq =
+    IRCsigmaCong fext u1 f1 u2 f2
+      (IRsigmaInjBase fext u1 f1 u2 f2 eq)
+      (IRsigmaInjStep fext u1 f1 u2 f2 eq)
+  IRtoCinj fext (IRCpi u1 f1) (IRCpi u2 f2) eq =
+    IRCpiCong fext u1 f1 u2 f2
+      (IRpiInjBase fext u1 f1 u2 f2 eq)
+      (IRpiInjStep fext u1 f1 u2 f2 eq)
+
+  public export
+  partial
+  IRsigmaInjBase : (fext : FunExt) ->
+    (u1 : IRCode) -> (f1 : IRdecode u1 -> IRCode) ->
+    (u2 : IRCode) -> (f2 : IRdecode u2 -> IRCode) ->
+    IRtoC fext (IRCsigma u1 f1) = IRtoC fext (IRCsigma u2 f2) -> u1 = u2
+  IRsigmaInjBase fext u1 f1 u2 f2 eq =
+    IRtoCinj fext u1 u2
+      (sigmaCodeInjFst
+        (IRtoC fext u1) (\w => IRtoC fext (f1 (tiFrom (IRdecIso fext u1) w)))
+        (IRtoC fext u2) (\w => IRtoC fext (f2 (tiFrom (IRdecIso fext u2) w)))
+        eq)
+
+  public export
+  partial
+  IRsigmaInjStep : (fext : FunExt) ->
+    (u1 : IRCode) -> (f1 : IRdecode u1 -> IRCode) ->
+    (u2 : IRCode) -> (f2 : IRdecode u2 -> IRCode) ->
+    (eq : IRtoC fext (IRCsigma u1 f1) = IRtoC fext (IRCsigma u2 f2)) ->
+    (d : IRdecode u1) ->
+    f1 d =
+      f2 (replace {p=IRdecode} {x=u1} {y=u2}
+            (IRsigmaInjBase fext u1 f1 u2 f2 eq) d)
+  IRsigmaInjStep fext u1 f1 u2 f2 eq d =
+    IRtoCinj fext (f1 d)
+      (f2 (replace {p=IRdecode} {x=u1} {y=u2}
+            (IRsigmaInjBase fext u1 f1 u2 f2 eq) d)) $
+      trans
+        (sym
+          (cong (\y => IRtoC fext (f1 y)) (tiFromTo (IRdecIso fext u1) d)))
+        (trans
+          (sigmaCodeInjSnd
+            (IRtoC fext u1)
+            (\w => IRtoC fext (f1 (tiFrom (IRdecIso fext u1) w)))
+            (IRtoC fext u2)
+            (\w => IRtoC fext (f2 (tiFrom (IRdecIso fext u2) w)))
+            eq (tiTo (IRdecIso fext u1) d))
+          (cong (\y => IRtoC fext (f2 y))
+            (IRdecIsoCoh fext u1 u2
+              (IRsigmaInjBase fext u1 f1 u2 f2 eq)
+              (sigmaCodeInjFst
+                (IRtoC fext u1)
+                (\w => IRtoC fext (f1 (tiFrom (IRdecIso fext u1) w)))
+                (IRtoC fext u2)
+                (\w => IRtoC fext (f2 (tiFrom (IRdecIso fext u2) w)))
+                eq)
+              d)))
+
+  public export
+  partial
+  IRpiInjBase : (fext : FunExt) ->
+    (u1 : IRCode) -> (f1 : IRdecode u1 -> IRCode) ->
+    (u2 : IRCode) -> (f2 : IRdecode u2 -> IRCode) ->
+    IRtoC fext (IRCpi u1 f1) = IRtoC fext (IRCpi u2 f2) -> u1 = u2
+  IRpiInjBase fext u1 f1 u2 f2 eq =
+    IRtoCinj fext u1 u2
+      (piCodeInjFst
+        (IRtoC fext u1) (\w => IRtoC fext (f1 (tiFrom (IRdecIso fext u1) w)))
+        (IRtoC fext u2) (\w => IRtoC fext (f2 (tiFrom (IRdecIso fext u2) w)))
+        eq)
+
+  public export
+  partial
+  IRpiInjStep : (fext : FunExt) ->
+    (u1 : IRCode) -> (f1 : IRdecode u1 -> IRCode) ->
+    (u2 : IRCode) -> (f2 : IRdecode u2 -> IRCode) ->
+    (eq : IRtoC fext (IRCpi u1 f1) = IRtoC fext (IRCpi u2 f2)) ->
+    (d : IRdecode u1) ->
+    f1 d =
+      f2 (replace {p=IRdecode} {x=u1} {y=u2}
+            (IRpiInjBase fext u1 f1 u2 f2 eq) d)
+  IRpiInjStep fext u1 f1 u2 f2 eq d =
+    IRtoCinj fext (f1 d)
+      (f2 (replace {p=IRdecode} {x=u1} {y=u2}
+            (IRpiInjBase fext u1 f1 u2 f2 eq) d)) $
+      trans
+        (sym
+          (cong (\y => IRtoC fext (f1 y)) (tiFromTo (IRdecIso fext u1) d)))
+        (trans
+          (piCodeInjSnd
+            (IRtoC fext u1)
+            (\w => IRtoC fext (f1 (tiFrom (IRdecIso fext u1) w)))
+            (IRtoC fext u2)
+            (\w => IRtoC fext (f2 (tiFrom (IRdecIso fext u2) w)))
+            eq (tiTo (IRdecIso fext u1) d))
+          (cong (\y => IRtoC fext (f2 y))
+            (IRdecIsoCoh fext u1 u2
+              (IRpiInjBase fext u1 f1 u2 f2 eq)
+              (piCodeInjFst
+                (IRtoC fext u1)
+                (\w => IRtoC fext (f1 (tiFrom (IRdecIso fext u1) w)))
+                (IRtoC fext u2)
+                (\w => IRtoC fext (f2 (tiFrom (IRdecIso fext u2) w)))
+                eq)
+              d)))
+
+
+-------------------------------------------------
+-------------------------------------------------
+---- The equivalence of the two formulations ----
+-------------------------------------------------
+-------------------------------------------------
+
+-- The codes are isomorphic ...
+public export
+partial
+IRcodeIso : (fext : FunExt) -> TIso IRCode IRCode'
+IRcodeIso fext =
+  MkTIso (IRtoC fext) (IRcodeInv fext)
+    (\u =>
+      IRtoCinj fext (IRcodeInv fext (IRtoC fext u)) u
+        (IRcodeInvEq fext (IRtoC fext u)))
+    (IRcodeInvEq fext)
+
+-- ... and over corresponding codes, the inductive-recursive decoding
+-- is the fibre of the inductive-inductive `IRfib`.
+public export
+partial
+IRdecFibIso : (fext : FunExt) -> (u : IRCode) ->
+  TIso (IRdecode u) (IRFib (tiTo (IRcodeIso fext) u))
+IRdecFibIso = IRdecIso
+
 mutual
   public export
   T0StarterT : Type

--- a/geb-idris/src/LanguageDef/Test/PolyIndTypesTest.idr
+++ b/geb-idris/src/LanguageDef/Test/PolyIndTypesTest.idr
@@ -385,6 +385,19 @@ TestPRA = PRAD TestPRAT1 TestPRAdir
 
 mutual
   public export
+  data IRCode : Type where
+    IRCnat : IRCode
+    IRCsigma : (u : IRCode) -> (IRdecode u -> IRCode) -> IRCode
+    IRCpi : (u : IRCode) -> (IRdecode u -> IRCode) -> IRCode
+
+  public export
+  IRdecode : IRCode -> Type
+  IRdecode IRCnat = Nat
+  IRdecode (IRCsigma u f) = Sigma {a=(IRdecode u)} (IRdecode . f)
+  IRdecode (IRCpi u f) = Pi {a=(IRdecode u)} (IRdecode . f)
+
+mutual
+  public export
   T0StarterT : Type
   T0StarterT = Unit
 


### PR DESCRIPTION
Introduce a couple formulations of inductive-recursive universes, represented as initial algebras of PRA endofunctors on presheaves on the walking arrow.