### PR TITLE
chore(vendor): refresh geb-mathlib and extend the back-port patch

### DIFF
--- a/geb-lean/docs/geb-mathlib-backport-notes.md
+++ b/geb-lean/docs/geb-mathlib-backport-notes.md
@@ -8,7 +8,7 @@
   - [1. `GebMeta` not vendored](#1-gebmeta-not-vendored)
   - [2. `linter.checkUnivs` configuration absent in v4.29](#2-lintercheckunivs-configuration-absent-in-v429)
   - [3. `ConcreteCategory` redesign (mathlib pull request 34741)](#3-concretecategory-redesign-mathlib-pull-request-34741)
-  - [4. Eliminator motive left as an unreduced beta-redex](#4-eliminator-motive-left-as-an-unreduced-beta-redex)
+  - [4. Eliminator motive or functional argument left as an unreduced beta-redex](#4-eliminator-motive-or-functional-argument-left-as-an-unreduced-beta-redex)
   - [5. `simp` rewriting under dependent proof arguments narrowed in v4.33](#5-simp-rewriting-under-dependent-proof-arguments-narrowed-in-v433)
   - [6. Explicit universe arguments in generalized field notation](#6-explicit-universe-arguments-in-generalized-field-notation)
   - [7. `rw`'s closing `rfl` runs at reducible transparency](#7-rws-closing-rfl-runs-at-reducible-transparency)
@@ -17,6 +17,9 @@
   - [10. `simp` leaves a `cast`'s proof argument unfolded](#10-simp-leaves-a-casts-proof-argument-unfolded)
   - [11. Conditional-rewrite lemmas renamed in v4.34](#11-conditional-rewrite-lemmas-renamed-in-v434)
   - [12. `Computability.Encoding` alphabet became a parameter](#12-computabilityencoding-alphabet-became-a-parameter)
+  - [13. `unusedArguments` reports a constant function](#13-unusedarguments-reports-a-constant-function)
+  - [14. Declaration reached upstream through a wider import closure](#14-declaration-reached-upstream-through-a-wider-import-closure)
+  - [15. `Arrow.mk_eq_mk_iff` states its endpoints through `𝟭 C`](#15-arrowmk_eq_mk_iff-states-its-endpoints-through-%F0%9D%9F%AD-c)
 - [Updating the patch for a new upstream](#updating-the-patch-for-a-new-upstream)
   - [The no-op condition](#the-no-op-condition)
 - [Module exclusion](#module-exclusion)
@@ -134,18 +137,42 @@ genuinely new (decide the adaptation, add a category here).
   (`arityHomEquivNatTrans`): the backward direction re-states
   naturality with `NatTrans.naturality_apply α f.op b`. Replace it
   with `FunctorToTypes.naturality _ _ α f.op b`.
+- Adaptation in `CategoryTheory/DiscreteFibration/FiberPresheaf.lean`:
+  `fiberPresheaf` wraps its `map` field in `TypeCat.ofHom` and proves
+  the two functor laws by `ConcreteCategory.hom_ext _ _`. Drop the
+  wrapper and replace `ConcreteCategory.hom_ext _ _` with `funext`; the
+  two laws then read `funext fun c => D.restrict_id c` and
+  `funext fun c => D.restrict_comp g'.unop g.unop c`. In the same
+  module, `fiberPresheafEquiv` reads a functor's identity law through
+  `ConcreteCategory.congr_hom (F.map_id _)`; replace that with
+  `congrFun (F.map_id _)` at both occurrences.
+- Adaptation in `CategoryTheory/DiscreteFibration/Packaged.lean`
+  (`fiberPresheafIso`): the naturality component is
+  `ConcreteCategory.hom_ext _ _ fun x => by ...`. Replace
+  `ConcreteCategory.hom_ext _ _` with `funext`.
 
-### 4. Eliminator motive left as an unreduced beta-redex
+### 4. Eliminator motive or functional argument left as an unreduced beta-redex
 
 - Upstream cause: a proof applies a dependent eliminator with an
-  explicit `motive` and enters the minor premise via
+  explicit `motive`, or a uniqueness principle at an explicit
+  functional argument, and enters the minor premise via
   `fun ... => by ...`. The affected sites are `elimData_valid` in
   `Slice/W.lean` and `wValidBool_eq_true_iff` in `Slice/Decidable.lean`
   (both `WType.rec`), `isHereditarilyNaturalBoolCore_eq_true_iff` in
   `Presheaf/Decidable.lean` (`SlicePFunctor.W.induction`),
-  `ofRose_toRose` in `Internal/ConcreteSyntax.lean` (`Ast.ind`), and
-  `length_spell` in `Data/Tree/Ranked/Preorder.lean`
-  (`RankedAlphabet.Term.induction`).
+  `ofRose_toRose` in `Internal/ConcreteSyntax.lean` (`Ast.ind`),
+  `length_spell` in `Data/Tree/Ranked/Preorder.lean`,
+  `length_fold_le_of_growth` in
+  `Internal/Computability/CobhamFoldProto/Variable.lean`, and
+  `dropEntry_algPara` in
+  `Internal/Computability/CobhamFoldProto/Destruct.lean` (all three
+  `RankedAlphabet.Term.induction`),
+  `scanFinal_replicate_false` in
+  `Internal/Computability/CobhamFoldProto/Layout.lean` (`Nat.rec`),
+  and `Term.fold_map` in
+  `Internal/Computability/CobhamFoldProto/Fold.lean`, where the
+  unreduced application is not a motive but the carrier map
+  `fun t ↦ e (Term.fold R alg t)` supplied to `Term.fold_unique`.
 - v4.29 symptom: the goal is `(fun w => ...) (WType.mk a f)` — the motive
   lambda is not beta-reduced at the constructor — so the opening
   `rw` reports "Did not find an occurrence of the pattern" (the rewritten
@@ -297,9 +324,12 @@ genuinely new (decide the adaptation, add a category here).
   `Computability/BellantoniCook/Tree.lean`,
   `Computability/Cobham/RankedTree.lean`,
   `Computability/Cobham/Tree.lean`, `Data/Tree/Ranked/Code.lean`,
-  `Data/Tree/Ranked/Preorder.lean`, and `Data/W/Basic.lean`. Only three
-  of the eleven appear in a build log: lake does not attempt a module
-  whose imports failed.
+  `Data/Tree/Ranked/Preorder.lean`, `Data/W/Basic.lean`, and, under
+  `Internal/Computability/CobhamFoldProto/`, `Degenerate.lean`,
+  `Destruct.lean`, `Fold.lean`, `Layout.lean`, `SelfDelim.lean`,
+  `SmashFree.lean`, and `Variable.lean`. Only a few of them appear in
+  any one build log: lake does not attempt a module whose imports
+  failed.
 - Adaptation: substitute the v4.29 names throughout the vendored tree.
   The adaptation is mechanical, so re-applying it to a fresh upstream
   source is a re-run rather than a hunk-by-hunk re-anchoring:
@@ -332,6 +362,56 @@ genuinely new (decide the adaptation, add a category here).
   structure has a fourth field, so reword to "as a
   `Computability.Encoding` over the alphabet `Bool`, whose remaining
   three fields they are".
+
+### 13. `unusedArguments` reports a constant function
+
+- Upstream cause:
+  `Internal/Computability/CobhamFoldProto/Degenerate.lean` defines the
+  terminal carrier's encoding, decoding, and algebra — `encUnit`,
+  `decUnit`, and `algUnit` — as constant functions, each ignoring an
+  argument its type obliges it to take.
+- v4.29 symptom: under `lake lint -- Geb`, the `unusedArguments`
+  env-linter reports `Geb.CobhamFold.encUnit argument 1`,
+  `Geb.CobhamFold.decUnit argument 1`, and
+  `Geb.CobhamFold.algUnit argument 3`. The declarations are unchanged
+  from upstream; the report is v4.29's linter.
+- Adaptation: insert `@[nolint unusedArguments]` between each
+  declaration's docstring and its `def` keyword, as category 2 does for
+  `checkUnivs`.
+
+### 14. Declaration reached upstream through a wider import closure
+
+- Upstream cause:
+  `CategoryTheory/DiscreteFibration/Basic.lean` uses
+  `Sigma.mk.inj_iff` without importing `Mathlib.Data.Sigma.Basic`,
+  reaching it through the transitive closure of its
+  `Mathlib.CategoryTheory` imports.
+- v4.29 symptom: `` Unknown constant `Sigma.mk.inj_iff` ``, followed by
+  `` Tactic `rcases` failed: `x✝ : ?m…` is not an inductive datatype ``
+  wherever the failed term stands as an `obtain` scrutinee. The
+  declaration itself is present in v4.29 under the same name, in
+  `Mathlib/Data/Sigma/Basic.lean`; only the import closure differs.
+- Adaptation: add `public import Mathlib.Data.Sigma.Basic` to the
+  module's import block, in alphabetical position.
+
+### 15. `Arrow.mk_eq_mk_iff` states its endpoints through `𝟭 C`
+
+- Upstream cause:
+  `CategoryTheory/DiscreteFibration/Packaged.lean`'s
+  `IsDiscreteFibration.toDiscreteFibration` obtains a hypothesis
+  `hf : p.map q.hom = eqToHom hX ≫ g ≫ eqToHom hY.symm`, where
+  `q := H.equiv.symm ⟨(Arrow.mk g, c), rfl⟩`,
+  from `Arrow.mk_eq_mk_iff` and discharges the `map_hom` field with
+  `simp only [Functor.map_comp, eqToHom_map, hf]` followed by `simp`.
+- v4.29 symptom: `This simp argument is unused: hf`, then
+  `unsolved goals`; `rw [hf]` reports that its pattern, which prints
+  identically to a subterm of the goal, does not occur there. An
+  `Arrow C` is a `Comma (𝟭 C) (𝟭 C)`, so `hf`'s endpoints are
+  `p.obj ((𝟭 C).obj …)` — visible in the types of `hX` and `hY` — while
+  the goal's are `p.obj …`; the two `p.map` applications differ in their
+  implicit endpoint arguments.
+- Adaptation: normalise the hypothesis and the goal first, prepending
+  `simp only [Functor.id_obj] at hf ⊢` to the existing `simp only`.
 
 ## Updating the patch for a new upstream
 

--- a/geb-lean/scripts/geb-mathlib-backport.patch
+++ b/geb-lean/scripts/geb-mathlib-backport.patch
@@ -19,6 +19,632 @@ index 60ce9f4..6bf7832 100644
  
  /-- The retraction law for the rose spelling: printing a rose tree and
  parsing the result returns that tree. -/
+diff --git a/vendor/geb-mathlib/Geb/Internal/Computability/CobhamFoldProto/Degenerate.lean b/vendor/geb-mathlib/Geb/Internal/Computability/CobhamFoldProto/Degenerate.lean
+index edf6251..80a0fe7 100644
+--- a/vendor/geb-mathlib/Geb/Internal/Computability/CobhamFoldProto/Degenerate.lean
++++ b/vendor/geb-mathlib/Geb/Internal/Computability/CobhamFoldProto/Degenerate.lean
+@@ -3,6 +3,7 @@ Copyright (c) 2026 Terence Rokop. All rights reserved.
+ Released under Apache 2.0 license as described in the file LICENSE.
+ Authors: Terence Rokop
+ -/
++-- Modified from geb-mathlib by scripts/geb-mathlib-backport.patch.
+ module
+ 
+ public import Geb.Internal.Computability.CobhamFoldProto.Expr
+@@ -81,16 +82,16 @@ namespace Geb.CobhamFold
+ open Cobham RankedAlphabet
+ 
+ /-- The empty encoding of the terminal carrier. -/
+-def encUnit : Unit → Fin 0 → Bool := fun _ ↦ Fin.elim0
++@[nolint unusedArguments] def encUnit : Unit → Fin 0 → Bool := fun _ ↦ Fin.elim0
+ 
+ /-- The inverse of the empty encoding. -/
+-def decUnit : (Fin 0 → Bool) → Unit := fun _ ↦ ()
++@[nolint unusedArguments] def decUnit : (Fin 0 → Bool) → Unit := fun _ ↦ ()
+ 
+ /-- The empty encoding's retraction, which holds by `Unit`'s eta. -/
+ theorem decUnit_encUnit : ∀ a : Unit, decUnit (encUnit a) = a := fun _ ↦ rfl
+ 
+ /-- The terminal algebra of a ranked alphabet. -/
+-def algUnit (R : RankedAlphabet) :
++@[nolint unusedArguments] def algUnit (R : RankedAlphabet) :
+     (i : Fin R.card) → (Fin (R.arity i) → Unit) → Unit := fun _ _ ↦ ()
+ 
+ /-- The multiplier one meets the bound at `p = 0`. -/
+@@ -137,16 +138,16 @@ theorem dropCountF_unit (R : RankedAlphabet) (b : Bool) (s : FoldScan Unit) :
+   · dsimp only
+     rw [arOf_eq_map_symOf]
+     by_cases hlen : (b :: buf).length = R.width
+-    · rw [ite_eq_left hlen, decide_eq_true hlen]
++    · rw [if_pos hlen, decide_eq_true hlen]
+       match hsym : symOf R (decodeBits (b :: buf)) with
+       | none => rfl
+       | some i =>
+         rw [Option.map_some]
+         dsimp only
+         by_cases hle : R.arity i ≤ stack.length
+-        · rw [ite_eq_left hle, decide_eq_true hle, Nat.one_mul]
+-        · rw [ite_eq_right hle, decide_eq_false hle]
+-    · rw [ite_eq_right hlen, decide_eq_false hlen]
++        · rw [if_pos hle, decide_eq_true hle, Nat.one_mul]
++        · rw [if_neg hle, decide_eq_false hle]
++    · rw [if_neg hlen, decide_eq_false hlen]
+ 
+ /-- At `p = 0` the bits a step prepends are the recognizer's: an entry is the
+ single `true` the pending count pushes. -/
+@@ -160,24 +161,24 @@ theorem nextPrefixF_unit (R : RankedAlphabet) (b : Bool) (s : FoldScan Unit) :
+   · dsimp only
+     rw [arOf_eq_map_symOf]
+     by_cases hlen : (b :: buf).length = R.width
+-    · rw [ite_eq_left hlen, decide_eq_true hlen]
++    · rw [if_pos hlen, decide_eq_true hlen]
+       match hsym : symOf R (decodeBits (b :: buf)) with
+       | none => rfl
+       | some i =>
+         rw [Option.map_some]
+         dsimp only
+         by_cases hle : R.arity i ≤ stack.length
+-        · rw [dite_eq_left hle, decide_eq_true hle]
++        · rw [dif_pos hle, decide_eq_true hle]
+           rfl
+-        · rw [dite_eq_right hle, decide_eq_false hle]
+-    · rw [ite_eq_right hlen, decide_eq_false hlen]
++        · rw [dif_neg hle, decide_eq_false hle]
++    · rw [if_neg hlen, decide_eq_false hlen]
+ 
+ /-- The fold at the terminal algebra is present exactly on the valid words:
+ the recognizer is the fold's degenerate instance. -/
+ theorem foldOut_unit (R : RankedAlphabet) (w : List Bool) :
+     foldOut R (algUnit R) w = if R.Valid w then some () else none := by
+   by_cases hv : R.Valid w
+-  · rw [ite_eq_left hv]
++  · rw [if_pos hv]
+     have hcond := (foldOut_cond R (algUnit R) w).trans hv
+     have h1 : (foldScanFinal R (algUnit R) w).stack.length = 1 :=
+       eq_of_beq ((Bool.and_eq_true _ _).mp hcond).2
+@@ -187,8 +188,8 @@ theorem foldOut_unit (R : RankedAlphabet) (w : List Bool) :
+       rw [hst] at h1
+       exact absurd h1 (by simp)
+     | _ :: _ => rfl
+-  · rw [ite_eq_right hv, foldOut, foldOut_cond]
+-    exact ite_eq_right hv
++  · rw [if_neg hv, foldOut, foldOut_cond]
++    exact if_neg hv
+ 
+ /-- The expression at the terminal algebra decides `RankedAlphabet.Valid`, its
+ value pinned on both branches. -/
+@@ -198,9 +199,9 @@ theorem foldOutSem_unit_eq_ite (R : RankedAlphabet) (w : List Bool) :
+       if R.Valid w then [true] else [false] := by
+   rw [foldOutSem_eq, foldOut_unit]
+   by_cases hv : R.Valid w
+-  · rw [ite_eq_left hv, ite_eq_left hv]
++  · rw [if_pos hv, if_pos hv]
+     rfl
+-  · rw [ite_eq_right hv, ite_eq_right hv]
++  · rw [if_neg hv, if_neg hv]
+     rfl
+ 
+ end Geb.CobhamFold
+diff --git a/vendor/geb-mathlib/Geb/Internal/Computability/CobhamFoldProto/Destruct.lean b/vendor/geb-mathlib/Geb/Internal/Computability/CobhamFoldProto/Destruct.lean
+index db23b24..ef4e0db 100644
+--- a/vendor/geb-mathlib/Geb/Internal/Computability/CobhamFoldProto/Destruct.lean
++++ b/vendor/geb-mathlib/Geb/Internal/Computability/CobhamFoldProto/Destruct.lean
+@@ -3,6 +3,7 @@ Copyright (c) 2026 Terence Rokop. All rights reserved.
+ Released under Apache 2.0 license as described in the file LICENSE.
+ Authors: Terence Rokop
+ -/
++-- Modified from geb-mathlib by scripts/geb-mathlib-backport.patch.
+ module
+ 
+ public import Geb.Internal.Computability.CobhamFoldProto.Initial
+@@ -203,6 +204,7 @@ theorem dropEntry_algPara (R : RankedAlphabet) (phi : ParaStep R) (t : R.Term) :
+   Term.induction (motive := fun t ↦
+       dropEntrySem ![Term.fold R (algPara R phi) t] = R.spell t)
+     (fun i ch ih ↦ by
++      beta_reduce
+       rw [Term.fold_mk, algPara, dropEntrySem_entryWord]
+       exact congrArg (algMk R i) (funext ih)) t
+ 
+@@ -471,8 +473,8 @@ theorem takeEntrySem_of_length_le_one : ∀ r : List Bool, r.length ≤ 1 →
+       omega)
+     rw [ht, takeEntrySem_cons]
+     cases b
+-    · rw [ite_eq_right (by simp)]
+-    · rw [ite_eq_left rfl, takeEntrySem_nil, dropEntrySem_nil, firstBitSem_eq]
++    · rw [if_neg (by simp)]
++    · rw [if_pos rfl, takeEntrySem_nil, dropEntrySem_nil, firstBitSem_eq]
+       rfl
+ 
+ /-- Dropping entries never lengthens a word. -/
+diff --git a/vendor/geb-mathlib/Geb/Internal/Computability/CobhamFoldProto/Fold.lean b/vendor/geb-mathlib/Geb/Internal/Computability/CobhamFoldProto/Fold.lean
+index 71512ed..8d3fec1 100644
+--- a/vendor/geb-mathlib/Geb/Internal/Computability/CobhamFoldProto/Fold.lean
++++ b/vendor/geb-mathlib/Geb/Internal/Computability/CobhamFoldProto/Fold.lean
+@@ -3,6 +3,7 @@ Copyright (c) 2026 Terence Rokop. All rights reserved.
+ Released under Apache 2.0 license as described in the file LICENSE.
+ Authors: Terence Rokop
+ -/
++-- Modified from geb-mathlib by scripts/geb-mathlib-backport.patch.
+ module
+ 
+ public import Geb.Mathlib.Data.Tree.Ranked.Preorder
+@@ -133,7 +134,7 @@ theorem arOf_eq_map_symOf (R : RankedAlphabet) (v : ℕ) :
+ /-- A block denotes the symbol it spells. -/
+ theorem symOf_decodeBits_code (R : RankedAlphabet) (i : Fin R.card) :
+     symOf R (decodeBits (R.code i)) = some i := by
+-  rw [decodeBits_code, symOf, dite_eq_left i.isLt]
++  rw [decodeBits_code, symOf, dif_pos i.isLt]
+ 
+ /-- The unique algebra morphism out of the term algebra: the fold of a term at
+ an algebra of the ranked alphabet. `RankedAlphabet.Term` is that alphabet's
+@@ -172,6 +173,7 @@ theorem Term.fold_map (R : RankedAlphabet)
+     ∀ t : R.Term, Term.fold R algV t = e (Term.fold R alg t) :=
+   fun t ↦ (Term.fold_unique R algV (fun t ↦ e (Term.fold R alg t))
+     (fun i ch ↦ by
++      beta_reduce
+       rw [Term.fold_mk]
+       exact (he i fun d ↦ Term.fold R alg (ch d)).symm) t).symm
+ 
+@@ -227,7 +229,7 @@ theorem toScan_foldScanStep (R : RankedAlphabet)
+   · dsimp only
+     rw [arOf_eq_map_symOf]
+     by_cases hlen : (b :: buf).length = R.width
+-    · rw [ite_eq_left hlen, decide_eq_true hlen]
++    · rw [if_pos hlen, decide_eq_true hlen]
+       dsimp only
+       match hsym : symOf R (decodeBits (b :: buf)) with
+       | none => rfl
+@@ -235,11 +237,11 @@ theorem toScan_foldScanStep (R : RankedAlphabet)
+         rw [Option.map_some]
+         dsimp only
+         by_cases hle : R.arity i ≤ stack.length
+-        · rw [dite_eq_left hle, decide_eq_true hle]
++        · rw [dif_pos hle, decide_eq_true hle]
+           exact Scan.ext rfl (by rw [toScan, List.length_cons, List.length_drop]) rfl
+-        · rw [dite_eq_right hle, decide_eq_false hle]
++        · rw [dif_neg hle, decide_eq_false hle]
+           rfl
+-    · rw [ite_eq_right hlen, decide_eq_false hlen]
++    · rw [if_neg hlen, decide_eq_false hlen]
+       rfl
+ 
+ /-- The fold scan of a word from a given state. `foldr` reads the word's last
+@@ -288,7 +290,7 @@ theorem mem_stack_foldScanFinal (R : RankedAlphabet)
+     · exact ih v hv
+     · dsimp only at hv
+       by_cases hlen : (b :: buf).length = R.width
+-      · rw [ite_eq_left hlen] at hv
++      · rw [if_pos hlen] at hv
+         match hsym : symOf R (decodeBits (b :: buf)) with
+         | none =>
+           rw [hsym] at hv
+@@ -297,13 +299,13 @@ theorem mem_stack_foldScanFinal (R : RankedAlphabet)
+           rw [hsym] at hv
+           dsimp only at hv
+           by_cases hst : R.arity i ≤ stack.length
+-          · rw [dite_eq_left hst] at hv
++          · rw [dif_pos hst] at hv
+             rcases List.mem_cons.mp hv with h | h
+             · exact h ▸ hpush i _
+             · exact ih v (List.mem_of_mem_drop h)
+-          · rw [dite_eq_right hst] at hv
++          · rw [dif_neg hst] at hv
+             exact ih v hv
+-      · rw [ite_eq_right hlen] at hv
++      · rw [if_neg hlen] at hv
+         exact ih v hv
+ 
+ /-- The fold scan of a concatenation reads the later part first. -/
+@@ -339,7 +341,7 @@ theorem foldScanFrom_short (R : RankedAlphabet)
+       rw [foldScanFrom_cons, ih (by simp only [List.length_cons] at hv; omega),
+         foldScanStep]
+       dsimp only
+-      rw [ite_eq_right (by
++      rw [if_neg (by
+         simp only [List.length_cons, List.length_append] at hv ⊢
+         omega)]
+       rfl)
+@@ -369,9 +371,9 @@ theorem foldScanFrom_code (R : RankedAlphabet)
+     foldScanFrom_short R alg (List.ofFn vals ++ st) [] v (by simp; omega),
+     foldScanStep]
+   simp only [List.append_nil]
+-  rw [ite_eq_left (by rw [List.length_cons]; omega), ← hcode, symOf_decodeBits_code]
++  rw [if_pos (by rw [List.length_cons]; omega), ← hcode, symOf_decodeBits_code]
+   dsimp only
+-  rw [dite_eq_left hle]
++  rw [dif_pos hle]
+   refine FoldScan.ext rfl ?_ rfl
+   refine congrArg₂ List.cons (congrArg (alg i) (funext fun d ↦ ?_))
+     (List.drop_left' hofFn)
+@@ -451,7 +453,7 @@ theorem foldOut_eq_none_of_not_valid (R : RankedAlphabet)
+     (alg : (i : Fin R.card) → (Fin (R.arity i) → α) → α) (w : List Bool)
+     (h : ¬ R.Valid w) : foldOut R alg w = none := by
+   rw [foldOut, foldOut_cond]
+-  exact ite_eq_right h
++  exact if_neg h
+ 
+ /-- The fold scan computes the decoding followed by the fold: the unique
+ algebra morphism out of the term algebra, read off the spelling. -/
+diff --git a/vendor/geb-mathlib/Geb/Internal/Computability/CobhamFoldProto/Layout.lean b/vendor/geb-mathlib/Geb/Internal/Computability/CobhamFoldProto/Layout.lean
+index 50c0a4b..3a5ad4f 100644
+--- a/vendor/geb-mathlib/Geb/Internal/Computability/CobhamFoldProto/Layout.lean
++++ b/vendor/geb-mathlib/Geb/Internal/Computability/CobhamFoldProto/Layout.lean
+@@ -3,6 +3,7 @@ Copyright (c) 2026 Terence Rokop. All rights reserved.
+ Released under Apache 2.0 license as described in the file LICENSE.
+ Authors: Terence Rokop
+ -/
++-- Modified from geb-mathlib by scripts/geb-mathlib-backport.patch.
+ module
+ 
+ public import Geb.Internal.Computability.CobhamFoldProto.Fold
+@@ -238,6 +239,7 @@ private theorem scanFinal_replicate_false : ∀ k : ℕ,
+   Nat.rec (motive := fun k ↦
+       Binary.binRanked.scanFinal (List.replicate k false) = ⟨[], k, true⟩) rfl
+     fun k ih ↦ by
++      beta_reduce
+       rw [List.replicate_succ, scanFinal_cons, ih,
+         Binary.scanStep_false_of_live_of_buf_nil _ rfl rfl]
+ 
+@@ -411,7 +413,7 @@ theorem dropCountF_take_stack (R : RankedAlphabet) (p : ℕ) (b : Bool)
+   · rfl
+   · dsimp only
+     by_cases hlen : (b :: buf).length = R.width
+-    · rw [ite_eq_left hlen, ite_eq_left hlen]
++    · rw [if_pos hlen, if_pos hlen]
+       match hsym : symOf R (decodeBits (b :: buf)) with
+       | none => rfl
+       | some i =>
+@@ -420,9 +422,9 @@ theorem dropCountF_take_stack (R : RankedAlphabet) (p : ℕ) (b : Bool)
+         have hmin : (stack.take (R.maxArity + 1)).length =
+             min (R.maxArity + 1) stack.length := List.length_take
+         by_cases hst : R.arity i ≤ stack.length
+-        · rw [ite_eq_left hst, ite_eq_left (by rw [hmin]; omega)]
+-        · rw [ite_eq_right hst, ite_eq_right (by rw [hmin]; omega)]
+-    · rw [ite_eq_right hlen, ite_eq_right hlen]
++        · rw [if_pos hst, if_pos (by rw [hmin]; omega)]
++        · rw [if_neg hst, if_neg (by rw [hmin]; omega)]
++    · rw [if_neg hlen, if_neg hlen]
+ 
+ /-- Truncating the stack at the dispatch window leaves the bits prepended
+ unchanged: the entries the algebra reads are the first `R.arity i`, and the
+@@ -439,7 +441,7 @@ theorem nextPrefixF_take_stack (R : RankedAlphabet) (enc : α → Fin p → Bool
+   · rfl
+   · dsimp only
+     by_cases hlen : (b :: buf).length = R.width
+-    · rw [ite_eq_left hlen, ite_eq_left hlen]
++    · rw [if_pos hlen, if_pos hlen]
+       match hsym : symOf R (decodeBits (b :: buf)) with
+       | none => rfl
+       | some i =>
+@@ -448,12 +450,12 @@ theorem nextPrefixF_take_stack (R : RankedAlphabet) (enc : α → Fin p → Bool
+         have hmin : (stack.take (R.maxArity + 1)).length =
+             min (R.maxArity + 1) stack.length := List.length_take
+         by_cases hst : R.arity i ≤ stack.length
+-        · rw [dite_eq_left hst, dite_eq_left (by rw [hmin]; omega)]
++        · rw [dif_pos hst, dif_pos (by rw [hmin]; omega)]
+           refine congrArg₂ List.cons rfl (congrArg₂ List.append rfl
+             (congrArg (entryBits enc) (congrArg (alg i) (funext fun d ↦ ?_))))
+           exact List.getElem_take
+-        · rw [dite_eq_right hst, dite_eq_right (by rw [hmin]; omega)]
+-    · rw [ite_eq_right hlen, ite_eq_right hlen]
++        · rw [dif_neg hst, dif_neg (by rw [hmin]; omega)]
++    · rw [if_neg hlen, if_neg hlen]
+ 
+ /-- A step of the fold scan rewrites a bounded prefix of the state word and
+ drops a bounded number of its bits: the flag and the slot are rebuilt, and the
+@@ -484,7 +486,7 @@ theorem stateWordF_foldScanStep_of_lt (R : RankedAlphabet)
+     rfl
+   · dsimp only
+     by_cases hlen : (b :: buf).length = R.width
+-    · rw [ite_eq_left hlen, ite_eq_left hlen, ite_eq_left hlen]
++    · rw [if_pos hlen, if_pos hlen, if_pos hlen]
+       match hsym : symOf R (decodeBits (b :: buf)) with
+       | none =>
+         dsimp only
+@@ -493,12 +495,12 @@ theorem stateWordF_foldScanStep_of_lt (R : RankedAlphabet)
+       | some i =>
+         dsimp only
+         by_cases hst : R.arity i ≤ stack.length
+-        · rw [dite_eq_left hst, ite_eq_left hst, dite_eq_left hst, hdropr (R.arity i),
++        · rw [dif_pos hst, if_pos hst, dif_pos hst, hdropr (R.arity i),
+             stateWordF, List.cons_append, List.append_assoc]
+           rfl
+-        · rw [dite_eq_right hst, ite_eq_right hst, dite_eq_right hst, hdrop]
++        · rw [dif_neg hst, if_neg hst, dif_neg hst, hdrop]
+           rfl
+-    · rw [ite_eq_right hlen, ite_eq_right hlen, ite_eq_right hlen, hdrop]
++    · rw [if_neg hlen, if_neg hlen, if_neg hlen, hdrop]
+       rfl
+ 
+ end Geb.CobhamFold
+diff --git a/vendor/geb-mathlib/Geb/Internal/Computability/CobhamFoldProto/SelfDelim.lean b/vendor/geb-mathlib/Geb/Internal/Computability/CobhamFoldProto/SelfDelim.lean
+index 1371a47..a6c473d 100644
+--- a/vendor/geb-mathlib/Geb/Internal/Computability/CobhamFoldProto/SelfDelim.lean
++++ b/vendor/geb-mathlib/Geb/Internal/Computability/CobhamFoldProto/SelfDelim.lean
+@@ -3,6 +3,7 @@ Copyright (c) 2026 Terence Rokop. All rights reserved.
+ Released under Apache 2.0 license as described in the file LICENSE.
+ Authors: Terence Rokop
+ -/
++-- Modified from geb-mathlib by scripts/geb-mathlib-backport.patch.
+ module
+ 
+ public import Geb.Internal.Computability.CobhamFoldProto.Bound
+@@ -307,9 +308,9 @@ theorem length_dropUnarySem_le : ∀ w : List Bool,
+   List.rec (Nat.le_refl 0) fun b v ih ↦ by
+     rw [dropUnarySem_cons, List.length_cons]
+     cases b
+-    · rw [ite_eq_right (by simp)]
++    · rw [if_neg (by simp)]
+       omega
+-    · rw [ite_eq_left rfl]
++    · rw [if_pos rfl]
+       omega
+ 
+ /-- The word past a unary length prefix, as an expression of arity one. -/
+@@ -345,9 +346,9 @@ theorem length_dropEntrySem_le : ∀ w : List Bool,
+   List.rec (Nat.le_refl 0) fun b v ih ↦ by
+     rw [dropEntrySem_cons, List.length_cons]
+     cases b
+-    · rw [ite_eq_right (by simp)]
++    · rw [if_neg (by simp)]
+       omega
+-    · rw [ite_eq_left rfl, List.length_tail]
++    · rw [if_pos rfl, List.length_tail]
+       omega
+ 
+ /-- The word past a whole self-delimiting entry, as an expression of arity
+@@ -390,9 +391,9 @@ theorem length_takeEntrySem_le : ∀ w : List Bool,
+   List.rec (Nat.le_refl 0) fun b v ih ↦ by
+     rw [takeEntrySem_cons, List.length_cons]
+     cases b
+-    · rw [ite_eq_right (by simp), List.length_nil]
++    · rw [if_neg (by simp), List.length_nil]
+       omega
+-    · rw [ite_eq_left rfl, List.length_append]
++    · rw [if_pos rfl, List.length_append]
+       have := length_firstBitSem_le (dropEntrySem ![v])
+       have := length_dropEntrySem_le v
+       have hfb : (firstBitSem ![dropEntrySem ![v]]).length ≤ 1 := by
+@@ -412,9 +413,9 @@ theorem two_mul_length_takeEntrySem_add_length_dropEntrySem_le :
+   List.rec (Nat.le_refl 0) fun b v ih ↦ by
+     rw [takeEntrySem_cons, dropEntrySem_cons, List.length_cons]
+     cases b
+-    · rw [ite_eq_right (by simp), ite_eq_right (by simp), List.length_nil]
++    · rw [if_neg (by simp), if_neg (by simp), List.length_nil]
+       omega
+-    · rw [ite_eq_left rfl, ite_eq_left rfl, List.length_append, List.length_tail,
++    · rw [if_pos rfl, if_pos rfl, List.length_append, List.length_tail,
+         firstBitSem_eq]
+       match hd : dropEntrySem ![v] with
+       | [] =>
+@@ -485,9 +486,9 @@ theorem length_takeUnarySem_le : ∀ w : List Bool,
+   List.rec (Nat.le_refl 0) fun b v ih ↦ by
+     rw [takeUnarySem_cons, List.length_cons]
+     cases b
+-    · rw [ite_eq_right (by simp), List.length_nil]
++    · rw [if_neg (by simp), List.length_nil]
+       omega
+-    · rw [ite_eq_left rfl, List.length_cons]
++    · rw [if_pos rfl, List.length_cons]
+       omega
+ 
+ /-- The leading run of `true`, as an expression of arity one. -/
+@@ -503,9 +504,9 @@ def takeUnaryOf : COf 1 :=
+ theorem takeUnarySem_replicate (X : List Bool) : ∀ k : ℕ,
+     takeUnarySem ![List.replicate k true ++ false :: X] = List.replicate k true :=
+   Nat.rec (by rw [List.replicate_zero, List.nil_append, takeUnarySem_cons,
+-      ite_eq_right (by simp)])
++      if_neg (by simp)])
+     fun k ih ↦ by
+-      rw [List.replicate_succ, List.cons_append, takeUnarySem_cons, ite_eq_left rfl,
++      rw [List.replicate_succ, List.cons_append, takeUnarySem_cons, if_pos rfl,
+         ih]
+ 
+ /-- Dropping a fixed number of whole self-delimiting entries. -/
+@@ -552,16 +553,16 @@ follows the sentinel. -/
+ theorem dropUnarySem_replicate (X : List Bool) : ∀ k : ℕ,
+     dropUnarySem ![List.replicate k true ++ false :: X] = X :=
+   Nat.rec rfl fun k ih ↦ by
+-    rw [List.replicate_succ, List.cons_append, dropUnarySem_cons, ite_eq_left rfl, ih]
++    rw [List.replicate_succ, List.cons_append, dropUnarySem_cons, if_pos rfl, ih]
+ 
+ /-- The entry-dropping primitive drops as many payload bits as the unary prefix
+ counts. -/
+ theorem dropEntrySem_replicate (X : List Bool) : ∀ k : ℕ,
+     dropEntrySem ![List.replicate k true ++ false :: X] = X.drop k :=
+   Nat.rec (by rw [List.replicate_zero, List.nil_append, dropEntrySem_cons,
+-      ite_eq_right (by simp), List.drop_zero])
++      if_neg (by simp), List.drop_zero])
+     fun k ih ↦ by
+-      rw [List.replicate_succ, List.cons_append, dropEntrySem_cons, ite_eq_left rfl,
++      rw [List.replicate_succ, List.cons_append, dropEntrySem_cons, if_pos rfl,
+         ih, List.tail_drop]
+ 
+ /-- Splitting a truncation at its last bit. Proved here rather than by
+@@ -580,9 +581,9 @@ counts. -/
+ theorem takeEntrySem_replicate (X : List Bool) : ∀ k : ℕ,
+     takeEntrySem ![List.replicate k true ++ false :: X] = X.take k :=
+   Nat.rec (by rw [List.replicate_zero, List.nil_append, takeEntrySem_cons,
+-      ite_eq_right (by simp), List.take_zero])
++      if_neg (by simp), List.take_zero])
+     fun k ih ↦ by
+-      rw [List.replicate_succ, List.cons_append, takeEntrySem_cons, ite_eq_left rfl,
++      rw [List.replicate_succ, List.cons_append, takeEntrySem_cons, if_pos rfl,
+         ih, dropEntrySem_replicate, firstBitSem_eq_take_one,
+         ← take_succ_append_take_one]
+ 
+diff --git a/vendor/geb-mathlib/Geb/Internal/Computability/CobhamFoldProto/SmashFree.lean b/vendor/geb-mathlib/Geb/Internal/Computability/CobhamFoldProto/SmashFree.lean
+index d793f0d..85fff92 100644
+--- a/vendor/geb-mathlib/Geb/Internal/Computability/CobhamFoldProto/SmashFree.lean
++++ b/vendor/geb-mathlib/Geb/Internal/Computability/CobhamFoldProto/SmashFree.lean
+@@ -3,6 +3,7 @@ Copyright (c) 2026 Terence Rokop. All rights reserved.
+ Released under Apache 2.0 license as described in the file LICENSE.
+ Authors: Terence Rokop
+ -/
++-- Modified from geb-mathlib by scripts/geb-mathlib-backport.patch.
+ module
+ 
+ public import Geb.Internal.Computability.CobhamFoldProto.Expr
+@@ -483,19 +484,19 @@ theorem smashFreeBool_branchV (R : RankedAlphabet)
+   · exact smashFreeBool_idOf
+   · dsimp only
+     by_cases hlen : (b :: buf).length = R.width
+-    · rw [ite_eq_left hlen]
++    · rw [if_pos hlen]
+       match symOf R (decodeBits (b :: buf)) with
+       | none => exact smashFreeBool_prependOf _ _ (smashFreeBool_predIterOf _)
+       | some i =>
+         dsimp only
+         by_cases hst : R.arity i ≤ depth
+-        · rw [ite_eq_left hst]
++        · rw [if_pos hst]
+           exact smashFreeBool_prependOf _ _
+             (smashFreeBool_comp1Of _ _ (smashFreeBool_rebuildOf _ (halg i))
+               (smashFreeBool_predIterOf _))
+-        · rw [ite_eq_right hst]
++        · rw [if_neg hst]
+           exact smashFreeBool_prependOf _ _ (smashFreeBool_predIterOf _)
+-    · rw [ite_eq_right hlen]
++    · rw [if_neg hlen]
+       exact smashFreeBool_prependOf _ _ (smashFreeBool_predIterOf _)
+ 
+ /-- A step of the bitstring fold carries no `smash` when the algebra's
+@@ -514,11 +515,11 @@ theorem smashFreeBool_readOfV (R : RankedAlphabet) :
+     by_cases hacc : ((decodeVAt R (readoutWidthV R) v).live &&
+         (decodeVAt R (readoutWidthV R) v).buf.isEmpty &&
+         (decodeVAt R (readoutWidthV R) v).depth == 1) = true
+-    · rw [ite_eq_left hacc]
++    · rw [if_pos hacc]
+       exact smashFreeBool_prependOf _ _
+         (smashFreeBool_comp1Of _ _ smashFreeBool_takeEntryOf
+           (smashFreeBool_predIterOf _))
+-    · rw [ite_eq_right hacc]
++    · rw [if_neg hacc]
+       exact smashFreeBool_constAtOf 1 _
+ 
+ /-- The fold at a bitstring carrier lies in the subalgebra `Cobham.SmashFree`
+diff --git a/vendor/geb-mathlib/Geb/Internal/Computability/CobhamFoldProto/Variable.lean b/vendor/geb-mathlib/Geb/Internal/Computability/CobhamFoldProto/Variable.lean
+index 785d0d9..69f6e3f 100644
+--- a/vendor/geb-mathlib/Geb/Internal/Computability/CobhamFoldProto/Variable.lean
++++ b/vendor/geb-mathlib/Geb/Internal/Computability/CobhamFoldProto/Variable.lean
+@@ -3,6 +3,7 @@ Copyright (c) 2026 Terence Rokop. All rights reserved.
+ Released under Apache 2.0 license as described in the file LICENSE.
+ Authors: Terence Rokop
+ -/
++-- Modified from geb-mathlib by scripts/geb-mathlib-backport.patch.
+ module
+ 
+ public import Geb.Internal.Computability.CobhamFoldProto.Bound
+@@ -471,16 +472,16 @@ theorem branchV_min (R : RankedAlphabet)
+   · rfl
+   · dsimp only
+     by_cases hlen : (b :: buf).length = R.width
+-    · rw [ite_eq_left hlen, ite_eq_left hlen]
++    · rw [if_pos hlen, if_pos hlen]
+       match hsym : symOf R (decodeBits (b :: buf)) with
+       | none => rfl
+       | some i =>
+         dsimp only
+         have hle : R.arity i ≤ R.maxArity := arity_le_maxArity R i
+         by_cases hst : R.arity i ≤ depth
+-        · rw [ite_eq_left hst, ite_eq_left (by omega)]
+-        · rw [ite_eq_right hst, ite_eq_right (by omega)]
+-    · rw [ite_eq_right hlen, ite_eq_right hlen]
++        · rw [if_pos hst, if_pos (by omega)]
++        · rw [if_neg hst, if_neg (by omega)]
++    · rw [if_neg hlen, if_neg hlen]
+ 
+ /-- The state layout at an explicit state. -/
+ theorem stateWordV_mk (R : RankedAlphabet) (buf : List Bool)
+@@ -523,7 +524,7 @@ theorem stepWord_foldStepV (R : RankedAlphabet)
+   · rw [stepWord_idOf]
+   · dsimp only
+     by_cases hlen : (b :: buf).length = R.width
+-    · rw [ite_eq_left hlen, ite_eq_left hlen]
++    · rw [if_pos hlen, if_pos hlen]
+       match hsym : symOf R (decodeBits (b :: buf)) with
+       | none =>
+         rw [stepWord_prependOf, stepWord_predIterOf, hdrop0, stateWordV_mk]
+@@ -531,7 +532,7 @@ theorem stepWord_foldStepV (R : RankedAlphabet)
+       | some i =>
+         dsimp only
+         by_cases hst : R.arity i ≤ stack.length
+-        · rw [ite_eq_left hst, dite_eq_left hst, stepWord_prependOf,
++        · rw [if_pos hst, dif_pos hst, stepWord_prependOf,
+             stepWord_comp1Of, stepWord_predIterOf, drop_stateWordV R _ h _ hst,
+             stepWord_rebuildOf, takeUnarySem_replicate, dropUnarySem_replicate,
+             stepWord_newStackOf, stepWord_dropEntriesOf_stackWordV,
+@@ -549,10 +550,10 @@ theorem stepWord_foldStepV (R : RankedAlphabet)
+             rfl
+           rw [hrep]
+           simp only [List.cons_append, List.append_assoc]
+-        · rw [ite_eq_right hst, dite_eq_right hst, stepWord_prependOf,
++        · rw [if_neg hst, dif_neg hst, stepWord_prependOf,
+             stepWord_predIterOf, hdrop0, stateWordV_mk]
+           simp only [List.cons_append, List.append_assoc]
+-    · rw [ite_eq_right hlen, ite_eq_right hlen, stepWord_prependOf,
++    · rw [if_neg hlen, if_neg hlen, stepWord_prependOf,
+         stepWord_predIterOf, hdrop0, stateWordV_mk]
+       simp only [List.cons_append, List.append_assoc]
+ 
+@@ -756,7 +757,7 @@ theorem stepWord_readOfV (R : RankedAlphabet) (s : FoldScan (List Bool))
+         beq_eq_false_iff_ne.mpr hn]
+   rw [hmin]
+   by_cases hacc : (s.live && s.buf.isEmpty && (s.stack.length == 1)) = true
+-  · rw [ite_eq_left hacc, ite_eq_left hacc, stepWord_prependOf, stepWord_comp1Of,
++  · rw [if_pos hacc, if_pos hacc, stepWord_prependOf, stepWord_comp1Of,
+       stepWord_predIterOf]
+     obtain ⟨_, hone⟩ := (Bool.and_eq_true _ _).mp hacc
+     have h1 : s.stack.length = 1 := eq_of_beq hone
+@@ -773,7 +774,7 @@ theorem stepWord_readOfV (R : RankedAlphabet) (s : FoldScan (List Bool))
+     rw [drop_stateWordV_succ R s h h1, stepWord_takeEntryOf, ha,
+       stackWordV_cons, stackWordV_nil, takeEntrySem_entryWord]
+     rfl
+-  · rw [ite_eq_right hacc, ite_eq_right hacc, stepWord_constAtOf]
++  · rw [if_neg hacc, if_neg hacc, stepWord_constAtOf]
+     rfl
+ 
+ /-- The readout composed onto the scan, at its declared arity. -/
+@@ -875,6 +876,7 @@ theorem length_fold_le_of_growth (R : RankedAlphabet)
+   Term.induction
+     (motive := fun t ↦ (Term.fold R alg t).length ≤ c * t.size)
+     fun i ch ih ↦ by
++      beta_reduce
+       rw [Term.fold_mk, size_mk, Nat.mul_add, Nat.mul_one]
+       refine Nat.le_trans (hgrow i fun d ↦ Term.fold R alg (ch d)) ?_
+       refine Nat.add_le_add_right ?_ c
+@@ -926,7 +928,7 @@ theorem potential_foldScanStep_le_of_invariant (R : RankedAlphabet)
+     omega
+   · dsimp only
+     by_cases hlen : (b :: buf).length = R.width
+-    · rw [ite_eq_left hlen]
++    · rw [if_pos hlen]
+       have hbw : buf.length + 1 = R.width := by
+         rw [List.length_cons] at hlen
+         omega
+@@ -938,7 +940,7 @@ theorem potential_foldScanStep_le_of_invariant (R : RankedAlphabet)
+       | some i =>
+         dsimp only
+         by_cases hst : R.arity i ≤ stack.length
+-        · rw [dite_eq_left hst]
++        · rw [dif_pos hst]
+           dsimp only
+           have hsum := sum_ofFn_getElem (R.arity i) stack hst
+           -- the popped arguments are members of the stack, so `hs` supplies
+@@ -963,11 +965,11 @@ theorem potential_foldScanStep_le_of_invariant (R : RankedAlphabet)
+             rw [← hbw, Nat.mul_add, Nat.mul_one]
+           simp only [List.length_nil, Nat.mul_zero, Nat.add_zero]
+           omega
+-        · rw [dite_eq_right hst]
++        · rw [dif_neg hst]
+           dsimp only
+           simp only [List.length_nil, Nat.mul_zero]
+           omega
+-    · rw [ite_eq_right hlen]
++    · rw [if_neg hlen]
+       dsimp only
+       have hcb : c * (buf.length + 1) = c * buf.length + c := by
+         rw [Nat.mul_add, Nat.mul_one]
 diff --git a/vendor/geb-mathlib/Geb/Internal/ConcreteSyntax.lean b/vendor/geb-mathlib/Geb/Internal/ConcreteSyntax.lean
 index 131bc16..6c08797 100644
 --- a/vendor/geb-mathlib/Geb/Internal/ConcreteSyntax.lean
@@ -247,6 +873,94 @@ index 5031b8c..229b1f3 100644
              parseChildren_print _ (List.ofFn ch) (g + 1) rest hchild hfuel,
              Option.map_some, Rose.ofList_ofFn]) r
  
+diff --git a/vendor/geb-mathlib/Geb/Mathlib/CategoryTheory/DiscreteFibration/Basic.lean b/vendor/geb-mathlib/Geb/Mathlib/CategoryTheory/DiscreteFibration/Basic.lean
+index 6168814..00c690a 100644
+--- a/vendor/geb-mathlib/Geb/Mathlib/CategoryTheory/DiscreteFibration/Basic.lean
++++ b/vendor/geb-mathlib/Geb/Mathlib/CategoryTheory/DiscreteFibration/Basic.lean
+@@ -3,12 +3,14 @@ Copyright (c) 2026 Terence Rokop. All rights reserved.
+ Released under Apache 2.0 license as described in the file LICENSE.
+ Authors: Terence Rokop
+ -/
++-- Modified from geb-mathlib by scripts/geb-mathlib-backport.patch.
+ module
+ 
+ public import Mathlib.CategoryTheory.Comma.Arrow
+ public import Mathlib.CategoryTheory.FiberedCategory.Fiber
+ public import Mathlib.CategoryTheory.FiberedCategory.Fibered
+ public import Mathlib.CategoryTheory.FiberedCategory.HomLift
++public import Mathlib.Data.Sigma.Basic
+ public import Mathlib.Tactic.Attr.Core
+ 
+ /-!
+diff --git a/vendor/geb-mathlib/Geb/Mathlib/CategoryTheory/DiscreteFibration/FiberPresheaf.lean b/vendor/geb-mathlib/Geb/Mathlib/CategoryTheory/DiscreteFibration/FiberPresheaf.lean
+index 78839a9..25f674a 100644
+--- a/vendor/geb-mathlib/Geb/Mathlib/CategoryTheory/DiscreteFibration/FiberPresheaf.lean
++++ b/vendor/geb-mathlib/Geb/Mathlib/CategoryTheory/DiscreteFibration/FiberPresheaf.lean
+@@ -3,6 +3,7 @@ Copyright (c) 2026 Terence Rokop. All rights reserved.
+ Released under Apache 2.0 license as described in the file LICENSE.
+ Authors: Terence Rokop
+ -/
++-- Modified from geb-mathlib by scripts/geb-mathlib-backport.patch.
+ module
+ 
+ public import Geb.Mathlib.CategoryTheory.DiscreteFibration.Elements
+@@ -98,10 +99,9 @@ theorem restrict_comp {b b' b'' : B} (g : b ⟶ b') (g' : b' ⟶ b'')
+ /-- The fiber presheaf `b ↦ p⁻¹(b)` of a discrete fibration. -/
+ def fiberPresheaf : Bᵒᵖ ⥤ Type u₁ where
+   obj b := p.Fiber b.unop
+-  map g := TypeCat.ofHom fun c => D.restrict g.unop c
+-  map_id _ := ConcreteCategory.hom_ext _ _ fun c => D.restrict_id c
+-  map_comp g g' :=
+-    ConcreteCategory.hom_ext _ _ fun c => D.restrict_comp g'.unop g.unop c
++  map g := fun c => D.restrict g.unop c
++  map_id _ := funext fun c => D.restrict_id c
++  map_comp g g' := funext fun c => D.restrict_comp g'.unop g.unop c
+ 
+ /-- The fiber presheaf's value on objects.  Not a `simp` lemma: it rewrites
+ the object arguments carried by the coercion in `fiberPresheaf_map`'s left-hand
+@@ -252,11 +252,11 @@ def fiberPresheafEquiv (b : B) : (π F).Fiber b ≃ F.obj (op b)
+     subst hb
+     refine Subtype.ext ?_
+     exact (congrArg (mk x.base)
+-      (ConcreteCategory.congr_hom (F.map_id (op x.base)) x.elt)).trans
++      (congrFun (F.map_id (op x.base)) x.elt)).trans
+       (mk_base_elt x)
+   right_inv y :=
+     show F.map (𝟙 (op b)) y = y from
+-      ConcreteCategory.congr_hom (F.map_id _) y
++      congrFun (F.map_id _) y
+ 
+ /-- Naturality of `fiberPresheafEquiv`: restriction in the fiber presheaf of
+ `π F` is restriction in `F`. -/
+diff --git a/vendor/geb-mathlib/Geb/Mathlib/CategoryTheory/DiscreteFibration/Packaged.lean b/vendor/geb-mathlib/Geb/Mathlib/CategoryTheory/DiscreteFibration/Packaged.lean
+index 74f7b97..4eaea77 100644
+--- a/vendor/geb-mathlib/Geb/Mathlib/CategoryTheory/DiscreteFibration/Packaged.lean
++++ b/vendor/geb-mathlib/Geb/Mathlib/CategoryTheory/DiscreteFibration/Packaged.lean
+@@ -3,6 +3,7 @@ Copyright (c) 2026 Terence Rokop. All rights reserved.
+ Released under Apache 2.0 license as described in the file LICENSE.
+ Authors: Terence Rokop
+ -/
++-- Modified from geb-mathlib by scripts/geb-mathlib-backport.patch.
+ module
+ 
+ public import Geb.Mathlib.CategoryTheory.DiscreteFibration.FiberPresheaf
+@@ -99,6 +100,7 @@ noncomputable def IsDiscreteFibration.toDiscreteFibration {p : C ⥤ B}
+       map_hom := fun {b c} g => ?_
+       unique := fun {b c} g {c'} h eh hh => ?_ }
+   · obtain ⟨hX, hY, hf⟩ := (Arrow.mk_eq_mk_iff _ _).1 (hm g)
++    simp only [Functor.id_obj] at hf ⊢
+     simp only [Functor.map_comp, eqToHom_map, hf]
+     simp
+   · refine sigma_eq_of_arrow_eq h _ ?_ (hr g)
+@@ -173,7 +175,7 @@ def fiberPresheafIso :
+     (discreteFibration F).fiberPresheaf ≅ F ⋙ uliftFunctor.{u₂, v₃} :=
+   NatIso.ofComponents
+     (fun b => ((fiberPresheafEquiv F b.unop).trans Equiv.ulift.symm).toIso)
+-    (fun {b b'} g => ConcreteCategory.hom_ext _ _ fun x => by
++    (fun {b b'} g => funext fun x => by
+       have h := fiberPresheafEquiv_restrict F g.unop x
+       rw [Quiver.Hom.op_unop] at h
+       exact congrArg ULift.up h)
 diff --git a/vendor/geb-mathlib/Geb/Mathlib/CategoryTheory/ElementaryTopos.lean b/vendor/geb-mathlib/Geb/Mathlib/CategoryTheory/ElementaryTopos.lean
 index 970932c..df65d6d 100644
 --- a/vendor/geb-mathlib/Geb/Mathlib/CategoryTheory/ElementaryTopos.lean

--- a/geb-lean/vendor/geb-mathlib/Geb/Cslib.lean
+++ b/geb-lean/vendor/geb-mathlib/Geb/Cslib.lean
@@ -9,6 +9,6 @@ module
 # Geb.Cslib — upstream-eligible content for CSLib
 
 Modules under this namespace are intended for eventual upstream
-extraction to CSLib and import only from `Mathlib.*`, `Cslib.*`,
-or `Geb.Cslib.*`.
+extraction to CSLib and import only from `Mathlib.*`, `Batteries.*`,
+`Cslib.*`, `Geb.Cslib.*`, `Geb.Mathlib.*` or `GebLang.*`.
 -/

--- a/geb-lean/vendor/geb-mathlib/Geb/Internal.lean
+++ b/geb-lean/vendor/geb-mathlib/Geb/Internal.lean
@@ -15,6 +15,7 @@ public import Geb.Internal.ReadableSExpr
 # Geb.Internal — downstream-only content
 
 Modules under this namespace are not intended for upstream
-extraction. They may import from `Mathlib.*`, `Cslib.*`,
-`Geb.Mathlib.*`, `Geb.Cslib.*`, or `Geb.Internal.*`.
+extraction. They may import from `Mathlib.*`, `Batteries.*`,
+`Cslib.*`, `Geb.Mathlib.*`, `Geb.Cslib.*`, `GebLang.*` or
+`Geb.Internal.*`.
 -/

--- a/geb-lean/vendor/geb-mathlib/Geb/Internal/Computability.lean
+++ b/geb-lean/vendor/geb-mathlib/Geb/Internal/Computability.lean
@@ -5,6 +5,7 @@ Authors: Terence Rokop
 -/
 module
 
+public import Geb.Internal.Computability.CobhamFoldProto
 
 /-!
 # Computability

--- a/geb-lean/vendor/geb-mathlib/Geb/Internal/Computability/CobhamFoldProto.lean
+++ b/geb-lean/vendor/geb-mathlib/Geb/Internal/Computability/CobhamFoldProto.lean
@@ -1,0 +1,25 @@
+/-
+Copyright (c) 2026 Terence Rokop. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Terence Rokop
+-/
+module
+
+public import Geb.Internal.Computability.CobhamFoldProto.Bound
+public import Geb.Internal.Computability.CobhamFoldProto.Fold
+public import Geb.Internal.Computability.CobhamFoldProto.SelfDelim
+public import Geb.Internal.Computability.CobhamFoldProto.Layout
+public import Geb.Internal.Computability.CobhamFoldProto.Expr
+public import Geb.Internal.Computability.CobhamFoldProto.Variable
+public import Geb.Internal.Computability.CobhamFoldProto.SmashFree
+public import Geb.Internal.Computability.CobhamFoldProto.Degenerate
+public import Geb.Internal.Computability.CobhamFoldProto.Initial
+public import Geb.Internal.Computability.CobhamFoldProto.Destruct
+
+/-!
+# The fold over recognized terms
+
+Index for the prototype generalizing the ranked-tree recognizer of
+`Geb/Mathlib/Computability/Cobham/RankedTree.lean` to a fold at an arbitrary
+algebra of the ranked alphabet.
+-/

--- a/geb-lean/vendor/geb-mathlib/Geb/Internal/Computability/CobhamFoldProto/Bound.lean
+++ b/geb-lean/vendor/geb-mathlib/Geb/Internal/Computability/CobhamFoldProto/Bound.lean
@@ -1,0 +1,477 @@
+/-
+Copyright (c) 2026 Terence Rokop. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Terence Rokop
+-/
+module
+
+public import Geb.Mathlib.Computability.Cobham.Scan
+
+/-!
+# Expression combinators and the scan at a linear growth bound
+
+`Cobham.scan` admits a state exceeding the input by an additive constant:
+its bound child prepends `growth` bits to the recursion variable, so the
+recursion bound reads `|state| ≤ |w| + growth`. A fold whose state carries one
+`(p + 1)`-bit block per pending subterm can exceed that, the block count rising
+once per `R.width` input bits. `R.width < p + 1` is necessary for it to do so,
+not sufficient: an alphabet whose symbols never grow the stack keeps the state
+bounded whatever the carrier. At `R.width ≥ p + 1` the additive bound always
+suffices, and `Geb.CobhamFold.length_stateWordF_not_le_add` exhibits the failure
+at the two-symbol alphabet, whose width is one.
+
+This module supplies the bound child `boundMulRaw`, built over `multRaw`, whose
+value is the `mult`-fold self-concatenation of the recursion variable, and the
+scan combinator
+`scanBRaw` parameterized by its bound child, so that `Cobham.scan`'s additive
+bound and the multiplicative bound `mult * |w| + growth` are two instances of
+one node. It also supplies the general expression combinators — a projection, two
+compositions and a concatenation — and the scan node `scan2Raw` at steps of
+arity two. Both fold constructions over this one reach `scan2Raw`, through
+`scanBRaw`, and the fixed-width one uses `comp1Of` besides; the projection, the
+general composition and the concatenation reach the bitstring construction
+alone.
+
+The multiplier is built from `Cobham.concatCompRaw`, whose head is the `concat`
+generator. `concat` belongs to the subalgebra `Cobham.SmashFree` names, which
+[Strahm2003] Theorem 1(2) contains in the functions computable simultaneously
+in polynomial time and linear space, so the multiplicative bound stays inside
+that subalgebra; `Geb.CobhamFold.smashFreeBool_boundMulRaw` states this at
+every multiplicity and growth.
+`Cobham.cond` already takes a concatenation bound in place of
+[HeraudNowak2011]'s smash bound for the same reason.
+
+## Main definitions
+
+* `Geb.CobhamFold.projOf`, `Geb.CobhamFold.compOf`, `Geb.CobhamFold.comp1Of`,
+  `Geb.CobhamFold.concatCompOf` — a projection, a composition, an arity-one
+  expression applied to an expression, and a concatenation, as expressions.
+* `Geb.CobhamFold.multRaw` — the `mult`-fold self-concatenation of the
+  recursion variable.
+* `Geb.CobhamFold.boundMulRaw` — that concatenation with `growth` bits
+  prepended.
+* `Geb.CobhamFold.scan2Raw` — the scan node at steps of arity two, which read
+  the remaining word as well as the recursive value.
+* `Geb.CobhamFold.scanBRaw`, `Geb.CobhamFold.scanBW` — that node at two steps
+  lifted from arity one, which is `Cobham.scan`'s shape, and it over
+  expressions.
+* `Geb.CobhamFold.scanBSem` — the meaning of that node at arity one.
+* `Geb.CobhamFold.scanMul`, `Geb.CobhamFold.scanMulOf` — the scan at the
+  multiplicative bound, as an expression of `Cobham.C` and at its declared
+  arity.
+
+## Main statements
+
+* `Geb.CobhamFold.wValid_concatCompRaw`, `Geb.CobhamFold.recBounded_concatCompRaw`
+  — admissibility and the recursion bound of a concatenation node, from its
+  two arguments'.
+* `Geb.CobhamFold.length_multSem` — the multiplier's value has length
+  `mult * |x 0|`, exactly.
+* `Geb.CobhamFold.length_boundMulSem` — the bound child's value has length
+  `growth + mult * |x 0|`.
+* `Geb.CobhamFold.scanBRaw_boundRaw` — at the additive bound child the
+  parameterized node is `Cobham.scanRaw`.
+* `Geb.CobhamFold.boundMulRaw_ne_boundRaw` — at the multiplier one, the
+  multiplicative bound child is not the additive one, at any growth.
+* `Geb.CobhamFold.scanBSem_nil`, `Geb.CobhamFold.scanBSem_cons`,
+  `Geb.CobhamFold.scanBSem_eq` — the scan on the empty word, on one bit, and as
+  a `List.foldr`, at every bound child.
+* `Geb.CobhamFold.scanMulSem_eq_eval` — the meaning read at the raw tree is the
+  meaning the expression carries.
+
+## Implementation notes
+
+`Cobham.concatCompRaw n a b` evaluates to `b`'s list followed by `a`'s, the
+`concat` generator reading its second argument as the earlier part of the word.
+`multRaw`'s step therefore places the projection second, so the recursion
+variable is prepended at each level; the value is a concatenation of copies of
+one list, so the order is immaterial and only `length_multSem` is stated.
+
+`scanBRaw` differs from `Cobham.scanRaw` only in taking its bound child as a
+parameter rather than building it from a growth. Every statement about the
+scan's value — `scanBSem_nil`, `scanBSem_cons`, `scanBSem_eq` — holds at every
+bound child, `Cobham.evalValue`'s `boundedRec` clause not consulting child
+three; only the recursion bound reads it.
+
+The transports `Cobham.semAt` introduces disappear here by proof irrelevance:
+each raw tree whose meaning is read here is a `WType.mk` whose shape's
+`Cobham.q` reduces to `1`, so the arity equation has definitionally equal
+sides.
+
+## References
+
+* [Cobham1965]
+* [HeraudNowak2011]
+* [Strahm2003]
+
+## Tags
+
+Cobham, bounded recursion on notation, scan, composition, concatenation, growth
+bound
+-/
+
+@[expose] public section
+
+namespace Geb.CobhamFold
+
+open Cobham
+
+/-- A projection as an expression. -/
+def projOf (n : ℕ) (i : Fin n) : COf n :=
+  ⟨⟨⟨WType.mk (.proj n i) Fin.elim0, ⟨fun c ↦ c.elim0, funext fun c ↦ c.elim0⟩⟩,
+      ⟨trivial, fun c ↦ c.elim0⟩⟩, rfl⟩
+
+/-- An `m`-ary expression applied to `m` arguments of arity `n`. -/
+def compOf {n m : ℕ} (head : COf m) (args : Fin m → COf n) : COf n :=
+  ⟨⟨⟨WType.mk (.comp n m) fun d ↦
+        match d with
+        | .inl () => head.1.1.1
+        | .inr i => (args i).1.1.1,
+      ⟨fun d ↦ match d with
+        | .inl () => head.1.1.2
+        | .inr i => (args i).1.1.2,
+      funext fun d ↦ match d with
+        | .inl () => (sig.wIndexValid_index_eq_wIndexRoot _).trans head.2
+        | .inr i => (sig.wIndexValid_index_eq_wIndexRoot _).trans (args i).2⟩⟩,
+    ⟨trivial, fun d ↦ match d with
+      | .inl () => head.1.2
+      | .inr i => (args i).1.2⟩⟩, rfl⟩
+
+/-- An arity-one expression applied to an `n`-ary one: `compOf` at one
+argument. -/
+def comp1Of {n : ℕ} (e : COf 1) (a : COf n) : COf n := compOf e fun _ ↦ a
+
+/-- The concatenation of two `n`-ary expressions, the second's value first:
+`compOf` at the `concat` generator. -/
+def concatCompOf (n : ℕ) (a b : COf n) : COf n := compOf concatOf ![a, b]
+
+/-- A concatenation node is admissible when both its arguments are, at the
+node's own arity. Its head is the `concat` generator, whose admissibility is
+vacuous. -/
+theorem wValid_concatCompRaw (n : ℕ) (a b : sig.toPFunctor.W)
+    (ha : sig.WValid a) (ha' : sig.wIndexRoot a = n)
+    (hb : sig.WValid b) (hb' : sig.wIndexRoot b = n) :
+    sig.WValid (concatCompRaw n a b) :=
+  ⟨fun d ↦ match d with
+    | .inl () => ⟨fun c ↦ c.elim0, funext fun c ↦ c.elim0⟩
+    | .inr i => match i with
+      | 0 => ha
+      | 1 => hb,
+  funext fun d ↦ match d with
+    | .inl () => rfl
+    | .inr i => match i with
+      | 0 => (sig.wIndexValid_index_eq_wIndexRoot a).trans ha'
+      | 1 => (sig.wIndexValid_index_eq_wIndexRoot b).trans hb'⟩
+
+/-- A concatenation node carries no recursion of its own: its `comp` shape's
+`Cobham.RecBoundedValue` is vacuous, so the condition is its arguments'. -/
+theorem recBounded_concatCompRaw (n : ℕ) (a b : sig.toPFunctor.W)
+    (hva : sig.WValid a) (hvb : sig.WValid b)
+    (hv : sig.WValid (concatCompRaw n a b))
+    (ha : RecBounded ⟨a, hva⟩) (hb : RecBounded ⟨b, hvb⟩) :
+    RecBounded ⟨concatCompRaw n a b, hv⟩ :=
+  ⟨trivial, fun d ↦ match d with
+    | .inl () => ⟨trivial, fun c ↦ c.elim0⟩
+    | .inr i => match i with
+      | 0 => ha
+      | 1 => hb⟩
+
+/-- Prepending a word to an expression prepends it to the expression's meaning,
+at every arity. `Cobham.stepWord_prependOf` is this at arity one. -/
+theorem semAt_prependOf {n : ℕ} (e : COf n) (x : Fin n → List Bool) :
+    ∀ u : List Bool,
+      semAt n (prependOf u e).1.1 (prependOf u e).2 x = u ++ semAt n e.1.1 e.2 x :=
+  List.rec rfl fun b v ih ↦ by
+    change b :: semAt n (prependOf v e).1.1 (prependOf v e).2 x = _
+    rw [ih]
+    rfl
+
+/-- A constant word's meaning, at every arity. -/
+@[simp] theorem semAt_constAtOf (n : ℕ) (u : List Bool) (x : Fin n → List Bool) :
+    semAt n (constAtOf n u).1.1 (constAtOf n u).2 x = u :=
+  (semAt_prependOf (zeroAtOf n) x u).trans (List.append_nil u)
+
+/-- A projection's meaning is the slot it names. -/
+@[simp] theorem semAt_projOf (n : ℕ) (i : Fin n) (x : Fin n → List Bool) :
+    semAt n (projOf n i).1.1 (projOf n i).2 x = x i := rfl
+
+/-- A concatenation's meaning is its second argument's followed by its
+first's. -/
+theorem semAt_concatCompOf (n : ℕ) (a b : COf n) (x : Fin n → List Bool) :
+    semAt n (concatCompOf n a b).1.1 (concatCompOf n a b).2 x =
+      semAt n b.1.1 b.2 x ++ semAt n a.1.1 a.2 x := rfl
+
+/-- A composition's meaning at every arity. `Geb.CobhamFold.stepWord_compOf`
+is this at arity one. -/
+theorem semAt_compOf {n m : ℕ} (head : COf m) (args : Fin m → COf n)
+    (x : Fin n → List Bool) :
+    semAt n (compOf head args).1.1 (compOf head args).2 x =
+      semAt m head.1.1 head.2 fun i ↦ semAt n (args i).1.1 (args i).2 x := rfl
+
+/-- An arity-one expression's meaning at an `n`-ary argument.
+`Geb.CobhamFold.stepWord_comp1Of` is this at arity one. -/
+theorem semAt_comp1Of {n : ℕ} (e : COf 1) (a : COf n) (x : Fin n → List Bool) :
+    semAt n (comp1Of e a).1.1 (comp1Of e a).2 x =
+      stepWord e (semAt n a.1.1 a.2 x) :=
+  congrArg (semAt 1 e.1.1 e.2) (funext fun i ↦ match i with | ⟨0, _⟩ => rfl)
+
+/-- The `mult`-fold self-concatenation of the recursion variable, of arity one:
+the empty bitstring at `mult = 0`, and one more copy of the sole argument at
+each successor. -/
+def multRaw : ℕ → sig.toPFunctor.W :=
+  Nat.rec (zeroAtRaw 1)
+    fun _ ih ↦ concatCompRaw 1 ih (WType.mk (.proj 1 0) Fin.elim0)
+
+/-- The multiplier has arity one, at every multiplicity. A case split, not a
+recursion: both `Nat.rec` branches are `comp` nodes of arity one. -/
+theorem wIndexRoot_multRaw (mult : ℕ) : sig.wIndexRoot (multRaw mult) = 1 := by
+  cases mult with
+  | zero => rfl
+  | succ _ => rfl
+
+/-- The multiplier is admissible, at every multiplicity. -/
+theorem wValid_multRaw (mult : ℕ) : sig.WValid (multRaw mult) :=
+  Nat.rec (zeroAt 1).1.2
+    (fun k ih ↦ wValid_concatCompRaw 1 _ _ ih (wIndexRoot_multRaw k)
+      ⟨fun c ↦ c.elim0, funext fun c ↦ c.elim0⟩ rfl)
+    mult
+
+/-- The multiplier's arity, in the form `Cobham.fst_eval` composes with. -/
+theorem arity_multRaw (mult : ℕ) :
+    arity ⟨multRaw mult, wValid_multRaw mult⟩ = 1 := wIndexRoot_multRaw mult
+
+/-- The multiplier carries no recursion of its own: every node is a `comp`, a
+`proj`, or the `concat` or `zero` generator. -/
+theorem recBounded_multRaw (mult : ℕ) :
+    RecBounded ⟨multRaw mult, wValid_multRaw mult⟩ :=
+  Nat.rec (zeroAt 1).2
+    (fun k ih ↦ recBounded_concatCompRaw 1 (multRaw k)
+      (WType.mk (.proj 1 0) Fin.elim0) (wValid_multRaw k)
+      ⟨fun c ↦ c.elim0, funext fun c ↦ c.elim0⟩ (wValid_multRaw (k + 1)) ih
+      ⟨trivial, fun c ↦ c.elim0⟩)
+    mult
+
+/-- The meaning of the multiplier at its arity. -/
+def multSem (mult : ℕ) : Sem 1 :=
+  semAt 1 ⟨multRaw mult, wValid_multRaw mult⟩ (arity_multRaw mult)
+
+/-- The multiplier's value has length exactly `mult` times the argument's.
+Stated at an arbitrary environment, which is the form the recursion bound
+reads it at. -/
+theorem length_multSem : ∀ (mult : ℕ) (x : Fin 1 → List Bool),
+    (multSem mult x).length = mult * (x 0).length :=
+  Nat.rec (fun x ↦ (Nat.zero_mul (x 0).length).symm)
+    (fun k ih x ↦ by
+      change (x 0 ++ multSem k x).length = _
+      rw [List.length_append, ih x, Nat.succ_mul, Nat.add_comm])
+
+/-- The multiplier with `growth` bits prepended: the bound child of a scan
+whose state may exceed the input by a factor as well as a constant.
+`Cobham.prependRaw` supplies the prepending, so the three obligations below are
+its own. -/
+def boundMulRaw (mult growth : ℕ) : sig.toPFunctor.W :=
+  prependRaw 1 (List.replicate growth true) (multRaw mult)
+
+/-- The bound child has arity one, at every multiplicity and growth. -/
+theorem wIndexRoot_boundMulRaw (mult growth : ℕ) :
+    sig.wIndexRoot (boundMulRaw mult growth) = 1 :=
+  wIndexRoot_prependRaw 1 _ _ (wIndexRoot_multRaw mult)
+
+/-- The bound child is admissible, at every multiplicity and growth. -/
+theorem wValid_boundMulRaw (mult growth : ℕ) :
+    sig.WValid (boundMulRaw mult growth) :=
+  wValid_prependRaw 1 _ (wValid_multRaw mult) (wIndexRoot_multRaw mult) _
+
+/-- The bound child's arity, in the form `Cobham.fst_eval` composes with. -/
+theorem arity_boundMulRaw (mult growth : ℕ) :
+    arity ⟨boundMulRaw mult growth, wValid_boundMulRaw mult growth⟩ = 1 :=
+  wIndexRoot_boundMulRaw mult growth
+
+/-- The bound child carries no recursion of its own, at every multiplicity and
+growth. -/
+theorem recBounded_boundMulRaw (mult growth : ℕ) :
+    RecBounded ⟨boundMulRaw mult growth, wValid_boundMulRaw mult growth⟩ :=
+  recBounded_prependRaw 1 _ (wValid_multRaw mult) (wIndexRoot_multRaw mult)
+    (recBounded_multRaw mult) _
+
+/-- The meaning of the bound child at its arity. -/
+def boundMulSem (mult growth : ℕ) : Sem 1 :=
+  semAt 1 ⟨boundMulRaw mult growth, wValid_boundMulRaw mult growth⟩
+    (arity_boundMulRaw mult growth)
+
+/-- The bound child's value has length `growth + mult * |x 0|`. -/
+theorem length_boundMulSem : ∀ (mult growth : ℕ) (x : Fin 1 → List Bool),
+    (boundMulSem mult growth x).length = growth + mult * (x 0).length :=
+  fun mult ↦ Nat.rec (fun x ↦ (length_multSem mult x).trans (Nat.zero_add _).symm)
+    (fun g ih x ↦ by
+      change (true :: boundMulSem mult g x).length = _
+      rw [List.length_cons, ih x]
+      omega)
+
+/-- The scan node at steps of arity two, which read the remaining word in slot
+zero as well as the recursive value in slot one. -/
+def scan2Raw (base step₀ step₁ bnd : sig.toPFunctor.W) : sig.toPFunctor.W :=
+  WType.mk (.boundedRec 0) ![base, step₀, step₁, bnd]
+
+/-- The arity-two scan node is admissible from its children's. -/
+theorem wValid_scan2Raw (base step₀ step₁ bnd : sig.toPFunctor.W)
+    (hb : sig.WValid base) (hb' : sig.wIndexRoot base = 0)
+    (h₀ : sig.WValid step₀) (h₀' : sig.wIndexRoot step₀ = 2)
+    (h₁ : sig.WValid step₁) (h₁' : sig.wIndexRoot step₁ = 2)
+    (hn : sig.WValid bnd) (hn' : sig.wIndexRoot bnd = 1) :
+    sig.WValid (scan2Raw base step₀ step₁ bnd) :=
+  ⟨fun d : Fin 4 ↦ match d with
+    | 0 => hb
+    | 1 => h₀
+    | 2 => h₁
+    | 3 => hn,
+  funext fun d : Fin 4 ↦ match d with
+    | 0 => (sig.wIndexValid_index_eq_wIndexRoot base).trans hb'
+    | 1 => (sig.wIndexValid_index_eq_wIndexRoot step₀).trans h₀'
+    | 2 => (sig.wIndexValid_index_eq_wIndexRoot step₁).trans h₁'
+    | 3 => (sig.wIndexValid_index_eq_wIndexRoot bnd).trans hn'⟩
+
+/-- The scan node at an arbitrary bound child: `scan2Raw` at two steps lifted
+from arity one, which is the shape `Cobham.scan` takes. -/
+def scanBRaw (base step₀ step₁ bnd : sig.toPFunctor.W) :
+    sig.toPFunctor.W :=
+  scan2Raw base (liftRaw step₀) (liftRaw step₁) bnd
+
+/-- `Cobham.scan`'s additive bound and the multiplicative bound are two
+instances of one node: at `Cobham.boundRaw` the parameterized node is
+`Cobham.scanRaw` itself, definitionally. -/
+theorem scanBRaw_boundRaw (base step₀ step₁ : sig.toPFunctor.W) (growth : ℕ) :
+    scanBRaw base step₀ step₁ (boundRaw growth) =
+      scanRaw base step₀ step₁ growth := rfl
+
+/-- The multiplicative bound child is not the additive one at any growth, so an
+expression built on it is a different raw tree from the corresponding
+`Cobham.scan` even at the multiplier one. At growth zero the two are nodes of
+different shape; each successor wraps both in the same `comp` node, so the
+recursion carries the separation up. -/
+theorem boundMulRaw_ne_boundRaw :
+    ∀ growth : ℕ, boundMulRaw 1 growth ≠ boundRaw growth :=
+  Nat.rec
+    (fun h ↦ by
+      injection h with ha _
+      exact absurd ha (by nofun))
+    fun _ ih h ↦ by
+      injection h with _ hf
+      exact ih (congrFun hf (Sum.inr 0))
+
+/-- The scan node is admissible when its base is, at arity zero, its two steps
+are, at arity one, and its bound child is, at arity one: `wValid_scan2Raw` at
+the lifted steps. -/
+theorem wValid_scanBRaw (base step₀ step₁ bnd : sig.toPFunctor.W)
+    (hb : sig.WValid base) (hb' : sig.wIndexRoot base = 0)
+    (h₀ : sig.WValid step₀) (h₀' : sig.wIndexRoot step₀ = 1)
+    (h₁ : sig.WValid step₁) (h₁' : sig.wIndexRoot step₁ = 1)
+    (hn : sig.WValid bnd) (hn' : sig.wIndexRoot bnd = 1) :
+    sig.WValid (scanBRaw base step₀ step₁ bnd) :=
+  wValid_scan2Raw base (liftRaw step₀) (liftRaw step₁) bnd hb hb'
+    (wValid_liftRaw step₀ h₀ h₀') (wIndexRoot_liftRaw step₀)
+    (wValid_liftRaw step₁ h₁ h₁') (wIndexRoot_liftRaw step₁) hn hn'
+
+/-- The scan node over expressions, carrying its admissibility. -/
+def scanBW (base : COf 0) (step₀ step₁ : COf 1)
+    (bnd : sig.toPFunctor.W) (hn : sig.WValid bnd)
+    (hn' : sig.wIndexRoot bnd = 1) : sig.W :=
+  ⟨scanBRaw base.1.1.1 step₀.1.1.1 step₁.1.1.1 bnd,
+    wValid_scanBRaw _ _ _ bnd base.1.1.2 base.2 step₀.1.1.2 step₀.2
+      step₁.1.1.2 step₁.2 hn hn'⟩
+
+/-- The scan node's arity, in the form `Cobham.fst_eval` composes with. -/
+theorem arity_scanBW (base : COf 0) (step₀ step₁ : COf 1)
+    (bnd : sig.toPFunctor.W) (hn : sig.WValid bnd)
+    (hn' : sig.wIndexRoot bnd = 1) :
+    arity (scanBW base step₀ step₁ bnd hn hn') = 1 := rfl
+
+/-- The meaning of a scan at its arity, read at the raw tree. -/
+def scanBSem (base : COf 0) (step₀ step₁ : COf 1)
+    (bnd : sig.toPFunctor.W) (hn : sig.WValid bnd)
+    (hn' : sig.wIndexRoot bnd = 1) : Sem 1 :=
+  semAt 1 (scanBW base step₀ step₁ bnd hn hn')
+    (arity_scanBW base step₀ step₁ bnd hn hn')
+
+/-- The scan's value on the empty bitstring is the base's word, at every bound
+child. -/
+theorem scanBSem_nil (base : COf 0) (step₀ step₁ : COf 1)
+    (bnd : sig.toPFunctor.W) (hn : sig.WValid bnd)
+    (hn' : sig.wIndexRoot bnd = 1) :
+    scanBSem base step₀ step₁ bnd hn hn' ![[]] = baseWord base := rfl
+
+/-- One step of the scan: the bit selects the step, which reads the value the
+scan of the rest of the word returns. -/
+theorem scanBSem_cons (base : COf 0) (step₀ step₁ : COf 1)
+    (bnd : sig.toPFunctor.W) (hn : sig.WValid bnd)
+    (hn' : sig.wIndexRoot bnd = 1) (b : Bool) (w : List Bool) :
+    scanBSem base step₀ step₁ bnd hn hn' ![b :: w] =
+      scanStepWord step₀ step₁ b (scanBSem base step₀ step₁ bnd hn hn' ![w]) := by
+  have hfun : ∀ r : List Bool, (fun _ : Fin 1 ↦ r) = ![r] :=
+    fun r ↦ funext fun i ↦ match i with | ⟨0, _⟩ => rfl
+  cases b
+  · change transport ((fst_eval step₀.1.1).trans step₀.2) (eval step₀.1.1).2
+      (fun _ ↦ scanBSem base step₀ step₁ bnd hn hn' ![w]) = _
+    exact congrArg _ (hfun _)
+  · change transport ((fst_eval step₁.1.1).trans step₁.2) (eval step₁.1.1).2
+      (fun _ ↦ scanBSem base step₀ step₁ bnd hn hn' ![w]) = _
+    exact congrArg _ (hfun _)
+
+/-- A scanner computes the right fold of its steps over the word, from its
+base. It holds at every bound child, `Cobham.evalValue`'s `boundedRec` clause
+not consulting child three. -/
+theorem scanBSem_eq (base : COf 0) (step₀ step₁ : COf 1)
+    (bnd : sig.toPFunctor.W) (hn : sig.WValid bnd)
+    (hn' : sig.wIndexRoot bnd = 1) (w : List Bool) :
+    scanBSem base step₀ step₁ bnd hn hn' ![w] =
+      w.foldr (scanStepWord step₀ step₁) (baseWord base) :=
+  List.rec (scanBSem_nil base step₀ step₁ bnd hn hn')
+    (fun b v ih ↦ (scanBSem_cons base step₀ step₁ bnd hn hn' b v).trans
+      (congrArg (scanStepWord step₀ step₁ b) ih)) w
+
+/-- The scanner at the multiplicative bound, as an expression of `Cobham.C`.
+The bound hypothesis is `mult * |w| + growth` where `Cobham.scan` asks for
+`|w| + growth`. -/
+def scanMul (base : COf 0) (step₀ step₁ : COf 1) (mult growth : ℕ)
+    (hbound : ∀ w : List Bool,
+      (scanBSem base step₀ step₁ (boundMulRaw mult growth)
+        (wValid_boundMulRaw mult growth) (wIndexRoot_boundMulRaw mult growth)
+        ![w]).length ≤ mult * w.length + growth) : C :=
+  ⟨scanBW base step₀ step₁ (boundMulRaw mult growth)
+      (wValid_boundMulRaw mult growth) (wIndexRoot_boundMulRaw mult growth), by
+    refine ⟨fun x ↦ ?_, ?_⟩
+    · rw [(funext fun i ↦ i.elim0 : Fin.tail x = Fin.tail ![x 0])]
+      change _ ≤ (boundMulSem mult growth x).length
+      rw [length_boundMulSem]
+      exact Nat.le_trans (hbound (x 0)) (Nat.le_of_eq (Nat.add_comm _ _))
+    · refine fun b : Fin 4 ↦ ?_
+      match b with
+      | 0 => exact base.1.2
+      | 1 => exact recBounded_liftRaw step₀
+      | 2 => exact recBounded_liftRaw step₁
+      | 3 => exact recBounded_boundMulRaw mult growth⟩
+
+/-- `scanMul` at its declared arity. -/
+def scanMulOf (base : COf 0) (step₀ step₁ : COf 1) (mult growth : ℕ)
+    (hbound : ∀ w : List Bool,
+      (scanBSem base step₀ step₁ (boundMulRaw mult growth)
+        (wValid_boundMulRaw mult growth) (wIndexRoot_boundMulRaw mult growth)
+        ![w]).length ≤ mult * w.length + growth) : COf 1 :=
+  ⟨scanMul base step₀ step₁ mult growth hbound, rfl⟩
+
+/-- The meaning read at the raw tree is the meaning the expression carries. -/
+theorem scanMulSem_eq_eval (base : COf 0) (step₀ step₁ : COf 1)
+    (mult growth : ℕ)
+    (hbound : ∀ w : List Bool,
+      (scanBSem base step₀ step₁ (boundMulRaw mult growth)
+        (wValid_boundMulRaw mult growth) (wIndexRoot_boundMulRaw mult growth)
+        ![w]).length ≤ mult * w.length + growth) :
+    transport (scanMulOf base step₀ step₁ mult growth hbound).2
+        (scanMulOf base step₀ step₁ mult growth hbound).1.eval =
+      scanBSem base step₀ step₁ (boundMulRaw mult growth)
+        (wValid_boundMulRaw mult growth)
+        (wIndexRoot_boundMulRaw mult growth) := rfl
+
+end Geb.CobhamFold
+
+end

--- a/geb-lean/vendor/geb-mathlib/Geb/Internal/Computability/CobhamFoldProto/Degenerate.lean
+++ b/geb-lean/vendor/geb-mathlib/Geb/Internal/Computability/CobhamFoldProto/Degenerate.lean
@@ -1,0 +1,209 @@
+/-
+Copyright (c) 2026 Terence Rokop. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Terence Rokop
+-/
+-- Modified from geb-mathlib by scripts/geb-mathlib-backport.patch.
+module
+
+public import Geb.Internal.Computability.CobhamFoldProto.Expr
+
+/-!
+# The recognizer as the fold's degenerate instance
+
+The fold of `Geb/Internal/Computability/CobhamFoldProto/Expr.lean` at the
+terminal algebra — the carrier `Unit`, whose encoding is empty, so `p = 0` —
+meets the recognizer of `Geb/Mathlib/Computability/Cobham/RankedTree.lean` at
+each layer: the state layout, the dispatch window, the readout window, the bits
+a step drops and prepends, and the accepted language.
+
+The two are not one expression. `boundMulRaw_ne_boundRaw` separates the two
+bound children at multiplicity one, at every growth, so the raw trees differ;
+and the rejecting words differ, `foldOutSem_unit_eq_ite` giving `[false]`
+where
+`Cobham.isRankedSem_eq_ite` gives the empty bitstring. What holds is that each
+component coincides and the languages agree.
+
+## Main definitions
+
+* `Geb.CobhamFold.encUnit`, `Geb.CobhamFold.decUnit` — the empty encoding of the
+  terminal carrier and its inverse.
+* `Geb.CobhamFold.algUnit` — the terminal algebra.
+
+## Main statements
+
+* `Geb.CobhamFold.dispatchWidthF_zero` — the dispatch window at `p = 0` is
+  `Cobham.dispatchWidth`.
+* `Geb.CobhamFold.stackBits_unit` — the stack's layout at `p = 0` is the
+  pending count in unary.
+* `Geb.CobhamFold.stateWordF_unit` — the state layout at `p = 0` is
+  `Cobham.stateWord` of the projected state.
+* `Geb.CobhamFold.readoutWidth_zero` — the readout window at `p = 0` is the
+  recognizer's verdict window.
+* `Geb.CobhamFold.dropCountF_unit`, `Geb.CobhamFold.nextPrefixF_unit` — the bits
+  a step drops and prepends at `p = 0` are `Cobham.dropCount` and
+  `Cobham.nextPrefix` of the projected state.
+* `Geb.CobhamFold.foldOut_unit` — the fold at the terminal algebra is present
+  exactly on the valid words.
+* `Geb.CobhamFold.foldOutSem_unit_eq_ite` — the expression at the terminal
+  algebra decides `RankedAlphabet.Valid`, pinning its value on both branches.
+
+## Implementation notes
+
+`nextPrefixF` branches on `Geb.CobhamFold.symOf` where `Cobham.nextPrefix`
+branches on `RankedAlphabet.arOf`, and the two agree through
+`Geb.CobhamFold.arOf_eq_map_symOf` rather than by reduction, which is why
+`dropCountF_unit` and `nextPrefixF_unit` are proved by a case analysis rather
+than stated as `rfl`.
+
+`Cobham.isRankedSem_eq_ite` gives the recognizer's rejecting value as the empty
+bitstring, while `foldOutSem_unit_eq_ite` gives `[false]`: `outWord` spells both
+branches at the width `p + 1`, so that the marker alone separates them. The
+languages the two accept are the same.
+
+`one_le_one_mul_width` takes the multiplier one: the state carries one bit per pending
+subterm and the count rises once per `R.width` input bits, so at `p = 0` the
+state never exceeds the input by more than the flag and the slot, which is the
+additive bound `Cobham.scan` already admits.
+
+## References
+
+* [Cobham1965]
+
+## Tags
+
+Cobham, ranked alphabet, fold, terminal algebra, recognizer
+-/
+
+@[expose] public section
+
+namespace Geb.CobhamFold
+
+open Cobham RankedAlphabet
+
+/-- The empty encoding of the terminal carrier. -/
+@[nolint unusedArguments] def encUnit : Unit → Fin 0 → Bool := fun _ ↦ Fin.elim0
+
+/-- The inverse of the empty encoding. -/
+@[nolint unusedArguments] def decUnit : (Fin 0 → Bool) → Unit := fun _ ↦ ()
+
+/-- The empty encoding's retraction, which holds by `Unit`'s eta. -/
+theorem decUnit_encUnit : ∀ a : Unit, decUnit (encUnit a) = a := fun _ ↦ rfl
+
+/-- The terminal algebra of a ranked alphabet. -/
+@[nolint unusedArguments] def algUnit (R : RankedAlphabet) :
+    (i : Fin R.card) → (Fin (R.arity i) → Unit) → Unit := fun _ _ ↦ ()
+
+/-- The multiplier one meets the bound at `p = 0`. -/
+theorem one_le_one_mul_width (R : RankedAlphabet) : 0 + 1 ≤ 1 * R.width := by
+  have := R.width_pos
+  omega
+
+/-- The dispatch window at `p = 0` is the recognizer's. -/
+theorem dispatchWidthF_zero (R : RankedAlphabet) :
+    dispatchWidthF R 0 = dispatchWidth R := by
+  rw [dispatchWidthF, dispatchWidth]
+  omega
+
+/-- The readout window at `p = 0` is the recognizer's verdict window, which
+`Cobham.acceptTest` reads at `R.width + 3` bits. -/
+theorem readoutWidth_zero (R : RankedAlphabet) :
+    readoutWidth R 0 = R.width + 3 := by
+  rw [readoutWidth]
+  omega
+
+/-- An entry at `p = 0` is the single `true` the unary count spells. -/
+theorem entryBits_unit (a : Unit) : entryBits encUnit a = [true] := rfl
+
+/-- The stack's layout at `p = 0` is the pending count in unary. -/
+theorem stackBits_unit : ∀ st : List Unit,
+    stackBits encUnit st = List.replicate st.length true :=
+  List.rec rfl fun a t ih ↦ by
+    rw [stackBits_cons, entryBits_unit, ih, List.length_cons, List.replicate_succ,
+      List.cons_append, List.nil_append]
+
+/-- The state layout at `p = 0` is `Cobham.stateWord` of the projected state. -/
+theorem stateWordF_unit (R : RankedAlphabet) (s : FoldScan Unit) :
+    stateWordF R encUnit s = stateWord R (toScan s) := by
+  rw [stateWordF, stackBits_unit, stateWord, toScan]
+
+/-- At `p = 0` the bits a step drops are the recognizer's. -/
+theorem dropCountF_unit (R : RankedAlphabet) (b : Bool) (s : FoldScan Unit) :
+    dropCountF R 0 b s = dropCount R b (toScan s) := by
+  obtain ⟨buf, stack, live⟩ := s
+  rw [dropCountF, dropCount, toScan]
+  dsimp only
+  cases live
+  · rfl
+  · dsimp only
+    rw [arOf_eq_map_symOf]
+    by_cases hlen : (b :: buf).length = R.width
+    · rw [if_pos hlen, decide_eq_true hlen]
+      match hsym : symOf R (decodeBits (b :: buf)) with
+      | none => rfl
+      | some i =>
+        rw [Option.map_some]
+        dsimp only
+        by_cases hle : R.arity i ≤ stack.length
+        · rw [if_pos hle, decide_eq_true hle, Nat.one_mul]
+        · rw [if_neg hle, decide_eq_false hle]
+    · rw [if_neg hlen, decide_eq_false hlen]
+
+/-- At `p = 0` the bits a step prepends are the recognizer's: an entry is the
+single `true` the pending count pushes. -/
+theorem nextPrefixF_unit (R : RankedAlphabet) (b : Bool) (s : FoldScan Unit) :
+    nextPrefixF R encUnit (algUnit R) b s = nextPrefix R b (toScan s) := by
+  obtain ⟨buf, stack, live⟩ := s
+  rw [nextPrefixF, nextPrefix, toScan]
+  dsimp only
+  cases live
+  · rfl
+  · dsimp only
+    rw [arOf_eq_map_symOf]
+    by_cases hlen : (b :: buf).length = R.width
+    · rw [if_pos hlen, decide_eq_true hlen]
+      match hsym : symOf R (decodeBits (b :: buf)) with
+      | none => rfl
+      | some i =>
+        rw [Option.map_some]
+        dsimp only
+        by_cases hle : R.arity i ≤ stack.length
+        · rw [dif_pos hle, decide_eq_true hle]
+          rfl
+        · rw [dif_neg hle, decide_eq_false hle]
+    · rw [if_neg hlen, decide_eq_false hlen]
+
+/-- The fold at the terminal algebra is present exactly on the valid words:
+the recognizer is the fold's degenerate instance. -/
+theorem foldOut_unit (R : RankedAlphabet) (w : List Bool) :
+    foldOut R (algUnit R) w = if R.Valid w then some () else none := by
+  by_cases hv : R.Valid w
+  · rw [if_pos hv]
+    have hcond := (foldOut_cond R (algUnit R) w).trans hv
+    have h1 : (foldScanFinal R (algUnit R) w).stack.length = 1 :=
+      eq_of_beq ((Bool.and_eq_true _ _).mp hcond).2
+    rw [foldOut, hcond]
+    match hst : (foldScanFinal R (algUnit R) w).stack with
+    | [] =>
+      rw [hst] at h1
+      exact absurd h1 (by simp)
+    | _ :: _ => rfl
+  · rw [if_neg hv, foldOut, foldOut_cond]
+    exact if_neg hv
+
+/-- The expression at the terminal algebra decides `RankedAlphabet.Valid`, its
+value pinned on both branches. -/
+theorem foldOutSem_unit_eq_ite (R : RankedAlphabet) (w : List Bool) :
+    foldOutSem R 0 encUnit decUnit decUnit_encUnit (algUnit R) 1 (one_le_one_mul_width R)
+        ![w] =
+      if R.Valid w then [true] else [false] := by
+  rw [foldOutSem_eq, foldOut_unit]
+  by_cases hv : R.Valid w
+  · rw [if_pos hv, if_pos hv]
+    rfl
+  · rw [if_neg hv, if_neg hv]
+    rfl
+
+end Geb.CobhamFold
+
+end

--- a/geb-lean/vendor/geb-mathlib/Geb/Internal/Computability/CobhamFoldProto/Destruct.lean
+++ b/geb-lean/vendor/geb-mathlib/Geb/Internal/Computability/CobhamFoldProto/Destruct.lean
@@ -1,0 +1,638 @@
+/-
+Copyright (c) 2026 Terence Rokop. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Terence Rokop
+-/
+-- Modified from geb-mathlib by scripts/geb-mathlib-backport.patch.
+module
+
+public import Geb.Internal.Computability.CobhamFoldProto.Initial
+public import Geb.Mathlib.Data.W.Basic
+
+/-!
+# The term algebra's destructor in the fold's language
+
+The inverse of the initial algebra's structure map, as expressions of
+Cobham's class, at the representation `RankedAlphabet.spell` fixes.
+
+`codeOf` and `dropCodeOf` read a word's leading block and what follows it,
+through a constant unary prefix that makes the word a self-delimiting entry
+whose payload is that block, so no dispatch over the block is needed.
+
+`algPara` is the paramorphism as a fold, at a carrier pairing a subterm's
+spelling with the step's value, the value delimited so the two are separable.
+The delimiting does not nest: each level reads only the spelling half of a
+child's value, so a subterm's boundary is reached by a fold rather than at
+the cost a nested encoding would carry. `WType.para` already exists, so no
+recursion scheme is introduced here; `algPara` is the encoding at which it is
+computed, and `algPara_eq_para` identifies the two.
+
+Under the preorder encoding the structure map is the identity on
+representations, `RankedAlphabet.spell_mk` stating that a symbol's block
+followed by its children's spellings is the spelling of the term they build.
+The content of the inverse laws is therefore that a valid word determines the
+symbol and the children's spellings.
+
+## Main definitions
+
+* `Geb.CobhamFold.codeOf`, `Geb.CobhamFold.dropCodeOf` — the block reader and
+  its complement.
+* `Geb.CobhamFold.ParaStep`, `Geb.CobhamFold.algPara` — the paramorphism's
+  step, and the paramorphism as a fold.
+* `Geb.CobhamFold.algCh` — the delimited-children algebra, one instance of
+  the paramorphism.
+* `Geb.CobhamFold.chGrowth` — the per-symbol growth the delimited-children
+  algebra meets under its own invariant.
+* `Geb.CobhamFold.algChOf` — that algebra as an expression of the class.
+* `Geb.CobhamFold.chFoldOf` — the delimited-children fold as an expression.
+* `Geb.CobhamFold.childSem`, `Geb.CobhamFold.childOf` — a child's spelling,
+  read from a fold's value and read by an expression.
+
+## Main statements
+
+* `Geb.CobhamFold.stepWord_codeOf`, `Geb.CobhamFold.stepWord_dropCodeOf` —
+  what those two compute at an arbitrary word.
+* `Geb.CobhamFold.stepWord_codeOf_spell_mk`,
+  `Geb.CobhamFold.stepWord_dropCodeOf_spell_mk` — what they recover from a
+  spelling.
+* `Geb.CobhamFold.dropEntry_algPara` — the value's second half is the
+  spelling, whatever the step.
+* `Geb.CobhamFold.takeEntry_algPara` — the paramorphism's defining equation.
+* `Geb.CobhamFold.algPara_eq_para` — it is `WType.para` at the step that sees
+  each child's spelling in place of the subtree.
+* `Geb.CobhamFold.sum_ofFn_length_eq_length_flatten`,
+  `Geb.CobhamFold.growth_algPara` — a family's total length, and the
+  per-symbol growth a bounded step gives.
+* `Geb.CobhamFold.dropEntry_algCh`, `Geb.CobhamFold.takeEntry_algCh` — the
+  paramorphism's two laws at `Geb.CobhamFold.algCh`.
+* `Geb.CobhamFold.length_algCh`,
+  `Geb.CobhamFold.five_mul_length_dropEntrySem_algCh_le` — its length at
+  arbitrary arguments, and the bound its outputs satisfy.
+* `Geb.CobhamFold.growth_algCh_of_dropEntrySem_le`,
+  `Geb.CobhamFold.stackSize_algCh_le` — the per-symbol growth condition at
+  `Geb.CobhamFold.algCh`, and the linearity hypothesis it discharges.
+* `Geb.CobhamFold.length_fold_algCh_le` — that fold's value at a term is
+  linear in the term, the linearity in the input word read at a spelling.
+* `Geb.CobhamFold.semAt_algChOf`, `Geb.CobhamFold.smashFreeBool_algChOf` —
+  what `Geb.CobhamFold.algChOf` computes, and that it carries no `smash`.
+* `Geb.CobhamFold.takeEntrySem_cons_true` — the presence marker is absorbed
+  into the entry's unary prefix, so one further bit is read from what follows
+  the entry.
+* `Geb.CobhamFold.fold_algCh_mk` — the fold's value at a constructed term.
+* `Geb.CobhamFold.childSem_mk`, `Geb.CobhamFold.childSem_of_le`,
+  `Geb.CobhamFold.stepWord_childOf`,
+  `Geb.CobhamFold.stepWord_childOf_of_le` — the child reader recovers a
+  child's spelling and is total.
+* `Geb.CobhamFold.smashFreeBool_chFoldOf`,
+  `Geb.CobhamFold.smashFreeBool_childOf` — the fold and the child reader
+  carry no `smash`, which is what `Cobham.SmashFree` names.
+* `Geb.CobhamFold.toSigma_mk` — the term algebra's destructor at the
+  `RankedAlphabet.Term.mk` presentation.
+* `Geb.CobhamFold.semAt_mkOf_spell` — the constructor's expression at the
+  children's spellings is the spelling of the term they build.
+* `Geb.CobhamFold.semAt_mkOf_childOf` — the constructor at the children the
+  destructor reads returns the word.
+
+## Implementation notes
+
+`algCh` does not meet the per-symbol growth condition
+`Geb.CobhamFold.stackSize_le_of_growth` consumes, and not because
+`dropEntrySem` fails to shrink — `length_dropEntrySem_le` bounds its result
+by its argument. It duplicates its children's payloads, delimited and plain,
+so its length is bounded by a multiple of the children's total rather than by
+that total plus a constant. A multiplicative condition alone would not give
+the linearity hypothesis either, a fold whose values multiply at every level
+being exponential in depth. The route taken instead is
+`five_mul_length_dropEntrySem_algCh_le`, a property of the algebra's own
+outputs that needs no induction hypothesis,
+carried along the scan by `mem_stack_foldScanFinal` and consumed by a
+potential argument in the shape
+`Geb.CobhamFold.potential_foldScanStep_le_of_invariant`'s.
+
+`Variable.lean` states the potential chain at a growth condition restricted
+to values satisfying a predicate the scan's stack carries, and derives the
+unrestricted forms from it at the trivial predicate. The restriction is what
+`algCh` needs and what the unrestricted condition does not give.
+
+`Geb.CobhamFold.foldOutExprV`'s readout emits `Geb.CobhamFold.outWordV`,
+which prefixes a presence marker. The marker is absorbed into the entry's
+unary prefix rather than left beside it, so one further bit is read from what
+follows the entry. Each equation is therefore stated in the "entries followed
+by an arbitrary remainder" form, which `takeEntrySem` at an `entryWord`
+tolerates, and the case past the last child is proved against that extra bit
+rather than in its absence.
+
+## References
+
+* [Cobham1965]
+* [Meertens1992]
+* [Strahm2003]
+
+## Tags
+
+Cobham, ranked tree, destructor, self-delimiting, subterm, paramorphism,
+smash-free
+-/
+
+@[expose] public section
+
+namespace Geb.CobhamFold
+
+open Cobham RankedAlphabet
+
+/-- The leading block of a word, as an expression of arity one: a constant
+unary prefix of the alphabet's width makes the word a self-delimiting entry
+whose payload is that block. -/
+def codeOf (R : RankedAlphabet) : COf 1 :=
+  comp1Of takeEntryOf (prependOf (List.replicate R.width true ++ [false]) idOf)
+
+/-- The word past its leading block, by the same prefix. -/
+def dropCodeOf (R : RankedAlphabet) : COf 1 :=
+  comp1Of dropEntryOf (prependOf (List.replicate R.width true ++ [false]) idOf)
+
+/-- The prefixed word, in the shape the payload primitives read. -/
+private theorem stepWord_prefix (R : RankedAlphabet) (w : List Bool) :
+    stepWord (prependOf (List.replicate R.width true ++ [false]) idOf) w =
+      List.replicate R.width true ++ false :: w := by
+  rw [stepWord_prependOf, stepWord_idOf, List.append_assoc]
+  rfl
+
+/-- The block reader truncates to the alphabet's width. -/
+theorem stepWord_codeOf (R : RankedAlphabet) (w : List Bool) :
+    stepWord (codeOf R) w = w.take R.width := by
+  rw [codeOf, stepWord_comp1Of, stepWord_prefix, stepWord_takeEntryOf,
+    takeEntrySem_replicate]
+
+/-- Its complement drops the alphabet's width. -/
+theorem stepWord_dropCodeOf (R : RankedAlphabet) (w : List Bool) :
+    stepWord (dropCodeOf R) w = w.drop R.width := by
+  rw [dropCodeOf, stepWord_comp1Of, stepWord_prefix, stepWord_dropEntryOf,
+    dropEntrySem_replicate]
+
+/-- At a spelling the block reader recovers the head symbol's block. -/
+theorem stepWord_codeOf_spell_mk (R : RankedAlphabet) (i : Fin R.card)
+    (ch : Fin (R.arity i) → R.Term) :
+    stepWord (codeOf R) (R.spell (Term.mk R i ch)) = R.code i := by
+  rw [stepWord_codeOf, spell_mk, List.take_left' (R.length_code i)]
+
+/-- And its complement recovers the children's spellings. -/
+theorem stepWord_dropCodeOf_spell_mk (R : RankedAlphabet) (i : Fin R.card)
+    (ch : Fin (R.arity i) → R.Term) :
+    stepWord (dropCodeOf R) (R.spell (Term.mk R i ch)) =
+      (List.ofFn fun d ↦ R.spell (ch d)).flatten := by
+  rw [stepWord_dropCodeOf, spell_mk, List.drop_left' (R.length_code i)]
+
+/-- A paramorphism's step: it receives each child's spelling beside its value.
+Distinct from `WType.paraStep`, which pairs a subtree with its value; here the
+subtree is replaced by its spelling, so the step is a function on
+bitstrings. -/
+abbrev ParaStep (R : RankedAlphabet) :=
+  (i : Fin R.card) → (Fin (R.arity i) → List Bool × List Bool) → List Bool
+
+/-- The paramorphism as a fold, at a carrier pairing a subterm's spelling with
+its value, the value delimited so the two are separable. -/
+def algPara (R : RankedAlphabet) (phi : ParaStep R) (i : Fin R.card)
+    (f : Fin (R.arity i) → List Bool) : List Bool :=
+  entryWord (phi i fun d ↦ (dropEntrySem ![f d], takeEntrySem ![f d])) ++
+    algMk R i fun d ↦ dropEntrySem ![f d]
+
+/-- The value's second half is the spelling, whatever the step, so the
+delimiting does not nest: each level reads only this half of a child's
+value. -/
+theorem dropEntry_algPara (R : RankedAlphabet) (phi : ParaStep R) (t : R.Term) :
+    dropEntrySem ![Term.fold R (algPara R phi) t] = R.spell t :=
+  Term.induction (motive := fun t ↦
+      dropEntrySem ![Term.fold R (algPara R phi) t] = R.spell t)
+    (fun i ch ih ↦ by
+      beta_reduce
+      rw [Term.fold_mk, algPara, dropEntrySem_entryWord]
+      exact congrArg (algMk R i) (funext ih)) t
+
+/-- The step is applied to each child's spelling and value, which is the
+paramorphism's defining equation. -/
+theorem takeEntry_algPara (R : RankedAlphabet) (phi : ParaStep R)
+    (i : Fin R.card) (ch : Fin (R.arity i) → R.Term) :
+    takeEntrySem ![Term.fold R (algPara R phi) (Term.mk R i ch)] =
+      phi i fun d ↦ (R.spell (ch d),
+        takeEntrySem ![Term.fold R (algPara R phi) (ch d)]) := by
+  rw [Term.fold_mk, algPara, takeEntrySem_entryWord]
+  exact congrArg (phi i) (funext fun d ↦
+    congrArg (·, _) (dropEntry_algPara R phi (ch d)))
+
+/-- Read through its take-half, the fold at `algPara` is `WType.para` at the
+step that sees each child's spelling in place of the subtree: the recursion
+scheme is [Meertens1992]'s, computed at the bitstring representation. -/
+theorem algPara_eq_para (R : RankedAlphabet) (phi : ParaStep R) (t : R.Term) :
+    takeEntrySem ![Term.fold R (algPara R phi) t] =
+      WType.para (α := Fin R.card) (β := fun i ↦ Fin (R.arity i)) (List Bool)
+        (fun x ↦ phi x.1 fun d ↦ (R.spell (x.2 d).1, (x.2 d).2)) t :=
+  Term.induction (motive := fun t ↦
+      takeEntrySem ![Term.fold R (algPara R phi) t] =
+        WType.para (α := Fin R.card) (β := fun i ↦ Fin (R.arity i)) (List Bool)
+          (fun x ↦ phi x.1 fun d ↦ (R.spell (x.2 d).1, (x.2 d).2)) t)
+    (fun i ch ih ↦ by
+      have h := WType.para_mk (α := Fin R.card) (β := fun i ↦ Fin (R.arity i))
+        (γ := List Bool)
+        (fun x ↦ phi x.1 fun d ↦ (R.spell (x.2 d).1, (x.2 d).2)) i ch
+      exact ((takeEntry_algPara R phi i ch).trans
+        (congrArg (phi i) (funext fun d ↦ congrArg (_, ·) (ih d)))).trans h.symm) t
+
+/-- A family's lengths sum to the length of its flattening. -/
+theorem sum_ofFn_length_eq_length_flatten {n : ℕ} (g : Fin n → List Bool) :
+    (List.ofFn fun d ↦ (g d).length).sum = ((List.ofFn g).flatten).length := by
+  rw [List.length_flatten, List.map_ofFn]
+  rfl
+
+/-- The weighted length bound, over a list rather than a family: the payloads
+counted twice and the remainders together fit inside the words. -/
+private theorem two_mul_length_flatten_take_add_drop_le : ∀ l : List (List Bool),
+    2 * ((l.map fun x ↦ takeEntrySem ![x]).flatten).length +
+        ((l.map fun x ↦ dropEntrySem ![x]).flatten).length ≤ l.flatten.length :=
+  List.rec (Nat.le_refl 0) fun a t ih ↦ by
+    have h := two_mul_length_takeEntrySem_add_length_dropEntrySem_le a
+    simp only [List.map_cons, List.flatten_cons, List.length_append]
+    omega
+
+/-- A paramorphism whose step is bounded by its children's values, plus a
+constant, meets the per-symbol growth condition at `2 * cphi + R.width + 1`,
+attained at a nullary symbol. The constant is unconditional because the
+weighted bound holds at an arbitrary word rather than only at a fold's
+value. -/
+theorem growth_algPara (R : RankedAlphabet) (phi : ParaStep R) (cphi : ℕ)
+    (hphi : ∀ (i : Fin R.card) (g : Fin (R.arity i) → List Bool × List Bool),
+      (phi i g).length ≤ (List.ofFn fun d ↦ (g d).2.length).sum + cphi)
+    (i : Fin R.card) (f : Fin (R.arity i) → List Bool) :
+    (algPara R phi i f).length ≤
+      (List.ofFn fun d ↦ (f d).length).sum + (2 * cphi + R.width + 1) := by
+  have hstep := hphi i fun d ↦ (dropEntrySem ![f d], takeEntrySem ![f d])
+  have hw := two_mul_length_flatten_take_add_drop_le (List.ofFn f)
+  rw [algPara, List.length_append, length_entryWord, length_algMk]
+  simp only [List.map_ofFn, Function.comp_def, sum_ofFn_length_eq_length_flatten] at hstep hw ⊢
+  omega
+
+/-- The delimited-children algebra: the paramorphism whose step returns its
+children's spellings, each delimited. -/
+def algCh (R : RankedAlphabet) : (i : Fin R.card) →
+    (Fin (R.arity i) → List Bool) → List Bool :=
+  algPara R fun _ g ↦ (List.ofFn fun d ↦ entryWord (g d).1).flatten
+
+/-- Its value's second half is the spelling. -/
+theorem dropEntry_algCh (R : RankedAlphabet) (t : R.Term) :
+    dropEntrySem ![Term.fold R (algCh R) t] = R.spell t :=
+  dropEntry_algPara R _ t
+
+/-- Its first half is the children's spellings, each delimited, so the `j`-th
+child is `Geb.CobhamFold.entryOf j` of it. -/
+theorem takeEntry_algCh (R : RankedAlphabet) (i : Fin R.card)
+    (ch : Fin (R.arity i) → R.Term) :
+    takeEntrySem ![Term.fold R (algCh R) (Term.mk R i ch)] =
+      (List.ofFn fun d ↦ entryWord (R.spell (ch d))).flatten :=
+  takeEntry_algPara R _ i ch
+
+/-- A family's delimited spelling is the stack layout at the list it names. -/
+theorem stackWordV_ofFn {n : ℕ} (g : Fin n → List Bool) :
+    stackWordV (List.ofFn g) = (List.ofFn fun d ↦ entryWord (g d)).flatten := by
+  rw [stackWordV, List.flatMap_def, List.map_ofFn]
+  rfl
+
+/-- The value's second half is the symbol's block followed by the children's
+own second halves, whatever the arguments. -/
+theorem dropEntrySem_algCh (R : RankedAlphabet) (i : Fin R.card)
+    (f : Fin (R.arity i) → List Bool) :
+    dropEntrySem ![algCh R i f] =
+      R.code i ++ (List.ofFn fun d ↦ dropEntrySem ![f d]).flatten := by
+  rw [algCh, algPara, dropEntrySem_entryWord, algMk]
+
+/-- Its length, at arbitrary arguments: five times the children's second
+halves, two bits per child, the sentinel and the block. -/
+theorem length_algCh (R : RankedAlphabet) (i : Fin R.card)
+    (f : Fin (R.arity i) → List Bool) :
+    (algCh R i f).length =
+      5 * ((List.ofFn fun d ↦ dropEntrySem ![f d]).flatten).length +
+        2 * R.arity i + 1 + R.width := by
+  have hlen := length_stackWordV (List.ofFn fun d ↦ dropEntrySem ![f d])
+  rw [stackWordV_ofFn, stackSize] at hlen
+  rw [algCh, algPara, List.length_append, length_entryWord, length_algMk]
+  simp only [List.length_ofFn, sum_ofFn_length_eq_length_flatten] at hlen ⊢
+  omega
+
+/-- Every value the delimited-children algebra produces carries its second
+half within a fixed multiple of its own length. It needs no induction
+hypothesis, holding at arbitrary arguments, and holds with equality at a
+nullary symbol. This is what a potential argument runs over where the
+per-symbol growth condition fails: `algCh` duplicates its children's
+payloads, delimited and plain, so `|algCh R i f|` is bounded by a multiple of
+the children's total rather than by that total plus a constant. -/
+theorem five_mul_length_dropEntrySem_algCh_le (R : RankedAlphabet) (i : Fin R.card)
+    (f : Fin (R.arity i) → List Bool) :
+    5 * (dropEntrySem ![algCh R i f]).length + 1 ≤
+      (algCh R i f).length + 4 * R.width := by
+  rw [dropEntrySem_algCh, List.length_append, R.length_code, length_algCh]
+  omega
+
+/-- The per-symbol growth the delimited-children algebra meets under its own
+invariant, attained at a symbol of maximum arity whose children are all
+nullary. -/
+def chGrowth (R : RankedAlphabet) : ℕ :=
+  4 * R.maxArity * R.width + R.maxArity + R.width + 1
+
+/-- The children's second halves, bounded by their own lengths under the
+invariant, over a list rather than a family. -/
+private theorem five_mul_length_flatten_dropEntrySem_le (R : RankedAlphabet) :
+    ∀ l : List (List Bool),
+      (∀ x ∈ l, 5 * (dropEntrySem ![x]).length + 1 ≤ x.length + 4 * R.width) →
+      5 * ((l.map fun x ↦ dropEntrySem ![x]).flatten).length + l.length ≤
+        l.flatten.length + 4 * R.width * l.length :=
+  List.rec (fun _ ↦ Nat.le_refl 0) fun a t ih h ↦ by
+    have ha := h a List.mem_cons_self
+    have ht := ih fun x hx ↦ h x (List.mem_cons_of_mem a hx)
+    -- `omega` atomises `4 * R.width * (t.length + 1)` and
+    -- `4 * R.width * t.length` separately, so the step is supplied by hand.
+    have hd : 4 * R.width * (t.length + 1) = 4 * R.width * t.length + 4 * R.width := by
+      rw [Nat.mul_add, Nat.mul_one]
+    simp only [List.map_cons, List.flatten_cons, List.length_append,
+      List.length_cons]
+    omega
+
+/-- The delimited-children algebra lengthens by at most `chGrowth R` per
+symbol, at arguments satisfying the invariant its own outputs satisfy. It
+does not meet the condition at arbitrary arguments: it duplicates its
+children's payloads, delimited and plain. -/
+theorem growth_algCh_of_dropEntrySem_le (R : RankedAlphabet) (i : Fin R.card)
+    (f : Fin (R.arity i) → List Bool)
+    (hf : ∀ d, 5 * (dropEntrySem ![f d]).length + 1 ≤
+      (f d).length + 4 * R.width) :
+    (algCh R i f).length ≤
+      (List.ofFn fun d ↦ (f d).length).sum + chGrowth R := by
+  have hlist := five_mul_length_flatten_dropEntrySem_le R (List.ofFn f)
+    (fun x hx ↦ by
+      obtain ⟨d, hd⟩ := List.mem_ofFn.mp hx
+      exact hd ▸ hf d)
+  have harity : R.arity i ≤ R.maxArity := R.arity_le_maxArity i
+  -- `omega` is linear: it atomises `4 * R.width * R.arity i` and
+  -- `4 * R.maxArity * R.width` separately and has no rule taking
+  -- `R.arity i ≤ R.maxArity` from one to the other, so the monotonicity and
+  -- the commutation are supplied by hand.
+  have hmono : 4 * R.width * R.arity i ≤ 4 * R.width * R.maxArity :=
+    Nat.mul_le_mul_left _ harity
+  have hcomm : 4 * R.width * R.maxArity = 4 * R.maxArity * R.width := by
+    rw [Nat.mul_assoc, Nat.mul_comm R.width, ← Nat.mul_assoc]
+  rw [length_algCh, chGrowth, sum_ofFn_length_eq_length_flatten]
+  simp only [List.map_ofFn, Function.comp_def, List.length_ofFn] at hlist ⊢
+  omega
+
+/-- The pending values stay linear in the input at the delimited-children
+algebra, which is the hypothesis `Geb.CobhamFold.foldOutOfV` takes. The
+per-symbol growth condition does not apply, so the bound runs through the
+invariant `five_mul_length_dropEntrySem_algCh_le` and a potential argument
+over it, which charges each input bit at most `chGrowth R` and so needs no
+assumption about how the pending subterms are laid out. -/
+theorem stackSize_algCh_le (R : RankedAlphabet) (w : List Bool) :
+    stackSize (foldScanFinal R (algCh R) w).stack ≤ chGrowth R * w.length :=
+  stackSize_le_of_growth_of_invariant R (algCh R)
+    (fun v ↦ 5 * (dropEntrySem ![v]).length + 1 ≤ v.length + 4 * R.width)
+    (chGrowth R) (five_mul_length_dropEntrySem_algCh_le R) (growth_algCh_of_dropEntrySem_le R) w
+
+/-- A subterm's value is linear in that subterm, and not only in the word the
+scan reads: at a spelling the scan ends with that value alone pending, so
+`stackSize_algCh_le` there bounds the value itself, and
+`RankedAlphabet.length_spell` turns the word's length into the subterm's node
+count. -/
+theorem length_fold_algCh_le (R : RankedAlphabet) (t : R.Term) :
+    (Term.fold R (algCh R) t).length ≤ chGrowth R * (R.width * t.size) := by
+  have h := stackSize_algCh_le R (R.spell t)
+  rw [foldScanFinal, foldScanFrom_spell, length_spell] at h
+  simp only [stackSize_cons, stackSize_nil] at h
+  omega
+
+/-- The delimited-children algebra as an expression of Cobham's class. Each
+slot contributes its own second half, plain in the first argument and
+delimited in the second; `Geb.CobhamFold.flattenOf` concatenates a family
+through `Geb.CobhamFold.compOf`, so no new combinator is introduced. -/
+def algChOf (R : RankedAlphabet) (i : Fin R.card) : COf (R.arity i) :=
+  concatCompOf (R.arity i)
+    (prependOf (R.code i)
+      (compOf (flattenOf (R.arity i)) fun d ↦
+        comp1Of dropEntryOf (projOf (R.arity i) d)))
+    (comp1Of entryWordOf
+      (compOf (flattenOf (R.arity i)) fun d ↦
+        comp1Of entryWordOf (comp1Of dropEntryOf (projOf (R.arity i) d))))
+
+/-- The expression computes the algebra. -/
+theorem semAt_algChOf (R : RankedAlphabet) (i : Fin R.card)
+    (f : Fin (R.arity i) → List Bool) :
+    semAt (R.arity i) (algChOf R i).1.1 (algChOf R i).2 f = algCh R i f := by
+  rw [algChOf, semAt_concatCompOf, semAt_prependOf, semAt_comp1Of,
+    semAt_compOf, semAt_compOf, semAt_flattenOf, semAt_flattenOf, algCh,
+    algPara, algMk]
+  simp only [semAt_comp1Of, semAt_projOf, stepWord_dropEntryOf,
+    stepWord_entryWordOf]
+
+/-- The expression carries no `smash`, which is
+`Geb.CobhamFold.smashFree_foldOutExprV`'s hypothesis at this algebra. -/
+theorem smashFreeBool_algChOf (R : RankedAlphabet) (i : Fin R.card) :
+    smashFreeBool (algChOf R i).1.1.1 = true :=
+  smashFreeBool_concatCompOf (R.arity i) _ _
+    (smashFreeBool_prependOf _ _
+      (smashFreeBool_compOf _ _ (smashFreeBool_flattenOf (R.arity i))
+        fun d ↦ smashFreeBool_comp1Of _ _ smashFreeBool_dropEntryOf
+          (smashFreeBool_projOf (R.arity i) d)))
+    (smashFreeBool_comp1Of _ _ smashFreeBool_entryWordOf
+      (smashFreeBool_compOf _ _ (smashFreeBool_flattenOf (R.arity i))
+        fun d ↦ smashFreeBool_comp1Of _ _ smashFreeBool_entryWordOf
+          (smashFreeBool_comp1Of _ _ smashFreeBool_dropEntryOf
+            (smashFreeBool_projOf (R.arity i) d))))
+
+/-- Splitting a truncation one bit past a prefix.
+`Geb.CobhamFold.take_succ_append_take_one` is the same split at an arbitrary
+index. Neither reaches for `List.take_add`, which `SelfDelim.lean` records as
+`Classical.choice`-dependent. -/
+private theorem take_append_length_add_one (u rest : List Bool) :
+    (u ++ rest).take (u.length + 1) = u ++ rest.take 1 := by
+  rw [take_succ_append_take_one u.length (u ++ rest), List.take_left' rfl,
+    List.drop_left' rfl]
+
+/-- The presence marker is absorbed into the entry's unary prefix rather than
+left beside it, so the payload read from a marked value is the value's own
+payload followed by one further bit of what the entry leaves. -/
+theorem takeEntrySem_cons_true (u rest : List Bool) :
+    takeEntrySem ![true :: (entryWord u ++ rest)] = u ++ rest.take 1 := by
+  have hshape : true :: (entryWord u ++ rest) =
+      List.replicate (u.length + 1) true ++ false :: (u ++ rest) := by
+    rw [entryWord, List.replicate_succ]
+    simp only [List.cons_append, List.append_assoc]
+  rw [hshape, takeEntrySem_replicate, take_append_length_add_one]
+
+/-- The payload primitive reads nothing from a word of at most one bit. -/
+theorem takeEntrySem_of_length_le_one : ∀ r : List Bool, r.length ≤ 1 →
+    takeEntrySem ![r] = []
+  | [], _ => takeEntrySem_nil
+  | b :: t, h => by
+    have ht : t = [] := List.eq_nil_of_length_eq_zero (by
+      rw [List.length_cons] at h
+      omega)
+    rw [ht, takeEntrySem_cons]
+    cases b
+    · rw [if_neg (by simp)]
+    · rw [if_pos rfl, takeEntrySem_nil, dropEntrySem_nil, firstBitSem_eq]
+      rfl
+
+/-- Dropping entries never lengthens a word. -/
+theorem length_stepWord_dropEntriesOf_le : ∀ (k : ℕ) (r : List Bool),
+    (stepWord (dropEntriesOf k) r).length ≤ r.length :=
+  Nat.rec (fun r ↦ by rw [dropEntriesOf_zero, stepWord_idOf])
+    fun k ih r ↦ by
+      rw [stepWord_dropEntriesOf_succ]
+      exact Nat.le_trans (ih _) (length_dropEntrySem_le r)
+
+/-- Dropping entries composes. -/
+theorem stepWord_dropEntriesOf_add : ∀ (n k : ℕ) (x : List Bool),
+    stepWord (dropEntriesOf (n + k)) x =
+      stepWord (dropEntriesOf k) (stepWord (dropEntriesOf n) x) :=
+  Nat.rec (fun k x ↦ by rw [Nat.zero_add, dropEntriesOf_zero, stepWord_idOf])
+    fun n ih k x ↦ by
+      rw [Nat.succ_add, stepWord_dropEntriesOf_succ, ih k,
+        stepWord_dropEntriesOf_succ]
+
+/-- The fold's value at a constructed term, in the shape the entry
+primitives read: the children's delimited spellings as one entry, then the
+symbol's block and the children's spellings plain. -/
+theorem fold_algCh_mk (R : RankedAlphabet) (i : Fin R.card)
+    (ch : Fin (R.arity i) → R.Term) :
+    Term.fold R (algCh R) (Term.mk R i ch) =
+      entryWord (stackWordV (List.ofFn fun d ↦ R.spell (ch d))) ++
+        (R.code i ++ (List.ofFn fun d ↦ R.spell (ch d)).flatten) := by
+  rw [Term.fold_mk, algCh, algPara, stackWordV_ofFn]
+  exact congrArg (fun g ↦ entryWord ((List.ofFn fun d ↦ entryWord (g d)).flatten) ++
+      algMk R i g)
+    (funext fun d ↦ dropEntry_algPara R _ (ch d))
+
+/-- The `j`-th child's spelling, read from a term's fold value. -/
+def childSem (R : RankedAlphabet) (j : ℕ) (t : R.Term) : List Bool :=
+  stepWord (entryOf j) (takeEntrySem ![Term.fold R (algCh R) t])
+
+/-- It recovers the `j`-th child's spelling. -/
+theorem childSem_mk (R : RankedAlphabet) (i : Fin R.card)
+    (ch : Fin (R.arity i) → R.Term) (j : ℕ) (h : j < R.arity i) :
+    childSem R j (Term.mk R i ch) = R.spell (ch ⟨j, h⟩) := by
+  rw [childSem, takeEntry_algCh, ← stackWordV_ofFn,
+    stepWord_entryOf_stackWordV,
+    List.drop_eq_getElem_cons (by rw [List.length_ofFn]; exact h)]
+  exact List.getElem_ofFn _
+
+/-- And returns the empty word past the last child, so it is total. -/
+theorem childSem_of_le (R : RankedAlphabet) (i : Fin R.card)
+    (ch : Fin (R.arity i) → R.Term) (j : ℕ) (h : R.arity i ≤ j) :
+    childSem R j (Term.mk R i ch) = [] := by
+  rw [childSem, takeEntry_algCh, ← stackWordV_ofFn,
+    stepWord_entryOf_stackWordV,
+    List.drop_eq_nil_of_le (by rw [List.length_ofFn]; exact h)]
+  rfl
+
+/-- The delimited-children fold as an expression, at its declared arity. The
+multiplier is `foldOutOfV`'s bound taken with equality, so it carries no
+hypothesis of its own. -/
+def chFoldOf (R : RankedAlphabet) : COf 1 :=
+  foldOutOfV R (algChOf R) (algCh R) (semAt_algChOf R) (2 * chGrowth R + 2)
+    (chGrowth R) (stackSize_algCh_le R) (Nat.le_refl _)
+
+/-- The `j`-th child's spelling, as an expression of Cobham's class: the
+`j`-th entry of the fold's payload. -/
+def childOf (R : RankedAlphabet) (j : ℕ) : COf 1 :=
+  comp1Of (entryOf j) (comp1Of takeEntryOf (chFoldOf R))
+
+/-- The fold expression's value, spelled by `Geb.CobhamFold.outWordV`. -/
+theorem stepWord_chFoldOf (R : RankedAlphabet) (w : List Bool) :
+    stepWord (chFoldOf R) w = outWordV (foldOut R (algCh R) w) :=
+  foldOutSemV_eq R (algChOf R) (algCh R) (semAt_algChOf R)
+    (2 * chGrowth R + 2) (chGrowth R) (stackSize_algCh_le R) (Nat.le_refl _) w
+
+/-- The `j`-th child's spelling, recovered from the spelling of the term. -/
+theorem stepWord_childOf (R : RankedAlphabet) (i : Fin R.card)
+    (ch : Fin (R.arity i) → R.Term) (j : ℕ) (h : j < R.arity i) :
+    stepWord (childOf R j) (R.spell (Term.mk R i ch)) = R.spell (ch ⟨j, h⟩) := by
+  have hlen : (List.ofFn fun d ↦ R.spell (ch d)).length = R.arity i :=
+    List.length_ofFn
+  rw [childOf, stepWord_comp1Of, stepWord_comp1Of, stepWord_takeEntryOf,
+    stepWord_chFoldOf, foldOut_spell]
+  change stepWord (entryOf j)
+    (takeEntrySem ![true :: Term.fold R (algCh R) (Term.mk R i ch)]) = _
+  rw [fold_algCh_mk, takeEntrySem_cons_true,
+    stepWord_entryOf_stackWordV_append j _ _ (by rw [hlen]; exact h),
+    List.getElem_ofFn]
+
+/-- And the empty word past the last child, so the expression is total. -/
+theorem stepWord_childOf_of_le (R : RankedAlphabet) (i : Fin R.card)
+    (ch : Fin (R.arity i) → R.Term) (j : ℕ) (h : R.arity i ≤ j) :
+    stepWord (childOf R j) (R.spell (Term.mk R i ch)) = [] := by
+  have hlen : (List.ofFn fun d ↦ R.spell (ch d)).length = R.arity i :=
+    List.length_ofFn
+  have hshort : ((R.code i ++
+      (List.ofFn fun d ↦ R.spell (ch d)).flatten).take 1).length ≤ 1 :=
+    Nat.le_trans (Nat.le_of_eq List.length_take) (Nat.min_le_left 1 _)
+  rw [childOf, stepWord_comp1Of, stepWord_comp1Of, stepWord_takeEntryOf,
+    stepWord_chFoldOf, foldOut_spell]
+  change stepWord (entryOf j)
+    (takeEntrySem ![true :: Term.fold R (algCh R) (Term.mk R i ch)]) = _
+  rw [fold_algCh_mk, takeEntrySem_cons_true, stepWord_entryOf,
+    ← Nat.add_sub_cancel' h, stepWord_dropEntriesOf_add,
+    stepWord_dropEntriesOf_stackWordV_append (R.arity i) _ _ (by rw [hlen]),
+    List.drop_eq_nil_of_le (Nat.le_of_eq hlen), stackWordV_nil,
+    List.nil_append]
+  exact takeEntrySem_of_length_le_one _
+    (Nat.le_trans (length_stepWord_dropEntriesOf_le _ _) hshort)
+
+/-- The delimited-children fold carries no `smash`, its algebra's own
+expressions carrying none. -/
+theorem smashFreeBool_chFoldOf (R : RankedAlphabet) :
+    smashFreeBool (chFoldOf R).1.1.1 = true :=
+  smashFree_foldOutExprV R (algChOf R) (smashFreeBool_algChOf R) (algCh R)
+    (semAt_algChOf R) (2 * chGrowth R + 2) (chGrowth R) (stackSize_algCh_le R)
+    (Nat.le_refl _)
+
+/-- So does the child reader, so with [Strahm2003] Theorem 1(2)'s
+left-to-right inclusion it is computable simultaneously in polynomial time
+and linear space. -/
+theorem smashFreeBool_childOf (R : RankedAlphabet) (j : ℕ) :
+    smashFreeBool (childOf R j).1.1.1 = true :=
+  smashFreeBool_comp1Of _ _ (smashFreeBool_entryOf j)
+    (smashFreeBool_comp1Of _ _ smashFreeBool_takeEntryOf
+      (smashFreeBool_chFoldOf R))
+
+/-- The term algebra's destructor at the `RankedAlphabet.Term.mk`
+presentation. `WType.ofSigma_toSigma` is the other inverse law, which mathlib
+already carries. -/
+theorem toSigma_mk (R : RankedAlphabet) (i : Fin R.card)
+    (ch : Fin (R.arity i) → R.Term) :
+    WType.toSigma (Term.mk R i ch) = ⟨i, ch⟩ := rfl
+
+/-- The constructor's expression at the children's spellings is the spelling
+of the term they build. Under the preorder encoding the structure map is the
+identity on representations, which is what `RankedAlphabet.spell_mk`
+states. -/
+theorem semAt_mkOf_spell (R : RankedAlphabet) (i : Fin R.card)
+    (ch : Fin (R.arity i) → R.Term) :
+    semAt (R.arity i) (mkOf R i).1.1 (mkOf R i).2 (fun d ↦ R.spell (ch d)) =
+      R.spell (Term.mk R i ch) := by
+  rw [semAt_mkOf, algMk, ← spell_mk]
+
+/-- The constructor at the children the destructor reads returns the word.
+It is stated under `R.parse w = some (Term.mk R i ch)` with `i` given rather
+than read, so no dispatch over the block is needed; `Geb.CobhamFold.childOf`
+and `Geb.CobhamFold.mkOf` are total and return an unspecified word off the
+recognized language. -/
+theorem semAt_mkOf_childOf (R : RankedAlphabet) (i : Fin R.card)
+    (ch : Fin (R.arity i) → R.Term) (w : List Bool)
+    (hw : R.parse w = some (Term.mk R i ch)) :
+    semAt (R.arity i) (mkOf R i).1.1 (mkOf R i).2
+        (fun d ↦ stepWord (childOf R d.val) w) = w := by
+  have hspell : R.spell (Term.mk R i ch) = w := R.parse_eq_some_iff.mp hw
+  have hchild : (fun d : Fin (R.arity i) ↦ stepWord (childOf R d.val) w) =
+      fun d ↦ R.spell (ch d) := by
+    funext d
+    rw [← hspell, stepWord_childOf R i ch d.val d.isLt]
+  rw [semAt_mkOf, algMk, hchild, ← spell_mk, hspell]
+
+end Geb.CobhamFold
+
+end

--- a/geb-lean/vendor/geb-mathlib/Geb/Internal/Computability/CobhamFoldProto/Expr.lean
+++ b/geb-lean/vendor/geb-mathlib/Geb/Internal/Computability/CobhamFoldProto/Expr.lean
@@ -1,0 +1,391 @@
+/-
+Copyright (c) 2026 Terence Rokop. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Terence Rokop
+-/
+module
+
+public import Geb.Internal.Computability.CobhamFoldProto.Bound
+public import Geb.Internal.Computability.CobhamFoldProto.Layout
+
+/-!
+# The fold over recognized terms as an expression of Cobham's class
+
+The fold scan of `Geb/Internal/Computability/CobhamFoldProto/Fold.lean`, laid
+out as a bitstring by
+`Geb/Internal/Computability/CobhamFoldProto/Layout.lean`, carried by the scan
+combinator of `Geb/Internal/Computability/CobhamFoldProto/Bound.lean`, and
+composed with a readout into an expression computing
+`RankedAlphabet.parse` followed by the fold.
+
+At `p = 0` and the carrier `Unit` this construction meets the recognizer of
+`Geb/Mathlib/Computability/Cobham/RankedTree.lean`; the module
+`Geb/Internal/Computability/CobhamFoldProto/Degenerate.lean` identifies the
+state layout, the dispatch window, the readout window and the step, and the two
+accept the same language. They are not the same expression.
+The raw trees differ — `Geb.CobhamFold.boundMulRaw_ne_boundRaw` separates the
+two bound children at multiplicity one, at every growth — and the rejecting
+words differ, this module's `outWord` spelling both branches at the width
+`p + 1` where
+`Cobham.isRankedSem_eq_ite` gives the empty bitstring.
+
+## Main definitions
+
+* `Geb.CobhamFold.foldStepF` — one step of the scan, as an expression of arity
+  one.
+* `Geb.CobhamFold.foldGrowth` — the growth the state layout's fixed part
+  contributes.
+* `Geb.CobhamFold.foldSemF` — the meaning of the scan.
+* `Geb.CobhamFold.foldExprF`, `Geb.CobhamFold.foldExprOfF` — the scan as an
+  expression of `Cobham.C`, and at its declared arity.
+* `Geb.CobhamFold.readoutWidth`, `Geb.CobhamFold.outWord`,
+  `Geb.CobhamFold.readState`, `Geb.CobhamFold.readOf` — the readout's window,
+  its output word, the `Option` it reads off the window, and the readout as an
+  expression.
+* `Geb.CobhamFold.foldOutOf`, `Geb.CobhamFold.foldOutExpr`,
+  `Geb.CobhamFold.foldOutSem` — the readout composed onto the scan by
+  `Geb.CobhamFold.comp1Of`.
+
+## Main statements
+
+* `Geb.CobhamFold.stepWord_foldStepF_of_lt` — a step of the expression computes
+  a step of the fold scan.
+* `Geb.CobhamFold.foldSemF_eq` — the expression computes the fold scan's state
+  word on every input.
+* `Geb.CobhamFold.length_foldSemF_le` — the recursion bound the scan combinator
+  asks for, at a multiplier covering one stack entry per symbol block.
+* `Geb.CobhamFold.length_outWord`, `Geb.CobhamFold.headD_outWord`,
+  `Geb.CobhamFold.bits_tail_outWord` — the output's width, the marker separating
+  its two branches, and the recoverability of the value.
+* `Geb.CobhamFold.stepWord_readOf` — the readout's value at the state it reads.
+* `Geb.CobhamFold.foldOutSem_eq` — the composition computes
+  `Geb.CobhamFold.foldOut`, spelled by `outWord`.
+
+* `Geb.CobhamFold.foldOutSem_eq_parse` — the same value read as
+  `RankedAlphabet.parse` followed by the algebra morphism.
+* `Geb.CobhamFold.foldSemF_eq_eval`, `Geb.CobhamFold.foldOutSem_eq_eval` — the
+  meanings read at the raw trees are the meanings the expressions carry.
+
+## Implementation notes
+
+The multiplier is a parameter constrained by `p + 1 ≤ mult * R.width`, rather
+than fixed at `p + 1`. The state carries one `(p + 1)`-bit entry per pending
+subterm and the pending count rises once per `R.width` input bits — that is
+`Geb.CobhamFold.width_mul_depth_scanFinal_le` — so any multiplier meeting the
+inequality bounds the state. `mult = p + 1` always meets it,
+`RankedAlphabet.width_pos` giving `1 ≤ R.width`; a wide alphabet admits a
+smaller one.
+
+The readout reads two stack entries: one to carry the value, and one more whose
+marker distinguishes a stack of exactly one entry from a longer one. That is the
+`Cobham.acceptWord R ++ [false]` of the recognizer's verdict test, one entry
+wide rather than one bit wide.
+
+`outWord` spells `none` as a `false` marker followed by `p` `false` bits, so
+both branches have the width `p + 1`, and the marker alone separates them.
+A rejected word receives that word rather than merely something other than an
+accepted one, which is the discipline `Cobham.isRankedSem_eq_ite` records.
+
+`readState` tests the decoded state's three fields rather than matching on its
+stack: a match whose pattern fixes the stack's length does not reduce at a
+variable stack.
+
+## References
+
+* [Cobham1965]
+
+## Tags
+
+Cobham, bounded recursion on notation, ranked alphabet, fold, catamorphism
+-/
+
+@[expose] public section
+
+namespace Geb.CobhamFold
+
+open Cobham RankedAlphabet
+
+universe u
+
+variable {α : Type u} {p : ℕ}
+
+/-- One step of the fold expression: dispatch on the state's leading bits,
+prepend the rebuilt prefix and drop the consumed bits. Every branch has that one
+shape. -/
+def foldStepF (R : RankedAlphabet) (p : ℕ) (enc : α → Fin p → Bool)
+    (dec : (Fin p → Bool) → α)
+    (alg : (i : Fin R.card) → (Fin (R.arity i) → α) → α) (b : Bool) : COf 1 :=
+  diagOf (casesOf (dispatchWidthF R p) fun v ↦
+    prependOf (nextPrefixF R enc alg b (decodeStateF R p dec v))
+      (predIterOf (dropCountF R p b (decodeStateF R p dec v))))
+
+/-- A step of the expression computes a step of the fold scan, on a state whose
+incomplete block is short of the width. This is where the decoder, the two
+truncation lemmas and the step lemma meet. -/
+theorem stepWord_foldStepF_of_lt (R : RankedAlphabet) (p : ℕ)
+    (enc : α → Fin p → Bool) (dec : (Fin p → Bool) → α)
+    (hdec : ∀ a, dec (enc a) = a)
+    (alg : (i : Fin R.card) → (Fin (R.arity i) → α) → α) (b : Bool)
+    (s : FoldScan α) (h : s.buf.length < R.width) :
+    stepWord (foldStepF R p enc dec alg b) (stateWordF R enc s) =
+      stateWordF R enc (foldScanStep R alg b s) := by
+  rw [foldStepF, stepWord_diagOf]
+  change casesSem (dispatchWidthF R p) _ ![stateWordF R enc s, stateWordF R enc s] = _
+  rw [casesSem_eq, stepWord_prependOf, stepWord_predIterOf,
+    decodeStateF_stateWordF_of_lt R dec enc hdec s h, nextPrefixF_take_stack,
+    dropCountF_take_stack, stateWordF_foldScanStep_of_lt R enc alg b s h]
+
+/-- The growth the state layout's fixed part contributes: the flag and the
+slot. -/
+def foldGrowth (R : RankedAlphabet) : ℕ := 1 + R.width
+
+/-- The fold expression's scan, at the two steps and the multiplicative
+bound. -/
+def foldSemF (R : RankedAlphabet) (p : ℕ) (enc : α → Fin p → Bool)
+    (dec : (Fin p → Bool) → α)
+    (alg : (i : Fin R.card) → (Fin (R.arity i) → α) → α) (mult : ℕ) : Sem 1 :=
+  scanBSem (constAtOf 0 (stateWordF R enc ⟨[], [], true⟩))
+    (foldStepF R p enc dec alg false) (foldStepF R p enc dec alg true)
+    (boundMulRaw mult (foldGrowth R)) (wValid_boundMulRaw mult (foldGrowth R))
+    (wIndexRoot_boundMulRaw mult (foldGrowth R))
+
+/-- The expression computes the fold scan's state word on every input. -/
+theorem foldSemF_eq (R : RankedAlphabet) (p : ℕ) (enc : α → Fin p → Bool)
+    (dec : (Fin p → Bool) → α) (hdec : ∀ a, dec (enc a) = a)
+    (alg : (i : Fin R.card) → (Fin (R.arity i) → α) → α) (mult : ℕ)
+    (w : List Bool) :
+    foldSemF R p enc dec alg mult ![w] =
+      stateWordF R enc (foldScanFinal R alg w) := by
+  rw [foldSemF, scanBSem_eq]
+  refine List.rec ?_ ?_ w
+  · rw [List.foldr_nil, baseWord_constAtOf]
+    rfl
+  · intro b v ih
+    rw [List.foldr_cons, ih]
+    cases b
+    · exact stepWord_foldStepF_of_lt R p enc dec hdec alg false _
+        (length_buf_foldScanFinal_lt R alg v)
+    · exact stepWord_foldStepF_of_lt R p enc dec hdec alg true _
+        (length_buf_foldScanFinal_lt R alg v)
+
+/-- The recursion bound the scan combinator asks for. The state carries one
+`(p + 1)`-bit entry per pending subterm, and the pending count rises once per
+`R.width` input bits, so a multiplier covering one entry per block bounds the
+state. Stated at `scanBSem`, which is the form `scanMul` consumes. -/
+theorem length_foldSemF_le (R : RankedAlphabet) (p : ℕ) (enc : α → Fin p → Bool)
+    (dec : (Fin p → Bool) → α) (hdec : ∀ a, dec (enc a) = a)
+    (alg : (i : Fin R.card) → (Fin (R.arity i) → α) → α) (mult : ℕ)
+    (hmult : p + 1 ≤ mult * R.width) (w : List Bool) :
+    (scanBSem (constAtOf 0 (stateWordF R enc ⟨[], [], true⟩))
+      (foldStepF R p enc dec alg false) (foldStepF R p enc dec alg true)
+      (boundMulRaw mult (foldGrowth R)) (wValid_boundMulRaw mult (foldGrowth R))
+      (wIndexRoot_boundMulRaw mult (foldGrowth R))
+      ![w]).length ≤ mult * w.length + foldGrowth R := by
+  have hstate : (scanBSem (constAtOf 0 (stateWordF R enc ⟨[], [], true⟩))
+      (foldStepF R p enc dec alg false) (foldStepF R p enc dec alg true)
+      (boundMulRaw mult (foldGrowth R)) (wValid_boundMulRaw mult (foldGrowth R))
+      (wIndexRoot_boundMulRaw mult (foldGrowth R)) ![w]).length =
+      1 + R.width + (p + 1) * (R.scanFinal w).depth := by
+    rw [← foldSemF, foldSemF_eq R p enc dec hdec alg mult w,
+      length_stateWordF_of_lt R enc _ (length_buf_foldScanFinal_lt R alg w),
+      length_stack_foldScanFinal]
+  have hd : R.width * (R.scanFinal w).depth ≤ w.length :=
+    width_mul_depth_scanFinal_le R w
+  have h1 : (p + 1) * (R.scanFinal w).depth ≤
+      mult * R.width * (R.scanFinal w).depth :=
+    Nat.mul_le_mul_right _ hmult
+  have h2 : mult * R.width * (R.scanFinal w).depth =
+      mult * (R.width * (R.scanFinal w).depth) := Nat.mul_assoc _ _ _
+  have h3 : mult * (R.width * (R.scanFinal w).depth) ≤ mult * w.length :=
+    Nat.mul_le_mul_left _ hd
+  rw [hstate, foldGrowth]
+  omega
+
+/-- The scan as a member of `Cobham.C`, at its arity: the form consumers take,
+`foldExprF` being its underlying expression. -/
+def foldExprOfF (R : RankedAlphabet) (p : ℕ) (enc : α → Fin p → Bool)
+    (dec : (Fin p → Bool) → α) (hdec : ∀ a, dec (enc a) = a)
+    (alg : (i : Fin R.card) → (Fin (R.arity i) → α) → α) (mult : ℕ)
+    (hmult : p + 1 ≤ mult * R.width) : COf 1 :=
+  scanMulOf (constAtOf 0 (stateWordF R enc ⟨[], [], true⟩))
+    (foldStepF R p enc dec alg false) (foldStepF R p enc dec alg true)
+    mult (foldGrowth R) (length_foldSemF_le R p enc dec hdec alg mult hmult)
+
+/-- The scan as an expression of Cobham's class, its recursion bound discharged
+by `length_foldSemF_le`. -/
+def foldExprF (R : RankedAlphabet) (p : ℕ) (enc : α → Fin p → Bool)
+    (dec : (Fin p → Bool) → α) (hdec : ∀ a, dec (enc a) = a)
+    (alg : (i : Fin R.card) → (Fin (R.arity i) → α) → α) (mult : ℕ)
+    (hmult : p + 1 ≤ mult * R.width) : C :=
+  (foldExprOfF R p enc dec hdec alg mult hmult).1
+
+/-- The meaning `foldSemF` reads at the raw tree is the meaning `foldExprF`
+carries. -/
+theorem foldSemF_eq_eval (R : RankedAlphabet) (p : ℕ) (enc : α → Fin p → Bool)
+    (dec : (Fin p → Bool) → α) (hdec : ∀ a, dec (enc a) = a)
+    (alg : (i : Fin R.card) → (Fin (R.arity i) → α) → α) (mult : ℕ)
+    (hmult : p + 1 ≤ mult * R.width) :
+    transport (foldExprOfF R p enc dec hdec alg mult hmult).2
+        (foldExprOfF R p enc dec hdec alg mult hmult).1.eval =
+      foldSemF R p enc dec alg mult := rfl
+
+/-- The number of state bits the readout dispatches on: the flag, the slot, and
+two stack entries. -/
+def readoutWidth (R : RankedAlphabet) (p : ℕ) : ℕ := 1 + R.width + (p + 1) * 2
+
+/-- The readout's output word: a marked encoding at a value, and a `false`
+marker followed by `p` `false` bits at none. Both branches have width
+`p + 1`. -/
+def outWord (enc : α → Fin p → Bool) : Option α → List Bool
+  | none => false :: List.replicate p false
+  | some a => entryBits enc a
+
+/-- Both branches of the output have an entry's width, so the leading marker
+alone separates them. -/
+theorem length_outWord (enc : α → Fin p → Bool) :
+    ∀ x : Option α, (outWord enc x).length = p + 1
+  | none => by rw [outWord, List.length_cons, List.length_replicate]
+  | some a => length_entryBits enc a
+
+/-- The output's leading marker is set exactly at a value, so a consumer
+separates the two branches by one bit. -/
+theorem headD_outWord (enc : α → Fin p → Bool) :
+    ∀ x : Option α, (outWord enc x).headD false = x.isSome
+  | none => rfl
+  | some _ => rfl
+
+/-- The carrier value is recoverable from the output: past the marker the
+output is the encoding, which a retraction inverts. -/
+theorem bits_tail_outWord (enc : α → Fin p → Bool) (a : α) :
+    bits p (outWord enc (some a)).tail = enc a := by
+  rw [outWord, entryBits, List.tail_cons, bits_ofFn]
+
+/-- The `Option` the readout reads off its window: the top of the stack when the
+state is live, carries no incomplete block and holds exactly one entry. The
+three tests are those of `Geb.CobhamFold.foldOut`. -/
+def readState (R : RankedAlphabet) (p : ℕ) (dec : (Fin p → Bool) → α)
+    (v : Fin (readoutWidth R p) → Bool) : Option α :=
+  if (decodeStateAt R p dec (readoutWidth R p) 2 v).live &&
+      (decodeStateAt R p dec (readoutWidth R p) 2 v).buf.isEmpty &&
+      (decodeStateAt R p dec (readoutWidth R p) 2 v).stack.length == 1 then
+    (decodeStateAt R p dec (readoutWidth R p) 2 v).stack.head?
+  else none
+
+/-- The readout as an expression of arity one: a dispatch on the verdict window
+whose every branch is a constant word. -/
+def readOf (R : RankedAlphabet) (p : ℕ) (enc : α → Fin p → Bool)
+    (dec : (Fin p → Bool) → α) : COf 1 :=
+  diagOf (casesOf (readoutWidth R p) fun v ↦
+    constAtOf 1 (outWord enc (readState R p dec v)))
+
+/-- The readout's value at the state it reads. -/
+theorem stepWord_readOf (R : RankedAlphabet) (p : ℕ) (enc : α → Fin p → Bool)
+    (dec : (Fin p → Bool) → α) (u : List Bool) :
+    stepWord (readOf R p enc dec) u =
+      outWord enc (readState R p dec (bits (readoutWidth R p) u)) := by
+  rw [readOf, stepWord_diagOf]
+  change casesSem (readoutWidth R p) _ ![u, u] = _
+  rw [casesSem_eq, stepWord_constAtOf]
+
+/-- The readout at the state word of a fold scan is the fold's `Option`. The
+decoder truncates the stack at two entries, which leaves all three tests
+unchanged: the marker of the second entry is what separates a stack of one from
+a longer one. -/
+theorem readState_stateWordF (R : RankedAlphabet) (p : ℕ)
+    (enc : α → Fin p → Bool) (dec : (Fin p → Bool) → α)
+    (hdec : ∀ a, dec (enc a) = a) (s : FoldScan α)
+    (h : s.buf.length < R.width) :
+    readState R p dec (bits (readoutWidth R p) (stateWordF R enc s)) =
+      (if s.live && s.buf.isEmpty && s.stack.length == 1 then s.stack.head?
+        else none) := by
+  have hdecode := decodeStateAt_stateWordF_of_lt R dec enc hdec s
+    (readoutWidth R p) 2 (by rw [readoutWidth]) h
+  rw [readState, hdecode]
+  dsimp only
+  have hlen : (s.stack.take 2).length = min 2 s.stack.length := List.length_take
+  by_cases hone : s.stack.length = 1
+  · have h2 : (s.stack.take 2).length = 1 := by
+      rw [hlen, hone]
+      omega
+    have hhead : (s.stack.take 2).head? = s.stack.head? := by
+      match s.stack with
+      | [] => rfl
+      | _ :: _ => rfl
+    rw [h2, hhead, hone]
+  · have h2 : ¬ (s.stack.take 2).length = 1 := by
+      rw [hlen]
+      omega
+    rw [Bool.and_eq_false_imp.mpr fun _ ↦ beq_eq_false_iff_ne.mpr h2,
+      Bool.and_eq_false_imp.mpr fun _ ↦ beq_eq_false_iff_ne.mpr hone]
+    rfl
+
+/-- The readout composed onto the scan, at its declared arity. -/
+def foldOutOf (R : RankedAlphabet) (p : ℕ) (enc : α → Fin p → Bool)
+    (dec : (Fin p → Bool) → α) (hdec : ∀ a, dec (enc a) = a)
+    (alg : (i : Fin R.card) → (Fin (R.arity i) → α) → α) (mult : ℕ)
+    (hmult : p + 1 ≤ mult * R.width) : COf 1 :=
+  comp1Of (readOf R p enc dec) (foldExprOfF R p enc dec hdec alg mult hmult)
+
+/-- The fold as an expression of Cobham's class: the value of a bitstring's
+term, spelled, and the absent value at a bitstring spelling no term. -/
+def foldOutExpr (R : RankedAlphabet) (p : ℕ) (enc : α → Fin p → Bool)
+    (dec : (Fin p → Bool) → α) (hdec : ∀ a, dec (enc a) = a)
+    (alg : (i : Fin R.card) → (Fin (R.arity i) → α) → α) (mult : ℕ)
+    (hmult : p + 1 ≤ mult * R.width) : C :=
+  (foldOutOf R p enc dec hdec alg mult hmult).1
+
+/-- The fold's meaning at its arity, read at the raw tree. -/
+def foldOutSem (R : RankedAlphabet) (p : ℕ) (enc : α → Fin p → Bool)
+    (dec : (Fin p → Bool) → α) (hdec : ∀ a, dec (enc a) = a)
+    (alg : (i : Fin R.card) → (Fin (R.arity i) → α) → α) (mult : ℕ)
+    (hmult : p + 1 ≤ mult * R.width) : Sem 1 :=
+  semAt 1 (foldOutOf R p enc dec hdec alg mult hmult).1.1
+    (foldOutOf R p enc dec hdec alg mult hmult).2
+
+/-- The meaning `foldOutSem` reads at the raw tree is the meaning `foldOutExpr`
+carries. -/
+theorem foldOutSem_eq_eval (R : RankedAlphabet) (p : ℕ) (enc : α → Fin p → Bool)
+    (dec : (Fin p → Bool) → α) (hdec : ∀ a, dec (enc a) = a)
+    (alg : (i : Fin R.card) → (Fin (R.arity i) → α) → α) (mult : ℕ)
+    (hmult : p + 1 ≤ mult * R.width) :
+    transport (foldOutOf R p enc dec hdec alg mult hmult).2
+        (foldOutOf R p enc dec hdec alg mult hmult).1.eval =
+      foldOutSem R p enc dec hdec alg mult hmult := rfl
+
+/-- One step of the fold: the readout on the scan's value. -/
+theorem foldOutSem_apply (R : RankedAlphabet) (p : ℕ) (enc : α → Fin p → Bool)
+    (dec : (Fin p → Bool) → α) (hdec : ∀ a, dec (enc a) = a)
+    (alg : (i : Fin R.card) → (Fin (R.arity i) → α) → α) (mult : ℕ)
+    (hmult : p + 1 ≤ mult * R.width) (w : List Bool) :
+    foldOutSem R p enc dec hdec alg mult hmult ![w] =
+      stepWord (readOf R p enc dec) (foldSemF R p enc dec alg mult ![w]) :=
+  congrArg (semAt 1 (readOf R p enc dec).1.1 (readOf R p enc dec).2)
+    (funext fun i ↦ match i with | ⟨0, _⟩ => rfl)
+
+/-- The expression computes the fold: at a bitstring spelling a term, the marked
+encoding of that term's value under the algebra, and at every other bitstring
+the absent value. -/
+theorem foldOutSem_eq (R : RankedAlphabet) (p : ℕ) (enc : α → Fin p → Bool)
+    (dec : (Fin p → Bool) → α) (hdec : ∀ a, dec (enc a) = a)
+    (alg : (i : Fin R.card) → (Fin (R.arity i) → α) → α) (mult : ℕ)
+    (hmult : p + 1 ≤ mult * R.width) (w : List Bool) :
+    foldOutSem R p enc dec hdec alg mult hmult ![w] =
+      outWord enc (foldOut R alg w) := by
+  rw [foldOutSem_apply, foldSemF_eq R p enc dec hdec alg mult w, stepWord_readOf,
+    readState_stateWordF R p enc dec hdec _ (length_buf_foldScanFinal_lt R alg w),
+    foldOut]
+
+/-- The expression computes the decoding followed by the fold: the unique
+algebra morphism out of the term algebra, read off a preorder spelling. -/
+theorem foldOutSem_eq_parse (R : RankedAlphabet) (p : ℕ)
+    (enc : α → Fin p → Bool) (dec : (Fin p → Bool) → α)
+    (hdec : ∀ a, dec (enc a) = a)
+    (alg : (i : Fin R.card) → (Fin (R.arity i) → α) → α) (mult : ℕ)
+    (hmult : p + 1 ≤ mult * R.width) (w : List Bool) :
+    foldOutSem R p enc dec hdec alg mult hmult ![w] =
+      outWord enc ((R.parse w).map (Term.fold R alg)) := by
+  rw [foldOutSem_eq, foldOut_eq]
+
+end Geb.CobhamFold
+
+end

--- a/geb-lean/vendor/geb-mathlib/Geb/Internal/Computability/CobhamFoldProto/Fold.lean
+++ b/geb-lean/vendor/geb-mathlib/Geb/Internal/Computability/CobhamFoldProto/Fold.lean
@@ -1,0 +1,574 @@
+/-
+Copyright (c) 2026 Terence Rokop. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Terence Rokop
+-/
+-- Modified from geb-mathlib by scripts/geb-mathlib-backport.patch.
+module
+
+public import Geb.Mathlib.Data.Tree.Ranked.Preorder
+import Geb.Mathlib.Data.W.Basic
+
+/-!
+# The fold scan of a preorder spelling
+
+`RankedAlphabet.scanStep` reads a preorder spelling right to left, carrying an
+incomplete block, a count of pending subterms and a liveness flag. At a
+completed block the symbol pops its arity from the count and pushes one, so the
+count is the height of a stack whose entries carry no data.
+
+This module replaces that count by a stack of values of an arbitrary carrier
+and the pop-push by an application of an algebra of the ranked alphabet.
+`toScan` projects the resulting state onto `RankedAlphabet.Scan` by taking the
+stack's length, and `toScan_foldScanStep` shows the projection is a step
+homomorphism at every carrier and every algebra: the validity scan is the
+image of the fold scan under the terminal map, not a separate construction.
+
+`foldOut` reads the final state as an `Option`, absent exactly where the word
+spells no term, and `foldOut_eq` identifies it with `RankedAlphabet.parse`
+followed by the fold. `R.Term` is the initial algebra of the alphabet, so that
+fold is the unique algebra morphism out of it.
+
+## Main definitions
+
+* `Geb.CobhamFold.symOf` — the symbol a block denotes, refining
+  `RankedAlphabet.arOf`, which returns only its arity.
+* `Geb.CobhamFold.Term.fold` — the unique algebra morphism out of the term
+  algebra.
+* `Geb.CobhamFold.FoldScan` — the fold scan's state.
+* `Geb.CobhamFold.foldScanStep`, `Geb.CobhamFold.foldScanFrom`,
+  `Geb.CobhamFold.foldScanFinal` — one step, the scan from a state, and the
+  scan from the initial state.
+* `Geb.CobhamFold.toScan` — the projection onto `RankedAlphabet.Scan`.
+* `Geb.CobhamFold.foldOut` — the final state read as an `Option`.
+
+## Main statements
+
+* `Geb.CobhamFold.arOf_eq_map_symOf` — `RankedAlphabet.arOf` is `symOf`
+  followed by the arity.
+* `Geb.CobhamFold.toScan_foldScanStep`, `Geb.CobhamFold.toScan_foldScanFinal` —
+  the projection is a step homomorphism, and carries the whole scan.
+* `Geb.CobhamFold.mem_stack_foldScanFinal` — every value on the scan's stack
+  is one the algebra produced.
+* `Geb.CobhamFold.foldScanFrom_code` — a completed block pops its arity's worth
+  of stack and pushes the algebra applied to them.
+* `Geb.CobhamFold.foldScanFrom_ofFn` — a family of spellings pushes one value
+  each, in index order.
+* `Geb.CobhamFold.foldScanFrom_spell` — a spelling pushes one value, the fold
+  of the term it spells.
+* `Geb.CobhamFold.Term.fold_unique` — the term algebra is initial, so `Term.fold`
+  is the algebra morphism out of it rather than one of several.
+* `Geb.CobhamFold.Term.fold_map`, `Geb.CobhamFold.foldOut_map` — fold fusion,
+  and the agreement of two folds at different carriers whose algebras commute
+  with a map.
+* `Geb.CobhamFold.foldOut_eq` — the fold scan computes `RankedAlphabet.parse`
+  followed by `Term.fold`.
+* `Geb.CobhamFold.buf_foldScanFinal`,
+  `Geb.CobhamFold.length_stack_foldScanFinal`,
+  `Geb.CobhamFold.length_buf_foldScanFinal_lt` — the projection's consequences
+  for the incomplete block and the stack's height, which every state layout over
+  this scan consumes.
+* `Geb.CobhamFold.width_mul_depth_add_length_buf_scanFinal_le` — the sharper
+  bound on the pending count: the alphabet's width times the count, plus the
+  incomplete block, is at most the word's length.
+* `Geb.CobhamFold.width_mul_depth_scanFinal_le` — its corollary dropping the
+  incomplete block, `R.width * depth ≤ |w|`.
+
+## Implementation notes
+
+The stack's head is the value of the term spelled immediately to the right of
+the symbol being read, which is that symbol's child zero: scanning right to
+left, `RankedAlphabet.scanFrom_append` reads the later part of a word first, so
+within a symbol's children the last one scanned — and so the one pushed last —
+is child zero. `foldScanStep` therefore indexes the algebra's argument by
+position in the stack directly.
+
+`foldScanStep` branches by `dite` where `RankedAlphabet.scanStep` branches by a
+`match` on `decide`: the arity branch needs the comparison's proof to index the
+stack, which a `match` on a `Bool` does not supply.
+
+`symOf` is what `RankedAlphabet.arOf` would be if the scan needed the symbol
+rather than its arity; `arOf_eq_map_symOf` is what makes the two scans branch
+alike, and so what `toScan_foldScanStep` rests on.
+
+`width_mul_depth_add_length_buf_scanFinal_le` sharpens
+`RankedAlphabet.depth_scanFinal_le_length` by the alphabet's width. The pending
+count rises only at a completed block, so it counts symbols rather than bits.
+The invariant carries the incomplete block's length because a partial block is
+progress toward the next increment; without that summand the induction does not
+close at the completing step. `omega` treats the products as atoms, so the
+completing step supplies the two linear facts relating them.
+
+## References
+
+* [GambinoHyland2004]
+
+## Tags
+
+ranked alphabet, preorder, scan, fold, catamorphism, initial algebra
+-/
+
+@[expose] public section
+
+namespace Geb.CobhamFold
+
+open RankedAlphabet
+
+universe u v
+
+variable {α : Type u} {β : Type v}
+
+/-- The symbol a block denotes, absent at a block denoting none.
+`RankedAlphabet.arOf` returns that symbol's arity; a fold needs the symbol
+itself, to select the algebra's operation. -/
+def symOf (R : RankedAlphabet) (v : ℕ) : Option (Fin R.card) :=
+  if h : v < R.card then some ⟨v, h⟩ else none
+
+/-- The arity of a block's symbol is the arity of what `symOf` returns, so the
+validity scan and the fold scan take the same branch at every block. -/
+theorem arOf_eq_map_symOf (R : RankedAlphabet) (v : ℕ) :
+    R.arOf v = (symOf R v).map R.arity := by
+  rw [arOf, symOf]
+  split <;> rfl
+
+/-- A block denotes the symbol it spells. -/
+theorem symOf_decodeBits_code (R : RankedAlphabet) (i : Fin R.card) :
+    symOf R (decodeBits (R.code i)) = some i := by
+  rw [decodeBits_code, symOf, dif_pos i.isLt]
+
+/-- The unique algebra morphism out of the term algebra: the fold of a term at
+an algebra of the ranked alphabet. `RankedAlphabet.Term` is that alphabet's
+W-type, so the morphism is its eliminator. -/
+def Term.fold (R : RankedAlphabet)
+    (alg : (i : Fin R.card) → (Fin (R.arity i) → α) → α) : R.Term → α :=
+  WType.elim α fun x ↦ alg x.1 x.2
+
+/-- The fold on a term, in the `RankedAlphabet.Term.mk` presentation. -/
+@[simp] theorem Term.fold_mk (R : RankedAlphabet)
+    (alg : (i : Fin R.card) → (Fin (R.arity i) → α) → α) (i : Fin R.card)
+    (ch : Fin (R.arity i) → R.Term) :
+    Term.fold R alg (Term.mk R i ch) = alg i fun d ↦ Term.fold R alg (ch d) := rfl
+
+/-- The term algebra is initial: a map commuting with the algebra is the fold,
+so `Term.fold` is the algebra morphism out of it rather than one of several.
+`RankedAlphabet.Term` is a `WType`, so this is `WType.elim_unique` at the
+alphabet's shape and direction families, read at a point; the initiality it
+expresses is [GambinoHyland2004]'s for polynomial functors. -/
+theorem Term.fold_unique (R : RankedAlphabet)
+    (alg : (i : Fin R.card) → (Fin (R.arity i) → α) → α) (f : R.Term → α)
+    (hf : ∀ (i : Fin R.card) (ch : Fin (R.arity i) → R.Term),
+      f (Term.mk R i ch) = alg i fun d ↦ f (ch d)) :
+    ∀ t : R.Term, f t = Term.fold R alg t :=
+  congrFun (WType.elim_unique
+    (fun x : Σ i : Fin R.card, Fin (R.arity i) → α ↦ alg x.1 x.2) f hf)
+
+/-- Fold fusion: a map commuting with two algebras carries one fold to the
+other. A corollary of initiality, and the statement that identifies the results
+of two fold constructions at different carriers. -/
+theorem Term.fold_map (R : RankedAlphabet)
+    (alg : (i : Fin R.card) → (Fin (R.arity i) → α) → α)
+    (algV : (i : Fin R.card) → (Fin (R.arity i) → β) → β) (e : α → β)
+    (he : ∀ (i : Fin R.card) (g : Fin (R.arity i) → α),
+      algV i (fun d ↦ e (g d)) = e (alg i g)) :
+    ∀ t : R.Term, Term.fold R algV t = e (Term.fold R alg t) :=
+  fun t ↦ (Term.fold_unique R algV (fun t ↦ e (Term.fold R alg t))
+    (fun i ch ↦ by
+      beta_reduce
+      rw [Term.fold_mk]
+      exact (he i fun d ↦ Term.fold R alg (ch d)).symm) t).symm
+
+/-- The state of the fold scan: the bits of an incomplete block, the stack of
+values of the subterms already scanned, and whether the scan has failed.
+`RankedAlphabet.Scan` is this state with the stack replaced by its length. -/
+@[ext] structure FoldScan (α : Type u) where
+  /-- The bits of an incomplete block, most recently read first. -/
+  buf : List Bool
+  /-- The values of the subterms already scanned, the most recently completed
+  first. -/
+  stack : List α
+  /-- Whether the scan has not yet failed. -/
+  live : Bool
+
+/-- The projection onto the validity scan's state: the stack's length is the
+pending count. -/
+def toScan (s : FoldScan α) : Scan := ⟨s.buf, s.stack.length, s.live⟩
+
+/-- One step of the fold scan, reading one bit. A failed state absorbs. An
+incomplete block takes the bit; a complete one is decoded, and its symbol pops
+its arity's worth of stack, applies the algebra to them and pushes the result,
+failing when the block spells no symbol or the stack is short of the arity. -/
+def foldScanStep (R : RankedAlphabet)
+    (alg : (i : Fin R.card) → (Fin (R.arity i) → α) → α) (b : Bool)
+    (s : FoldScan α) : FoldScan α :=
+  match s.live with
+  | false => s
+  | true =>
+    if (b :: s.buf).length = R.width then
+      match symOf R (decodeBits (b :: s.buf)) with
+      | none => ⟨[], s.stack, false⟩
+      | some i =>
+        if h : R.arity i ≤ s.stack.length then
+          ⟨[], alg i (fun d ↦ s.stack[d.val]'(Nat.lt_of_lt_of_le d.isLt h)) ::
+            s.stack.drop (R.arity i), true⟩
+        else ⟨[], s.stack, false⟩
+    else ⟨b :: s.buf, s.stack, true⟩
+
+/-- The projection is a step homomorphism: the validity scan is the fold scan
+at every carrier and every algebra, read through the stack's length. -/
+theorem toScan_foldScanStep (R : RankedAlphabet)
+    (alg : (i : Fin R.card) → (Fin (R.arity i) → α) → α) (b : Bool)
+    (s : FoldScan α) :
+    toScan (foldScanStep R alg b s) = R.scanStep b (toScan s) := by
+  obtain ⟨buf, stack, live⟩ := s
+  change toScan (foldScanStep R alg b ⟨buf, stack, live⟩) =
+    R.scanStep b ⟨buf, stack.length, live⟩
+  rw [foldScanStep, scanStep]
+  dsimp only
+  cases live
+  · rfl
+  · dsimp only
+    rw [arOf_eq_map_symOf]
+    by_cases hlen : (b :: buf).length = R.width
+    · rw [if_pos hlen, decide_eq_true hlen]
+      dsimp only
+      match hsym : symOf R (decodeBits (b :: buf)) with
+      | none => rfl
+      | some i =>
+        rw [Option.map_some]
+        dsimp only
+        by_cases hle : R.arity i ≤ stack.length
+        · rw [dif_pos hle, decide_eq_true hle]
+          exact Scan.ext rfl (by rw [toScan, List.length_cons, List.length_drop]) rfl
+        · rw [dif_neg hle, decide_eq_false hle]
+          rfl
+    · rw [if_neg hlen, decide_eq_false hlen]
+      rfl
+
+/-- The fold scan of a word from a given state. `foldr` reads the word's last
+bit first, which is the processing order of a right-to-left scan. -/
+def foldScanFrom (R : RankedAlphabet)
+    (alg : (i : Fin R.card) → (Fin (R.arity i) → α) → α) (w : List Bool)
+    (s : FoldScan α) : FoldScan α :=
+  w.foldr (foldScanStep R alg) s
+
+/-- The fold scan of a word from the initial state. -/
+def foldScanFinal (R : RankedAlphabet)
+    (alg : (i : Fin R.card) → (Fin (R.arity i) → α) → α) (w : List Bool) :
+    FoldScan α :=
+  foldScanFrom R alg w ⟨[], [], true⟩
+
+/-- The fold scan of the empty word. -/
+@[simp] theorem foldScanFrom_nil (R : RankedAlphabet)
+    (alg : (i : Fin R.card) → (Fin (R.arity i) → α) → α) (s : FoldScan α) :
+    foldScanFrom R alg [] s = s := rfl
+
+/-- The fold scan of a word, one bit at a time. -/
+@[simp] theorem foldScanFrom_cons (R : RankedAlphabet)
+    (alg : (i : Fin R.card) → (Fin (R.arity i) → α) → α) (b : Bool)
+    (w : List Bool) (s : FoldScan α) :
+    foldScanFrom R alg (b :: w) s = foldScanStep R alg b (foldScanFrom R alg w s) :=
+  rfl
+
+/-- Every value on the fold scan's stack is one the algebra produced: the
+stack starts empty, and the completing pop is the only clause that pushes. -/
+theorem mem_stack_foldScanFinal (R : RankedAlphabet)
+    (alg : (i : Fin R.card) → (Fin (R.arity i) → α) → α) (P : α → Prop)
+    (hpush : ∀ (i : Fin R.card) (f : Fin (R.arity i) → α), P (alg i f)) :
+    ∀ (w : List Bool), ∀ v ∈ (foldScanFinal R alg w).stack, P v :=
+  List.rec (fun v hv ↦ absurd hv (by simp [foldScanFinal, foldScanFrom]))
+    fun b u ih v hv ↦ by
+    have hcons : foldScanFinal R alg (b :: u) =
+        foldScanStep R alg b (foldScanFinal R alg u) := rfl
+    rw [hcons, foldScanStep] at hv
+    -- `foldScanFinal R alg u` is a term, not a local variable, so `obtain` on
+    -- it would introduce fresh locals and rewrite neither `hv` nor `ih`. The
+    -- named equation is what carries the split into both.
+    rcases hfs : foldScanFinal R alg u with ⟨buf, stack, live⟩
+    rw [hfs] at hv ih
+    dsimp only at hv ih ⊢
+    cases live
+    · exact ih v hv
+    · dsimp only at hv
+      by_cases hlen : (b :: buf).length = R.width
+      · rw [if_pos hlen] at hv
+        match hsym : symOf R (decodeBits (b :: buf)) with
+        | none =>
+          rw [hsym] at hv
+          exact ih v hv
+        | some i =>
+          rw [hsym] at hv
+          dsimp only at hv
+          by_cases hst : R.arity i ≤ stack.length
+          · rw [dif_pos hst] at hv
+            rcases List.mem_cons.mp hv with h | h
+            · exact h ▸ hpush i _
+            · exact ih v (List.mem_of_mem_drop h)
+          · rw [dif_neg hst] at hv
+            exact ih v hv
+      · rw [if_neg hlen] at hv
+        exact ih v hv
+
+/-- The fold scan of a concatenation reads the later part first. -/
+theorem foldScanFrom_append (R : RankedAlphabet)
+    (alg : (i : Fin R.card) → (Fin (R.arity i) → α) → α) (u v : List Bool)
+    (s : FoldScan α) :
+    foldScanFrom R alg (u ++ v) s = foldScanFrom R alg u (foldScanFrom R alg v s) :=
+  List.foldr_append
+
+/-- The projection carries the whole scan, not only one step. -/
+theorem toScan_foldScanFrom (R : RankedAlphabet)
+    (alg : (i : Fin R.card) → (Fin (R.arity i) → α) → α) (s : FoldScan α) :
+    ∀ w : List Bool, toScan (foldScanFrom R alg w s) = R.scanFrom w (toScan s) :=
+  List.rec rfl fun b v ih ↦ by
+    rw [foldScanFrom_cons, toScan_foldScanStep, ih, scanFrom_cons]
+
+/-- The projection of the fold scan from the initial state is the validity
+scan. -/
+theorem toScan_foldScanFinal (R : RankedAlphabet)
+    (alg : (i : Fin R.card) → (Fin (R.arity i) → α) → α) (w : List Bool) :
+    toScan (foldScanFinal R alg w) = R.scanFinal w :=
+  toScan_foldScanFrom R alg ⟨[], [], true⟩ w
+
+/-- A word shorter than a block only accumulates, as it does in the validity
+scan. -/
+theorem foldScanFrom_short (R : RankedAlphabet)
+    (alg : (i : Fin R.card) → (Fin (R.arity i) → α) → α) (st : List α)
+    (bs : List Bool) :
+    ∀ u : List Bool, u.length + bs.length < R.width →
+      foldScanFrom R alg u ⟨bs, st, true⟩ = ⟨u ++ bs, st, true⟩ :=
+  List.rec (fun _ ↦ rfl)
+    (fun b v ih hv ↦ by
+      rw [foldScanFrom_cons, ih (by simp only [List.length_cons] at hv; omega),
+        foldScanStep]
+      dsimp only
+      rw [if_neg (by
+        simp only [List.length_cons, List.length_append] at hv ⊢
+        omega)]
+      rfl)
+
+/-- Reading a symbol's block from a state with no incomplete block whose stack
+begins with the symbol's arguments pops them and pushes the algebra applied to
+them. -/
+theorem foldScanFrom_code (R : RankedAlphabet)
+    (alg : (i : Fin R.card) → (Fin (R.arity i) → α) → α) (i : Fin R.card)
+    (vals : Fin (R.arity i) → α) (st : List α) :
+    foldScanFrom R alg (R.code i) ⟨[], List.ofFn vals ++ st, true⟩ =
+      ⟨[], alg i vals :: st, true⟩ := by
+  obtain ⟨b, v, hcode⟩ : ∃ b v, R.code i = b :: v := by
+    match hc : R.code i with
+    | [] =>
+      have hw := length_code R i
+      rw [hc] at hw
+      exact absurd hw.symm (Nat.ne_of_gt R.width_pos)
+    | b :: v => exact ⟨b, v, rfl⟩
+  have hw := length_code R i
+  rw [hcode, List.length_cons] at hw
+  have hofFn : (List.ofFn vals).length = R.arity i := List.length_ofFn
+  have hle : R.arity i ≤ (List.ofFn vals ++ st).length := by
+    rw [List.length_append, hofFn]
+    omega
+  rw [hcode, foldScanFrom_cons,
+    foldScanFrom_short R alg (List.ofFn vals ++ st) [] v (by simp; omega),
+    foldScanStep]
+  simp only [List.append_nil]
+  rw [if_pos (by rw [List.length_cons]; omega), ← hcode, symOf_decodeBits_code]
+  dsimp only
+  rw [dif_pos hle]
+  refine FoldScan.ext rfl ?_ rfl
+  refine congrArg₂ List.cons (congrArg (alg i) (funext fun d ↦ ?_))
+    (List.drop_left' hofFn)
+  have hd : d.val < (List.ofFn vals).length := by rw [hofFn]; exact d.isLt
+  rw [List.getElem_append_left hd, List.getElem_ofFn]
+
+/-- The fold scan of a family of spellings pushes one value per spelling, in
+index order: the value of index zero ends on top. -/
+theorem foldScanFrom_ofFn (R : RankedAlphabet)
+    (alg : (i : Fin R.card) → (Fin (R.arity i) → α) → α) :
+    ∀ (n : ℕ) (f : Fin n → List Bool) (g : Fin n → α),
+      (∀ (d : Fin n) (t : List α),
+        foldScanFrom R alg (f d) ⟨[], t, true⟩ = ⟨[], g d :: t, true⟩) →
+      ∀ st : List α,
+        foldScanFrom R alg (List.ofFn f).flatten ⟨[], st, true⟩ =
+          ⟨[], List.ofFn g ++ st, true⟩ :=
+  Nat.rec
+    (fun _ _ _ st ↦ by
+      rw [List.ofFn_zero, List.flatten_nil, foldScanFrom_nil, List.ofFn_zero,
+        List.nil_append])
+    (fun _ ih f g hf st ↦ by
+      rw [List.ofFn_succ, List.flatten_cons, foldScanFrom_append,
+        ih (fun i ↦ f i.succ) (fun i ↦ g i.succ) (fun d t ↦ hf d.succ t) st,
+        hf 0 (List.ofFn (fun i ↦ g i.succ) ++ st), List.ofFn_succ, List.cons_append])
+
+/-- A spelling pushes one value: the fold of the term it spells, whatever the
+stack before it. -/
+theorem foldScanFrom_spell (R : RankedAlphabet)
+    (alg : (i : Fin R.card) → (Fin (R.arity i) → α) → α) (t : R.Term)
+    (st : List α) :
+    foldScanFrom R alg (R.spell t) ⟨[], st, true⟩ =
+      ⟨[], Term.fold R alg t :: st, true⟩ :=
+  Term.induction
+    (motive := fun t ↦ ∀ st : List α, foldScanFrom R alg (R.spell t) ⟨[], st, true⟩ =
+      ⟨[], Term.fold R alg t :: st, true⟩)
+    (fun i ch ih st ↦ by
+      rw [spell_mk, foldScanFrom_append,
+        foldScanFrom_ofFn R alg (R.arity i) (fun d ↦ R.spell (ch d))
+          (fun d ↦ Term.fold R alg (ch d)) (fun d t ↦ ih d t) st,
+        foldScanFrom_code R alg i (fun d ↦ Term.fold R alg (ch d)) st]
+      rfl)
+    t st
+
+/-- The final state read as an `Option`: the value on top of the stack when the
+scan ends live, with no incomplete block and exactly one pending subterm, and
+absent otherwise. The three conditions are those of
+`RankedAlphabet.validBool`, read on the stack's length rather than on a
+count. -/
+def foldOut (R : RankedAlphabet)
+    (alg : (i : Fin R.card) → (Fin (R.arity i) → α) → α) (w : List Bool) :
+    Option α :=
+  if (foldScanFinal R alg w).live && (foldScanFinal R alg w).buf.isEmpty &&
+      (foldScanFinal R alg w).stack.length == 1 then
+    (foldScanFinal R alg w).stack.head?
+  else none
+
+/-- The condition `foldOut` tests is the recognizer's verdict. The projection
+supplies it: the three fields the test reads are the three
+`RankedAlphabet.validBool` reads, and `toScan` carries each. -/
+theorem foldOut_cond (R : RankedAlphabet)
+    (alg : (i : Fin R.card) → (Fin (R.arity i) → α) → α) (w : List Bool) :
+    ((foldScanFinal R alg w).live && (foldScanFinal R alg w).buf.isEmpty &&
+      (foldScanFinal R alg w).stack.length == 1) = R.validBool w := by
+  rw [validBool, ← toScan_foldScanFinal R alg w, toScan]
+
+/-- A spelling folds to the fold of the term it spells. -/
+theorem foldOut_spell (R : RankedAlphabet)
+    (alg : (i : Fin R.card) → (Fin (R.arity i) → α) → α) (t : R.Term) :
+    foldOut R alg (R.spell t) = some (Term.fold R alg t) := by
+  rw [foldOut, foldScanFinal, foldScanFrom_spell]
+  rfl
+
+/-- A word spelling no term folds to nothing: the condition `foldOut` tests is
+the recognizer's verdict, which `RankedAlphabet.valid_iff_exists_spell` places
+exactly at the spellings. -/
+theorem foldOut_eq_none_of_not_valid (R : RankedAlphabet)
+    (alg : (i : Fin R.card) → (Fin (R.arity i) → α) → α) (w : List Bool)
+    (h : ¬ R.Valid w) : foldOut R alg w = none := by
+  rw [foldOut, foldOut_cond]
+  exact if_neg h
+
+/-- The fold scan computes the decoding followed by the fold: the unique
+algebra morphism out of the term algebra, read off the spelling. -/
+theorem foldOut_eq (R : RankedAlphabet)
+    (alg : (i : Fin R.card) → (Fin (R.arity i) → α) → α) (w : List Bool) :
+    foldOut R alg w = (R.parse w).map (Term.fold R alg) := by
+  match hp : R.parse w with
+  | some t =>
+    rw [Option.map_some]
+    rw [← (parse_eq_some_iff R).mp hp]
+    exact foldOut_spell R alg t
+  | none =>
+    rw [Option.map_none]
+    refine foldOut_eq_none_of_not_valid R alg w fun hv ↦ ?_
+    rw [valid_iff_isSome_parse, hp] at hv
+    exact absurd hv (by simp)
+
+/-- One step raises the alphabet's width times the pending count, plus the
+incomplete block's length, by at most one. Every clause but the completing pop
+leaves the count alone; the pop raises it by at most one, and the block it
+consumes is worth the width. -/
+theorem width_mul_depth_scanStep_le (R : RankedAlphabet) (b : Bool) (s : Scan) :
+    R.width * (R.scanStep b s).depth + (R.scanStep b s).buf.length ≤
+      R.width * s.depth + s.buf.length + 1 := by
+  obtain ⟨buf, depth, live⟩ := s
+  rw [scanStep]
+  dsimp only
+  cases live
+  · dsimp only
+    omega
+  · dsimp only
+    cases hc : decide ((b :: buf).length = R.width)
+    · dsimp only
+      simp only [List.length_cons]
+      omega
+    · dsimp only
+      have hbw : buf.length + 1 = R.width := by
+        have hd := of_decide_eq_true hc
+        rw [List.length_cons] at hd
+        omega
+      cases R.arOf (decodeBits (b :: buf))
+      · dsimp only
+        simp only [List.length_nil]
+        omega
+      · rename_i r
+        dsimp only
+        cases decide (r ≤ depth)
+        · dsimp only
+          simp only [List.length_nil]
+          omega
+        · dsimp only
+          have h2 : R.width * (depth - r + 1) ≤ R.width * (depth + 1) :=
+            Nat.mul_le_mul_left _ (by omega)
+          have h3 : R.width * (depth + 1) = R.width * depth + R.width :=
+            Nat.mul_succ _ _
+          simp only [List.length_nil]
+          omega
+
+/-- The incomplete block of the fold scan is the incomplete block of the
+validity scan, the projection carrying it. -/
+theorem buf_foldScanFinal (R : RankedAlphabet)
+    (alg : (i : Fin R.card) → (Fin (R.arity i) → α) → α) (w : List Bool) :
+    (foldScanFinal R alg w).buf = (R.scanFinal w).buf :=
+  congrArg Scan.buf (toScan_foldScanFinal R alg w)
+
+/-- The stack's height is the validity scan's pending count. -/
+theorem length_stack_foldScanFinal (R : RankedAlphabet)
+    (alg : (i : Fin R.card) → (Fin (R.arity i) → α) → α) (w : List Bool) :
+    (foldScanFinal R alg w).stack.length = (R.scanFinal w).depth :=
+  congrArg Scan.depth (toScan_foldScanFinal R alg w)
+
+/-- The fold scan's incomplete block never fills. -/
+theorem length_buf_foldScanFinal_lt (R : RankedAlphabet)
+    (alg : (i : Fin R.card) → (Fin (R.arity i) → α) → α) (w : List Bool) :
+    (foldScanFinal R alg w).buf.length < R.width := by
+  rw [buf_foldScanFinal]
+  exact length_buf_scanFinal_lt R w
+
+/-- Two folds whose algebras commute with a map agree on results, up to that
+map, on every input. This is the equivalence between two fold constructions at
+different carriers: neither construction enters the statement, only the shared
+specification `foldOut_eq` gives them. -/
+theorem foldOut_map (R : RankedAlphabet)
+    (alg : (i : Fin R.card) → (Fin (R.arity i) → α) → α)
+    (algV : (i : Fin R.card) → (Fin (R.arity i) → β) → β) (e : α → β)
+    (he : ∀ (i : Fin R.card) (g : Fin (R.arity i) → α),
+      algV i (fun d ↦ e (g d)) = e (alg i g)) (w : List Bool) :
+    foldOut R algV w = (foldOut R alg w).map e := by
+  rw [foldOut_eq, foldOut_eq]
+  match R.parse w with
+  | none => rfl
+  | some t =>
+    rw [Option.map_some, Option.map_some, Term.fold_map R alg algV e he t]
+    rfl
+
+/-- The pending count rises only at a completed block, so the alphabet's width
+times the count, plus the length of the incomplete block, is at most the word's
+length. This sharpens `RankedAlphabet.depth_scanFinal_le_length` by the width:
+the count is a number of symbols, not of bits. -/
+theorem width_mul_depth_add_length_buf_scanFinal_le (R : RankedAlphabet)
+    (w : List Bool) :
+    R.width * (R.scanFinal w).depth + (R.scanFinal w).buf.length ≤ w.length :=
+  List.rec (by simp only [scanFinal_nil, List.length_nil]; omega)
+    (fun b v ih ↦ by
+      rw [scanFinal_cons, List.length_cons]
+      exact Nat.le_trans (width_mul_depth_scanStep_le R b (R.scanFinal v))
+        (Nat.add_le_add_right ih 1)) w
+
+/-- The pending count is at most the word's length divided by the block width,
+in the multiplied form a state layout consumes. -/
+theorem width_mul_depth_scanFinal_le (R : RankedAlphabet) (w : List Bool) :
+    R.width * (R.scanFinal w).depth ≤ w.length :=
+  Nat.le_trans (Nat.le_add_right _ _)
+    (width_mul_depth_add_length_buf_scanFinal_le R w)
+
+end Geb.CobhamFold
+
+end

--- a/geb-lean/vendor/geb-mathlib/Geb/Internal/Computability/CobhamFoldProto/Initial.lean
+++ b/geb-lean/vendor/geb-mathlib/Geb/Internal/Computability/CobhamFoldProto/Initial.lean
@@ -1,0 +1,204 @@
+/-
+Copyright (c) 2026 Terence Rokop. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Terence Rokop
+-/
+module
+
+public import Geb.Internal.Computability.CobhamFoldProto.SmashFree
+
+/-!
+# The term algebra's constructor in the fold's language
+
+The initial algebra's structure map at the carrier `List Bool`, whose
+elements are read as spellings.
+
+`Term.fold` at `algMk` is `RankedAlphabet.spell` itself, so `algMk` is the
+step `spell`'s own `WType.elim` runs, named apart from it, and the preorder
+encoding is the unique morphism from the term algebra into it by the
+initiality `Term.fold_unique` carries [GambinoHyland2004]. The carrier
+`List Bool` is not itself initial — the spellings are a proper subalgebra of
+it — so what the equation says is that `algMk` is the initial algebra's
+structure map transported along the encoding.
+
+`mkOf` computes that map inside the class: the symbol's block prepended to
+`flattenOf`, a `Nat.rec` on the arity whose step composes the arity-`n` tail
+against the shifted projections, so no `def` calls itself.
+
+## Main definitions
+
+* `Geb.CobhamFold.algMk` — the initial algebra's structure map.
+* `Geb.CobhamFold.flattenOf` — the concatenation of an arity's slots.
+* `Geb.CobhamFold.mkOf` — the structure map as an expression of the class.
+
+## Main statements
+
+* `Geb.CobhamFold.fold_algMk` — the fold at that map is the spelling.
+* `Geb.CobhamFold.length_algMk` — it lengthens by the alphabet's width.
+* `Geb.CobhamFold.foldOut_algMk` — the fold at that map is the identity on
+  the recognized language.
+* `Geb.CobhamFold.flattenOf_succ` — the slot concatenation at a successor,
+  which `Nat.rec` generates no equation lemma for.
+* `Geb.CobhamFold.semAt_flattenOf`, `Geb.CobhamFold.semAt_mkOf` — what those
+  two expressions compute.
+* `Geb.CobhamFold.growth_algMk`, `Geb.CobhamFold.stackSize_algMk_le` — the
+  per-symbol growth condition at the constant `R.width`, and the linearity
+  hypothesis it discharges.
+* `Geb.CobhamFold.smashFreeBool_flattenOf`,
+  `Geb.CobhamFold.smashFreeBool_mkOf` — those expressions carry no `smash`.
+* `Geb.CobhamFold.foldOutSemV_algMk` — the expression at that algebra returns
+  its own input on the recognized language, characterised for every input
+  word; `## Implementation notes` records why it is characterised rather than
+  computed.
+* `Geb.CobhamFold.smashFree_foldOutExprV_mkOf` — that expression lies in the
+  subalgebra `Cobham.SmashFree` names.
+
+## Implementation notes
+
+Nothing here is evaluated. `readoutWidthV R` is six at
+`RankedAlphabet.Binary.binRanked`, so the readout dispatches on `2 ^ 6`
+branches. `foldOutSemV_algMk` characterises the output word for every input
+word instead, which needs no branch of that tree.
+
+`algMk` and the step `RankedAlphabet.spell`'s own `WType.elim` runs agree by
+`rfl` rather than sharing one definition: factoring that step out of `spell`
+would touch `Geb/Mathlib/Data/Tree/Ranked/Preorder.lean`.
+
+## References
+
+* [Cobham1965]
+* [GambinoHyland2004]
+* [Strahm2003]
+
+## Tags
+
+Cobham, ranked tree, initial algebra, term algebra, preorder encoding,
+expression, smash-free, catamorphism
+-/
+
+@[expose] public section
+
+namespace Geb.CobhamFold
+
+open Cobham
+
+/-- The initial algebra's structure map, at the carrier `List Bool`: a
+symbol's block followed by its children's spellings. -/
+def algMk (R : RankedAlphabet) (i : Fin R.card)
+    (f : Fin (R.arity i) → List Bool) : List Bool :=
+  R.code i ++ (List.ofFn f).flatten
+
+/-- The fold at that map is the preorder encoding, so `RankedAlphabet.spell`
+is the unique morphism from the term algebra into it, by the initiality
+`Geb.CobhamFold.Term.fold_unique` carries [GambinoHyland2004]. -/
+theorem fold_algMk (R : RankedAlphabet) : Term.fold R (algMk R) = R.spell := rfl
+
+/-- It lengthens its arguments' total by exactly the alphabet's width. -/
+theorem length_algMk (R : RankedAlphabet) (i : Fin R.card)
+    (f : Fin (R.arity i) → List Bool) :
+    (algMk R i f).length = (List.ofFn fun d ↦ (f d).length).sum + R.width := by
+  rw [algMk, List.length_append, R.length_code, List.length_flatten,
+    List.map_ofFn]
+  exact Nat.add_comm _ _
+
+/-- The fold at that map is the identity on the recognized language. -/
+theorem foldOut_algMk (R : RankedAlphabet) (w : List Bool) :
+    foldOut R (algMk R) w = (R.parse w).map (fun _ ↦ w) := by
+  rw [foldOut_eq, fold_algMk]
+  cases h : R.parse w with
+  | none => rfl
+  | some t => exact congrArg some (R.parse_eq_some_iff.mp h)
+
+/-- The concatenation of an arity's slots, in index order. Built by `Nat.rec`
+on the arity, the arity-`n` tail composed against the shifted projections, so
+no `def` calls itself. -/
+def flattenOf : (n : ℕ) → COf n :=
+  Nat.rec (zeroAtOf 0) fun n ih ↦
+    concatCompOf (n + 1) (compOf ih fun i ↦ projOf (n + 1) i.succ)
+      (projOf (n + 1) 0)
+
+/-- One more slot concatenates onto the shifted tail, its own value first.
+`flattenOf` is a bare `Nat.rec`, for which Lean generates no equation
+lemma. -/
+theorem flattenOf_succ (n : ℕ) :
+    flattenOf (n + 1) =
+      concatCompOf (n + 1) (compOf (flattenOf n) fun i ↦ projOf (n + 1) i.succ)
+        (projOf (n + 1) 0) := rfl
+
+/-- It computes the concatenation of its slots. The single unfolding step is
+definitional but the closed form is not, `List.ofFn_succ` itself not being
+`rfl`. -/
+theorem semAt_flattenOf : ∀ (n : ℕ) (x : Fin n → List Bool),
+    semAt n (flattenOf n).1.1 (flattenOf n).2 x = (List.ofFn x).flatten :=
+  Nat.rec (fun x ↦ by rw [List.ofFn_zero, List.flatten_nil]; rfl)
+    fun n ih x ↦ by
+      rw [flattenOf_succ, semAt_concatCompOf, semAt_projOf, semAt_compOf]
+      simp only [semAt_projOf]
+      rw [ih fun i ↦ x i.succ, List.ofFn_succ, List.flatten_cons]
+
+/-- The initial algebra's structure map as an expression of Cobham's class:
+the symbol's block prepended to the concatenation of the slots. -/
+def mkOf (R : RankedAlphabet) (i : Fin R.card) : COf (R.arity i) :=
+  prependOf (R.code i) (flattenOf (R.arity i))
+
+/-- The expression computes the structure map. -/
+theorem semAt_mkOf (R : RankedAlphabet) (i : Fin R.card)
+    (f : Fin (R.arity i) → List Bool) :
+    semAt (R.arity i) (mkOf R i).1.1 (mkOf R i).2 f = algMk R i f := by
+  rw [mkOf, semAt_prependOf, semAt_flattenOf, algMk]
+
+/-- The growth condition at the constant `R.width`, which `length_algMk`
+gives with equality. -/
+theorem growth_algMk (R : RankedAlphabet) (i : Fin R.card)
+    (f : Fin (R.arity i) → List Bool) :
+    (algMk R i f).length ≤ (List.ofFn fun d ↦ (f d).length).sum + R.width :=
+  Nat.le_of_eq (length_algMk R i f)
+
+/-- The pending values stay linear in the input, at the same constant. This
+is the hypothesis `Geb.CobhamFold.foldOutExprV` takes, discharged by
+`Geb.CobhamFold.stackSize_le_of_growth` from the per-symbol condition
+alone. -/
+theorem stackSize_algMk_le (R : RankedAlphabet) (w : List Bool) :
+    stackSize (foldScanFinal R (algMk R) w).stack ≤ R.width * w.length :=
+  stackSize_le_of_growth R (algMk R) R.width (growth_algMk R) w
+
+/-- The slot concatenation carries no `smash`: the empty bitstring at arity
+zero, and a `concat` composition of projections at every successor. -/
+theorem smashFreeBool_flattenOf : ∀ n : ℕ,
+    smashFreeBool (flattenOf n).1.1.1 = true :=
+  Nat.rec (smashFreeBool_zeroAtOf 0) fun n ih ↦
+    smashFreeBool_concatCompOf (n + 1) _ _
+      (smashFreeBool_compOf _ _ ih fun i ↦ smashFreeBool_projOf (n + 1) i.succ)
+      (smashFreeBool_projOf (n + 1) 0)
+
+/-- The structure map's expression carries no `smash`, which is
+`Geb.CobhamFold.smashFree_foldOutExprV`'s hypothesis at this algebra. -/
+theorem smashFreeBool_mkOf (R : RankedAlphabet) (i : Fin R.card) :
+    smashFreeBool (mkOf R i).1.1.1 = true :=
+  smashFreeBool_prependOf _ _ (smashFreeBool_flattenOf (R.arity i))
+
+/-- The expression at the structure map returns its own input, spelled by
+`Geb.CobhamFold.outWordV`, on the recognized language and the absence marker
+off it. The output word is characterised for every input word rather than
+computed from one, the readout's dispatch having `2 ^ readoutWidthV R`
+branches. -/
+theorem foldOutSemV_algMk (R : RankedAlphabet) (mult : ℕ)
+    (hmult : 2 * R.width + 2 ≤ mult) (w : List Bool) :
+    foldOutSemV R (mkOf R) (algMk R) (semAt_mkOf R) mult R.width
+        (stackSize_algMk_le R) hmult ![w] =
+      outWordV ((R.parse w).map fun _ ↦ w) := by
+  rw [foldOutSemV_eq, foldOut_algMk]
+
+/-- That expression lies in the subalgebra `Cobham.SmashFree` names, so with
+[Strahm2003] Theorem 1(2)'s left-to-right inclusion it is computable
+simultaneously in polynomial time and linear space. -/
+theorem smashFree_foldOutExprV_mkOf (R : RankedAlphabet) (mult : ℕ)
+    (hmult : 2 * R.width + 2 ≤ mult) :
+    SmashFree (foldOutExprV R (mkOf R) (algMk R) (semAt_mkOf R) mult R.width
+      (stackSize_algMk_le R) hmult) :=
+  smashFree_foldOutExprV R (mkOf R) (smashFreeBool_mkOf R) (algMk R)
+    (semAt_mkOf R) mult R.width (stackSize_algMk_le R) hmult
+
+end Geb.CobhamFold
+
+end

--- a/geb-lean/vendor/geb-mathlib/Geb/Internal/Computability/CobhamFoldProto/Layout.lean
+++ b/geb-lean/vendor/geb-mathlib/Geb/Internal/Computability/CobhamFoldProto/Layout.lean
@@ -1,0 +1,508 @@
+/-
+Copyright (c) 2026 Terence Rokop. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Terence Rokop
+-/
+-- Modified from geb-mathlib by scripts/geb-mathlib-backport.patch.
+module
+
+public import Geb.Internal.Computability.CobhamFoldProto.Fold
+public import Geb.Mathlib.Computability.Cobham.RankedTree
+
+/-!
+# The fold scan's state as a bitstring
+
+`Cobham.stateWord` lays `RankedAlphabet.Scan` out as a bitstring: the liveness
+flag, the incomplete block in a slot of the alphabet's width, then the pending
+count in unary. This module lays `Geb.CobhamFold.FoldScan` out the same way,
+with the unary count replaced by one block per stack entry.
+
+Each entry occupies `p + 1` bits: a `true` presence marker followed by the `p`
+bits of the carrier's encoding. The marker is what the unary count's `true`
+already was, so at `p = 0` — the carrier `Unit`, whose encoding is empty — the
+layout is `Cobham.stateWord` and the dispatch window is
+`Cobham.dispatchWidth`, which `Geb.CobhamFold.stateWordF_unit` and
+`Geb.CobhamFold.dispatchWidthF_zero` state. The layout generalizes the
+recognizer's rather than sitting beside it.
+
+The marker is not redundant at `p > 0`. `Cobham.bits` pads a window past the
+word's end with `false`, and a carrier value may encode to all-`false`, so
+without a marker the padding would be indistinguishable from a stack entry. The
+marker separates them: the run of markers gives the stack's height capped at the
+window, which is what decides whether a symbol's arity is available.
+
+## Main definitions
+
+* `Geb.CobhamFold.entryBits`, `Geb.CobhamFold.stackBits` — one stack entry, and
+  the stack, as bitstrings.
+* `Geb.CobhamFold.stateWordF` — the fold scan's state as a bitstring.
+* `Geb.CobhamFold.dispatchWidthF` — the number of state bits a step dispatches
+  on.
+* `Geb.CobhamFold.decodeStack`, `Geb.CobhamFold.decodeStateAt`,
+  `Geb.CobhamFold.decodeStateF` — the inverse of the layout, at an arbitrary
+  window and at the dispatch window.
+* `Geb.CobhamFold.dropCountF`, `Geb.CobhamFold.nextPrefixF` — the bits a step
+  drops and prepends.
+
+## Main statements
+
+* `Geb.CobhamFold.length_stackBits`, `Geb.CobhamFold.length_stateWordF_of_lt` —
+  the layout's lengths.
+* `Geb.CobhamFold.take_stackBits`, `Geb.CobhamFold.drop_stackBits`,
+  `Geb.CobhamFold.drop_stackBits_mul` — the stack's layout truncated, advanced
+  by one entry, and advanced by several.
+* `Geb.CobhamFold.ofFn_bits_stateWordF` — the state word truncated to a window
+  and zero-padded.
+* `Geb.CobhamFold.decodeStateAt_stateWordF_of_lt`,
+  `Geb.CobhamFold.decodeStateF_stateWordF_of_lt` — the decoder inverts the
+  layout up to truncating the stack at the window.
+* `Geb.CobhamFold.dropCountF_take_stack`, `Geb.CobhamFold.nextPrefixF_take_stack`
+  — truncating the stack at the window changes neither.
+* `Geb.CobhamFold.stateWordF_foldScanStep_of_lt` — a step rewrites a bounded
+  prefix and drops a bounded number of bits.
+* `Geb.CobhamFold.length_stateWordF_not_le_add` — at the two-symbol alphabet,
+  whose width is one, the additive bound `Cobham.scan` admits fails of this
+  layout at every positive carrier width.
+
+## Implementation notes
+
+`dispatchWidthF` reads `R.maxArity + 1` entries. `R.maxArity` of them are what a
+symbol's algebra can consume; the extra one distinguishes a stack of exactly
+`R.maxArity` entries from a longer one, which is what decides `r ≤ height` for
+every arity `r`, `RankedAlphabet.le_maxArity_of_arOf_eq_some` bounding the
+arities. This is `Cobham.dispatchWidth`'s `R.maxArity + 1` window, one entry
+wide rather than one bit wide.
+
+`decodeStack` recurses on a fuel argument by `Nat.rec` rather than on the word,
+so no `def` here calls itself.
+
+`decodeStateF` reads the stack through `List` operations rather than by `Fin`
+arithmetic, for the reason `Cobham.decodeState` records: a branch family's
+domain is `Fin (dispatchWidthF R p) → Bool` at a symbolic width, and indexing it
+would carry a bound proof at every step, while `DecidableEq (Fin n → Bool)`
+depends on `Classical.choice`: it resolves through
+`FinEnum.decidablePiFinEnum`, which is choice-free, at mathlib's `FinEnum.fin`,
+which is not.
+
+The retraction hypothesis `∀ a, dec (enc a) = a` enters only at
+`decodeStateF_stateWordF_of_lt`; the lengths and the step lemma hold whatever
+`dec` does off the image of `enc`, as they do in
+`Geb/Mathlib/Computability/Cobham/Fold.lean`.
+
+## References
+
+* [Cobham1965]
+
+## Tags
+
+Cobham, ranked alphabet, preorder, fold, state layout, stack
+-/
+
+@[expose] public section
+
+namespace Geb.CobhamFold
+
+open Cobham RankedAlphabet
+
+universe u
+
+variable {α : Type u} {p : ℕ}
+
+/-- One stack entry as a bitstring: a `true` presence marker followed by the
+carrier's encoding. -/
+def entryBits (enc : α → Fin p → Bool) (a : α) : List Bool :=
+  true :: List.ofFn (enc a)
+
+/-- The stack as a bitstring: one marked block per entry, the top entry
+first. At `p = 0` this is the run of `true` `Cobham.stateWord` spells the
+pending count with. -/
+def stackBits (enc : α → Fin p → Bool) (st : List α) : List Bool :=
+  st.flatMap (entryBits enc)
+
+/-- The fold scan's state as a bitstring: the liveness flag, the block slot,
+then the stack. -/
+def stateWordF (R : RankedAlphabet) (enc : α → Fin p → Bool) (s : FoldScan α) :
+    List Bool :=
+  s.live :: bufBits R s.buf ++ stackBits enc s.stack
+
+/-- The number of state bits a step dispatches on: the flag, the slot, and
+`R.maxArity + 1` stack entries. -/
+def dispatchWidthF (R : RankedAlphabet) (p : ℕ) : ℕ :=
+  1 + R.width + (p + 1) * (R.maxArity + 1)
+
+/-- An entry occupies the encoding's width plus its marker. -/
+@[simp] theorem length_entryBits (enc : α → Fin p → Bool) (a : α) :
+    (entryBits enc a).length = p + 1 := by
+  rw [entryBits, List.length_cons, List.length_ofFn]
+
+/-- The stack's layout is one entry's width per entry. -/
+theorem length_stackBits (enc : α → Fin p → Bool) :
+    ∀ st : List α, (stackBits enc st).length = (p + 1) * st.length :=
+  List.rec rfl fun a t ih ↦ by
+    rw [stackBits, List.flatMap_cons, List.length_append,
+      length_entryBits, ← stackBits, ih, List.length_cons, Nat.mul_succ]
+    omega
+
+/-- The empty stack's layout. -/
+@[simp] theorem stackBits_nil (enc : α → Fin p → Bool) :
+    stackBits enc ([] : List α) = [] := rfl
+
+/-- The stack's layout, one entry at a time. -/
+@[simp] theorem stackBits_cons (enc : α → Fin p → Bool) (a : α) (st : List α) :
+    stackBits enc (a :: st) = entryBits enc a ++ stackBits enc st := rfl
+
+/-- The state word's length: the flag, the slot, and the stack. -/
+theorem length_stateWordF_of_lt (R : RankedAlphabet) (enc : α → Fin p → Bool)
+    (s : FoldScan α) (h : s.buf.length < R.width) :
+    (stateWordF R enc s).length = 1 + R.width + (p + 1) * s.stack.length := by
+  rw [stateWordF, List.cons_append, List.length_cons, List.length_append,
+    length_bufBits_of_lt R s.buf h, length_stackBits]
+  omega
+
+/-- The stack's layout truncated to a whole number of entries is the layout of
+the truncated stack. -/
+theorem take_stackBits (enc : α → Fin p → Bool) :
+    ∀ (st : List α) (m : ℕ),
+      (stackBits enc st).take ((p + 1) * m) = stackBits enc (st.take m) :=
+  List.rec (fun _ ↦ by rw [stackBits_nil, List.take_nil, List.take_nil, stackBits_nil])
+    (fun a t ih m ↦ match m with
+      | 0 => by rw [Nat.mul_zero, List.take_zero, List.take_zero, stackBits_nil]
+      | k + 1 => by
+        have hlen : (p + 1) * (k + 1) = (entryBits enc a).length + (p + 1) * k := by
+          rw [length_entryBits, Nat.mul_succ]
+          omega
+        rw [stackBits_cons, hlen, List.take_length_add_append, ih k,
+          List.take_succ_cons, stackBits_cons])
+
+/-- The stack's layout advanced past its first entry is the layout of the
+rest. -/
+theorem drop_stackBits (enc : α → Fin p → Bool) (a : α) (st : List α) :
+    (stackBits enc (a :: st)).drop (p + 1) = stackBits enc st := by
+  rw [stackBits_cons]
+  exact List.drop_left' (length_entryBits enc a)
+
+/-- The stack's layout advanced past a whole number of entries is the layout of
+the stack advanced by that many. -/
+theorem drop_stackBits_mul (enc : α → Fin p → Bool) :
+    ∀ (n : ℕ) (st : List α),
+      (stackBits enc st).drop ((p + 1) * n) = stackBits enc (st.drop n) :=
+  Nat.rec (fun st ↦ by rw [Nat.mul_zero, List.drop_zero, List.drop_zero])
+    (fun k ih st ↦ match st with
+      | [] => by rw [stackBits_nil, List.drop_nil, List.drop_nil, stackBits_nil]
+      | a :: t => by
+        have hmul : (p + 1) * (k + 1) = (p + 1) + (p + 1) * k := by
+          rw [Nat.mul_succ]
+          omega
+        rw [hmul, ← List.drop_drop, drop_stackBits, ih t, List.drop_succ_cons])
+
+/-- The bits of a spelled-out family followed by anything are that family: the
+window reads only the family's own width. -/
+theorem bits_ofFn_append (f : Fin p → Bool) (l : List Bool) :
+    bits p (List.ofFn f ++ l) = f := by
+  funext j
+  have hj : j.val < (List.ofFn f).length := by
+    rw [List.length_ofFn]
+    exact j.isLt
+  rw [bits, List.getD_eq_getElem?_getD, List.getElem?_append_left hj,
+    List.getElem?_eq_getElem hj, List.getElem_ofFn]
+  rfl
+
+/-- The state word truncated to a window of whole entries past the slot, and
+zero-padded: the flag, the slot, the stack truncated at the window, and padding
+where the stack is shorter. Stated at an arbitrary window, the dispatch and the
+verdict reading different ones. -/
+theorem ofFn_bits_stateWordF (R : RankedAlphabet) (enc : α → Fin p → Bool)
+    (s : FoldScan α) (n m : ℕ) (hn : n = 1 + R.width + (p + 1) * m)
+    (h : s.buf.length < R.width) :
+    List.ofFn (bits n (stateWordF R enc s)) =
+      s.live :: (bufBits R s.buf ++
+        (stackBits enc (s.stack.take m) ++
+          List.replicate ((p + 1) * m - (p + 1) * s.stack.length) false)) := by
+  subst hn
+  have hbuf : (bufBits R s.buf).length = R.width := length_bufBits_of_lt R s.buf h
+  have hdw : 1 + R.width + (p + 1) * m = (bufBits R s.buf).length + ((p + 1) * m) + 1 := by
+    rw [hbuf]
+    omega
+  have hpad : 1 + R.width + (p + 1) * m - (stateWordF R enc s).length =
+      (p + 1) * m - (p + 1) * s.stack.length := by
+    rw [length_stateWordF_of_lt R enc s h]
+    omega
+  rw [ofFn_bits, hpad, stateWordF, List.cons_append, hdw, List.take_succ_cons,
+    List.take_length_add_append, take_stackBits, List.cons_append,
+    List.append_assoc]
+
+/-- The validity scan of a word of leaves has one pending subterm per leaf.
+At the two-symbol alphabet a block is one bit and `false` spells the nullary
+symbol, so nothing is ever popped. -/
+private theorem scanFinal_replicate_false : ∀ k : ℕ,
+    Binary.binRanked.scanFinal (List.replicate k false) = ⟨[], k, true⟩ :=
+  Nat.rec (motive := fun k ↦
+      Binary.binRanked.scanFinal (List.replicate k false) = ⟨[], k, true⟩) rfl
+    fun k ih ↦ by
+      beta_reduce
+      rw [List.replicate_succ, scanFinal_cons, ih,
+        Binary.scanStep_false_of_live_of_buf_nil _ rfl rfl]
+
+/-- At the two-symbol alphabet, whose width is one, the additive bound
+`Cobham.scan` admits fails of this layout at every positive carrier width, so
+the multiplicative bound `Geb.CobhamFold.scanMul` carries is not a convenience.
+A word of `k` leaves leaves `k` entries on the stack, giving a state of
+`2 + (q + 1) * k` bits against an input of `k`; no fixed `growth` dominates
+that. The failure needs `R.width < q + 1`, and needs an alphabet whose symbols
+grow the stack: at `R.width ≥ q + 1` the additive bound always suffices, and an
+alphabet with no nullary symbol keeps the stack empty whatever the carrier. -/
+theorem length_stateWordF_not_le_add {β : Type u} {q : ℕ} (hq : 0 < q)
+    (enc : β → Fin q → Bool)
+    (alg : (i : Fin Binary.binRanked.card) →
+      (Fin (Binary.binRanked.arity i) → β) → β) (growth : ℕ) :
+    ∃ w : List Bool, w.length + growth <
+      (stateWordF Binary.binRanked enc
+        (foldScanFinal Binary.binRanked alg w)).length := by
+  refine ⟨List.replicate growth false, ?_⟩
+  have hproj :=
+    toScan_foldScanFinal Binary.binRanked alg (List.replicate growth false)
+  rw [scanFinal_replicate_false] at hproj
+  have hbuf :
+      (foldScanFinal Binary.binRanked alg (List.replicate growth false)).buf = [] :=
+    congrArg Scan.buf hproj
+  have hstack :
+      (foldScanFinal Binary.binRanked alg
+        (List.replicate growth false)).stack.length = growth :=
+    congrArg Scan.depth hproj
+  rw [length_stateWordF_of_lt Binary.binRanked enc _
+      (by rw [hbuf]; exact Binary.binRanked.width_pos),
+    hstack, List.length_replicate]
+  have hw : Binary.binRanked.width = 1 := rfl
+  rw [hw, Nat.add_mul, Nat.one_mul]
+  have hle : 1 * growth ≤ q * growth := Nat.mul_le_mul_right growth hq
+  rw [Nat.one_mul] at hle
+  omega
+
+/-- The inverse of the stack's layout, read off a bitstring with a fuel bound:
+each marked block contributes its decoded value, and the first unmarked block
+ends the stack. -/
+def decodeStack (dec : (Fin p → Bool) → α) : ℕ → List Bool → List α :=
+  Nat.rec (motive := fun _ ↦ List Bool → List α) (fun _ ↦ [])
+    fun _ ih l ↦
+      match l with
+      | true :: rest => dec (bits p rest) :: ih (rest.drop p)
+      | _ => []
+
+/-- The decoder at no fuel reads no entry. -/
+@[simp] theorem decodeStack_zero (dec : (Fin p → Bool) → α) (l : List Bool) :
+    decodeStack dec 0 l = [] := rfl
+
+/-- The decoder's computation rule at a marked block. -/
+theorem decodeStack_succ_true (dec : (Fin p → Bool) → α) (k : ℕ)
+    (rest : List Bool) :
+    decodeStack dec (k + 1) (true :: rest) =
+      dec (bits p rest) :: decodeStack dec k (rest.drop p) := rfl
+
+/-- The decoder inverts the stack's layout, up to truncating at the fuel.
+The retraction hypothesis is what identifies each decoded block with the value
+that spelled it; the trailing `false` padding stops the recursion. -/
+theorem decodeStack_stackBits_append (dec : (Fin p → Bool) → α)
+    (enc : α → Fin p → Bool) (hdec : ∀ a, dec (enc a) = a) :
+    ∀ (k : ℕ) (st : List α) (j : ℕ),
+      decodeStack dec k (stackBits enc st ++ List.replicate j false) = st.take k :=
+  Nat.rec (fun st _ ↦ by rw [decodeStack_zero, List.take_zero])
+    (fun k ih st j ↦ match st with
+      | [] => by
+        match j with
+        | 0 => rfl
+        | _ + 1 => rfl
+      | a :: t => by
+        rw [stackBits_cons, entryBits]
+        simp only [List.cons_append, List.append_assoc]
+        rw [decodeStack_succ_true, bits_ofFn_append, hdec,
+          List.drop_left' (List.length_ofFn (f := enc a)), ih t j,
+          List.take_succ_cons])
+
+/-- The inverse of the state layout at a window of `n` bits reading `m` stack
+entries: the flag is the head, the block is the slot past its padding and
+sentinel, and the stack is decoded from what follows the slot. Stated at an
+arbitrary window, the dispatch and the readout reading different ones. -/
+def decodeStateAt (R : RankedAlphabet) (p : ℕ) (dec : (Fin p → Bool) → α)
+    (n m : ℕ) (v : Fin n → Bool) : FoldScan α :=
+  ⟨(((List.ofFn v).tail.take R.width).dropWhile (fun b ↦ !b)).tail,
+    decodeStack dec m ((List.ofFn v).tail.drop R.width),
+    (List.ofFn v).headD false⟩
+
+/-- The decoder inverts the layout, up to truncating the stack at the window. -/
+theorem decodeStateAt_stateWordF_of_lt (R : RankedAlphabet)
+    (dec : (Fin p → Bool) → α) (enc : α → Fin p → Bool)
+    (hdec : ∀ a, dec (enc a) = a) (s : FoldScan α) (n m : ℕ)
+    (hn : n = 1 + R.width + (p + 1) * m) (h : s.buf.length < R.width) :
+    decodeStateAt R p dec n m (bits n (stateWordF R enc s)) =
+      { s with stack := s.stack.take m } := by
+  have hbuf : (bufBits R s.buf).length = R.width := length_bufBits_of_lt R s.buf h
+  have hword := ofFn_bits_stateWordF R enc s n m hn h
+  have hslot : ((List.ofFn (bits n (stateWordF R enc s))).tail.take
+      R.width) = bufBits R s.buf := by
+    rw [hword, List.tail_cons, List.take_left' hbuf]
+  have htail : ((List.ofFn (bits n (stateWordF R enc s))).tail.drop
+      R.width) = stackBits enc (s.stack.take m) ++
+        List.replicate ((p + 1) * m - (p + 1) * s.stack.length) false := by
+    rw [hword, List.tail_cons, List.drop_left' hbuf]
+  refine FoldScan.ext ?_ ?_ ?_
+  · rw [decodeStateAt, hslot, dropWhile_bufBits]
+    rfl
+  · rw [decodeStateAt, htail, decodeStack_stackBits_append dec enc hdec,
+      List.take_take, Nat.min_self]
+  · rw [decodeStateAt, hword, List.headD_cons]
+
+/-- The decoder at the dispatch window. -/
+def decodeStateF (R : RankedAlphabet) (p : ℕ) (dec : (Fin p → Bool) → α)
+    (v : Fin (dispatchWidthF R p) → Bool) : FoldScan α :=
+  decodeStateAt R p dec (dispatchWidthF R p) (R.maxArity + 1) v
+
+/-- The decoder inverts the layout, up to truncating the stack at the dispatch
+window `R.maxArity + 1`. -/
+theorem decodeStateF_stateWordF_of_lt (R : RankedAlphabet)
+    (dec : (Fin p → Bool) → α) (enc : α → Fin p → Bool)
+    (hdec : ∀ a, dec (enc a) = a) (s : FoldScan α)
+    (h : s.buf.length < R.width) :
+    decodeStateF R p dec (bits (dispatchWidthF R p) (stateWordF R enc s)) =
+      { s with stack := s.stack.take (R.maxArity + 1) } :=
+  decodeStateAt_stateWordF_of_lt R dec enc hdec s (dispatchWidthF R p)
+    (R.maxArity + 1) (by rw [dispatchWidthF]) h
+
+/-- The bits a step drops from the state word: the flag and the slot, together
+with the entries the symbol of a completed block pops. -/
+def dropCountF (R : RankedAlphabet) (p : ℕ) (b : Bool) (s : FoldScan α) : ℕ :=
+  match s.live with
+  | false => 1 + R.width
+  | true =>
+    if (b :: s.buf).length = R.width then
+      match symOf R (decodeBits (b :: s.buf)) with
+      | none => 1 + R.width
+      | some i =>
+        if R.arity i ≤ s.stack.length then 1 + R.width + (p + 1) * R.arity i
+        else 1 + R.width
+    else 1 + R.width
+
+/-- The bits a step prepends to the state word: the rebuilt flag and slot,
+together with the entry the symbol of a completed block pushes. -/
+def nextPrefixF (R : RankedAlphabet) (enc : α → Fin p → Bool)
+    (alg : (i : Fin R.card) → (Fin (R.arity i) → α) → α) (b : Bool)
+    (s : FoldScan α) : List Bool :=
+  match s.live with
+  | false => false :: bufBits R s.buf
+  | true =>
+    if (b :: s.buf).length = R.width then
+      match symOf R (decodeBits (b :: s.buf)) with
+      | none => false :: bufBits R []
+      | some i =>
+        if h : R.arity i ≤ s.stack.length then
+          true :: bufBits R [] ++
+            entryBits enc (alg i fun d ↦ s.stack[d.val]'(Nat.lt_of_lt_of_le d.isLt h))
+        else false :: bufBits R []
+    else true :: bufBits R (b :: s.buf)
+
+/-- Truncating the stack at the dispatch window leaves the bits dropped
+unchanged: the only test reading the stack's height compares it with an arity,
+which `RankedAlphabet.arity_le_maxArity` bounds by `R.maxArity`. -/
+theorem dropCountF_take_stack (R : RankedAlphabet) (p : ℕ) (b : Bool)
+    (s : FoldScan α) :
+    dropCountF R p b { s with stack := s.stack.take (R.maxArity + 1) } =
+      dropCountF R p b s := by
+  obtain ⟨buf, stack, live⟩ := s
+  rw [dropCountF, dropCountF]
+  dsimp only
+  cases live
+  · rfl
+  · dsimp only
+    by_cases hlen : (b :: buf).length = R.width
+    · rw [if_pos hlen, if_pos hlen]
+      match hsym : symOf R (decodeBits (b :: buf)) with
+      | none => rfl
+      | some i =>
+        dsimp only
+        have hle : R.arity i ≤ R.maxArity := arity_le_maxArity R i
+        have hmin : (stack.take (R.maxArity + 1)).length =
+            min (R.maxArity + 1) stack.length := List.length_take
+        by_cases hst : R.arity i ≤ stack.length
+        · rw [if_pos hst, if_pos (by rw [hmin]; omega)]
+        · rw [if_neg hst, if_neg (by rw [hmin]; omega)]
+    · rw [if_neg hlen, if_neg hlen]
+
+/-- Truncating the stack at the dispatch window leaves the bits prepended
+unchanged: the entries the algebra reads are the first `R.arity i`, and the
+window holds `R.maxArity + 1` of them. -/
+theorem nextPrefixF_take_stack (R : RankedAlphabet) (enc : α → Fin p → Bool)
+    (alg : (i : Fin R.card) → (Fin (R.arity i) → α) → α) (b : Bool)
+    (s : FoldScan α) :
+    nextPrefixF R enc alg b { s with stack := s.stack.take (R.maxArity + 1) } =
+      nextPrefixF R enc alg b s := by
+  obtain ⟨buf, stack, live⟩ := s
+  rw [nextPrefixF, nextPrefixF]
+  dsimp only
+  cases live
+  · rfl
+  · dsimp only
+    by_cases hlen : (b :: buf).length = R.width
+    · rw [if_pos hlen, if_pos hlen]
+      match hsym : symOf R (decodeBits (b :: buf)) with
+      | none => rfl
+      | some i =>
+        dsimp only
+        have hle : R.arity i ≤ R.maxArity := arity_le_maxArity R i
+        have hmin : (stack.take (R.maxArity + 1)).length =
+            min (R.maxArity + 1) stack.length := List.length_take
+        by_cases hst : R.arity i ≤ stack.length
+        · rw [dif_pos hst, dif_pos (by rw [hmin]; omega)]
+          refine congrArg₂ List.cons rfl (congrArg₂ List.append rfl
+            (congrArg (entryBits enc) (congrArg (alg i) (funext fun d ↦ ?_))))
+          exact List.getElem_take
+        · rw [dif_neg hst, dif_neg (by rw [hmin]; omega)]
+    · rw [if_neg hlen, if_neg hlen]
+
+/-- A step of the fold scan rewrites a bounded prefix of the state word and
+drops a bounded number of its bits: the flag and the slot are rebuilt, and the
+stack in the tail is popped by the arity of a completed block's symbol and
+pushed with the algebra's value. -/
+theorem stateWordF_foldScanStep_of_lt (R : RankedAlphabet)
+    (enc : α → Fin p → Bool)
+    (alg : (i : Fin R.card) → (Fin (R.arity i) → α) → α) (b : Bool)
+    (s : FoldScan α) (h : s.buf.length < R.width) :
+    stateWordF R enc (foldScanStep R alg b s) =
+      nextPrefixF R enc alg b s ++
+        (stateWordF R enc s).drop (dropCountF R p b s) := by
+  have hpre : (s.live :: bufBits R s.buf).length = 1 + R.width := by
+    rw [List.length_cons, length_bufBits_of_lt R s.buf h]
+    omega
+  have hdrop : (stateWordF R enc s).drop (1 + R.width) = stackBits enc s.stack :=
+    List.drop_left' hpre
+  have hdropr : ∀ n : ℕ, (stateWordF R enc s).drop (1 + R.width + (p + 1) * n) =
+      stackBits enc (s.stack.drop n) := fun n ↦ by
+    rw [← List.drop_drop, hdrop, drop_stackBits_mul]
+  obtain ⟨buf, stack, live⟩ := s
+  dsimp only at hdrop hdropr
+  rw [foldScanStep, dropCountF, nextPrefixF]
+  dsimp only
+  cases live
+  · dsimp only
+    rw [hdrop]
+    rfl
+  · dsimp only
+    by_cases hlen : (b :: buf).length = R.width
+    · rw [if_pos hlen, if_pos hlen, if_pos hlen]
+      match hsym : symOf R (decodeBits (b :: buf)) with
+      | none =>
+        dsimp only
+        rw [hdrop]
+        rfl
+      | some i =>
+        dsimp only
+        by_cases hst : R.arity i ≤ stack.length
+        · rw [dif_pos hst, if_pos hst, dif_pos hst, hdropr (R.arity i),
+            stateWordF, List.cons_append, List.append_assoc]
+          rfl
+        · rw [dif_neg hst, if_neg hst, dif_neg hst, hdrop]
+          rfl
+    · rw [if_neg hlen, if_neg hlen, if_neg hlen, hdrop]
+      rfl
+
+end Geb.CobhamFold
+
+end

--- a/geb-lean/vendor/geb-mathlib/Geb/Internal/Computability/CobhamFoldProto/SelfDelim.lean
+++ b/geb-lean/vendor/geb-mathlib/Geb/Internal/Computability/CobhamFoldProto/SelfDelim.lean
@@ -1,0 +1,604 @@
+/-
+Copyright (c) 2026 Terence Rokop. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Terence Rokop
+-/
+-- Modified from geb-mathlib by scripts/geb-mathlib-backport.patch.
+module
+
+public import Geb.Internal.Computability.CobhamFoldProto.Bound
+
+/-!
+# Self-delimiting bitstrings in Cobham's class
+
+A stack whose entries are bitstrings of varying length needs entries that
+delimit themselves, and a step that reads one needs to parse it. This module
+supplies the parsing primitives as expressions of Cobham's class.
+
+An entry spelling the payload `u` is `List.replicate u.length true` followed by
+`false` followed by `u`: a unary length prefix, read from the list's head, which
+is the end a step of the outer scan pops from.
+
+`Cobham.scan` lifts steps of arity one, applying them to the recursive value
+alone. `dropUnaryOf`, `dropEntryOf` and `takeEntryOf` need the remaining word as
+well,
+which `Cobham.evalRec` supplies in slot zero of a step's environment, so `scan2`
+takes its steps at arity two directly.
+
+`takeEntryOf` is the one whose use of it is least avoidable. Its recursion
+appends a bit at the *end* of the payload accumulated so far, which is not a
+head operation; the `concat` generator supplies the append, and the appended bit is read
+off the remaining word by `firstBitOf` after `dropEntryOf`. Without slot zero the
+payload would not be extractable and the algebra could not be applied.
+
+## Main definitions
+
+* `Geb.CobhamFold.scan2` — the arity-two scan node as an expression;
+  `Geb.CobhamFold.scan2Raw` itself lives with the scan combinators in
+  `Geb/Internal/Computability/CobhamFoldProto/Bound.lean`.
+* `Geb.CobhamFold.entryWord` — the self-delimiting spelling of a payload.
+* `Geb.CobhamFold.firstBitOf`, `Geb.CobhamFold.unaryOf`,
+  `Geb.CobhamFold.takeUnaryOf`, `Geb.CobhamFold.dropUnaryOf`,
+  `Geb.CobhamFold.dropEntryOf`, `Geb.CobhamFold.takeEntryOf` — the parsing
+  primitives.
+* `Geb.CobhamFold.idOf`, `Geb.CobhamFold.dropEntriesOf`,
+  `Geb.CobhamFold.entryOf` — the identity, and the primitives iterated to reach
+  the `j`-th entry. The composition combinators they are built from live in
+  `Geb/Internal/Computability/CobhamFoldProto/Bound.lean`.
+
+## Main statements
+
+* `Geb.CobhamFold.scan2Sem_nil`, `Geb.CobhamFold.scan2Sem_cons` — the arity-two
+  scan on the empty word and on one bit.
+* `Geb.CobhamFold.stepWord_firstBitOf`, `Geb.CobhamFold.stepWord_unaryOf`,
+  `Geb.CobhamFold.stepWord_takeUnaryOf`,
+  `Geb.CobhamFold.stepWord_dropUnaryOf`,
+  `Geb.CobhamFold.stepWord_dropEntryOf`,
+  `Geb.CobhamFold.stepWord_takeEntryOf` — what each primitive computes.
+* `Geb.CobhamFold.take_succ_append_take_one` — a truncation splits at its
+  last bit.
+* `Geb.CobhamFold.takeEntrySem_entryWord`,
+  `Geb.CobhamFold.dropEntrySem_entryWord` — the payload and the remainder of a
+  self-delimiting entry.
+* `Geb.CobhamFold.two_mul_length_takeEntrySem_add_length_dropEntrySem_le` —
+  the payload counted twice and the remainder fit inside the word.
+
+* `Geb.CobhamFold.scan2Sem_eq_eval` — the meaning read at the raw tree is the
+  meaning the expression carries.
+
+## Implementation notes
+
+Every primitive's value is no longer than its argument, so each takes
+`Cobham.boundRaw 0` as its bound child: the recursion variable itself dominates.
+The bounds are established over arbitrary words, not only over well-formed
+entries, since `Cobham.RecBoundedValue` quantifies over every environment.
+
+Each primitive recurses over the whole word, not over the entry it reads.
+`Cobham.evalRec` recurses to the empty word whatever the value depends on, so
+`dropEntryOf` touches every bit of its argument although, at an entry spelling
+the payload `u`, the first `2 * u.length + 1` bits are what fix where its value
+starts. Their steps are not constant either: `dropEntryOf`'s
+applies `Cobham.pred`, itself a `boundedRec`, and `takeEntryOf`'s runs a fresh
+`dropEntryOf` over the remaining word, so counting a `boundedRec`'s cost as the
+sum over its levels of its step's cost makes `dropEntryOf` quadratic in its
+argument and `takeEntryOf` cubic.
+
+Nothing here measures a number of reduction steps, as
+`Geb/Mathlib/Computability/Cobham/Tree.lean` records of its own subject; the
+paragraph above analyses the expression under one cost model.
+
+The accompanying lower bound rests only on the class's shape rather than on a
+cost model: reading an unbounded field of the state requires a recursion over
+the state, `boundedRec` being the class's only recursion. It is an argument
+about the expression, not a theorem stated here.
+
+That gives a dichotomy rather than a spectrum, in what a step reads rather than
+in what it costs. A carrier whose values are bounded by a constant is the
+fixed-width case — pad to that constant and dispatch on a constant window, and
+no step reads an unbounded field. A carrier whose values are unbounded needs
+entries of this shape, and every step reads one. There is no intermediate
+regime, a bound of any constant `B` being the fixed-width case at width `B`.
+Neither case has constant-time steps: reading even a bounded prefix of the state
+goes through a `boundedRec` over the state.
+
+Only `boundedRec` nodes carry a `Cobham.RecBoundedValue` obligation, `comp`'s
+being vacuous, so composing these primitives imposes no further bound. This is
+why `entryWord`'s spelling, which is longer than its argument, needs no growth
+allowance: it is a composition, not a recursion.
+
+## References
+
+* [Cobham1965]
+
+## Tags
+
+Cobham, bounded recursion on notation, self-delimiting, prefix code
+-/
+
+@[expose] public section
+
+namespace Geb.CobhamFold
+
+open Cobham
+
+/-- The arity-two scan node over expressions, carrying its admissibility. -/
+def scan2W (base : COf 0) (step₀ step₁ : COf 2) : sig.W :=
+  ⟨scan2Raw base.1.1.1 step₀.1.1.1 step₁.1.1.1 (boundRaw 0),
+    wValid_scan2Raw _ _ _ _ base.1.1.2 base.2 step₀.1.1.2 step₀.2
+      step₁.1.1.2 step₁.2 (wValid_boundRaw 0) (wIndexRoot_boundRaw 0)⟩
+
+/-- The arity-two scan node's arity. -/
+theorem arity_scan2W (base : COf 0) (step₀ step₁ : COf 2) :
+    arity (scan2W base step₀ step₁) = 1 := rfl
+
+/-- The meaning of the arity-two scan at its arity. -/
+def scan2Sem (base : COf 0) (step₀ step₁ : COf 2) : Sem 1 :=
+  semAt 1 (scan2W base step₀ step₁) (arity_scan2W base step₀ step₁)
+
+/-- The word an arity-two step contributes at the remaining word and the
+recursive value. -/
+def step2Word (e : COf 2) (v r : List Bool) : List Bool :=
+  semAt 2 e.1.1 e.2 ![v, r]
+
+/-- The arity-two scan on the empty bitstring is its base's word. -/
+theorem scan2Sem_nil (base : COf 0) (step₀ step₁ : COf 2) :
+    scan2Sem base step₀ step₁ ![[]] = baseWord base := rfl
+
+/-- One step of the arity-two scan, which reads the remaining word as well as
+the value the scan of that word returns. -/
+theorem scan2Sem_cons (base : COf 0) (step₀ step₁ : COf 2) (b : Bool)
+    (w : List Bool) :
+    scan2Sem base step₀ step₁ ![b :: w] =
+      step2Word (if b then step₁ else step₀) w (scan2Sem base step₀ step₁ ![w]) := by
+  have hfun : ∀ v r : List Bool,
+      (Fin.cons v (Fin.cons r Fin.elim0) : Fin 2 → List Bool) = ![v, r] :=
+    fun v r ↦ funext fun i ↦ match i with | 0 => rfl | 1 => rfl
+  cases b
+  · change transport ((fst_eval step₀.1.1).trans step₀.2) (eval step₀.1.1).2
+      (Fin.cons w (Fin.cons (scan2Sem base step₀ step₁ ![w]) Fin.elim0)) = _
+    exact congrArg _ (hfun _ _)
+  · change transport ((fst_eval step₁.1.1).trans step₁.2) (eval step₁.1.1).2
+      (Fin.cons w (Fin.cons (scan2Sem base step₀ step₁ ![w]) Fin.elim0)) = _
+    exact congrArg _ (hfun _ _)
+
+/-- The arity-two scan as an expression of the class, its recursion bounded by
+the recursion variable itself. -/
+def scan2 (base : COf 0) (step₀ step₁ : COf 2)
+    (hbound : ∀ w : List Bool, (scan2Sem base step₀ step₁ ![w]).length ≤ w.length) :
+    C :=
+  ⟨scan2W base step₀ step₁, by
+    refine ⟨fun x ↦ ?_, ?_⟩
+    · rw [(funext fun i ↦ i.elim0 : Fin.tail x = Fin.tail ![x 0])]
+      change _ ≤ (boundSem 0 x).length
+      rw [boundSem_eq]
+      exact hbound (x 0)
+    · refine fun b : Fin 4 ↦ ?_
+      match b with
+      | 0 => exact base.1.2
+      | 1 => exact step₀.1.2
+      | 2 => exact step₁.1.2
+      | 3 => exact recBounded_boundRaw 0⟩
+
+/-- `scan2` at its declared arity. -/
+def scan2Of (base : COf 0) (step₀ step₁ : COf 2)
+    (hbound : ∀ w : List Bool, (scan2Sem base step₀ step₁ ![w]).length ≤ w.length) :
+    COf 1 :=
+  ⟨scan2 base step₀ step₁ hbound, rfl⟩
+
+/-- The meaning read at the raw tree is the meaning the expression carries. -/
+theorem scan2Sem_eq_eval (base : COf 0) (step₀ step₁ : COf 2)
+    (hbound : ∀ w : List Bool, (scan2Sem base step₀ step₁ ![w]).length ≤ w.length) :
+    transport (scan2Of base step₀ step₁ hbound).2
+        (scan2Of base step₀ step₁ hbound).1.eval =
+      scan2Sem base step₀ step₁ := rfl
+
+/-- Prepending a word prepends it to what an arity-two step contributes. -/
+theorem step2Word_prependOf (e : COf 2) (v r : List Bool) :
+    ∀ u : List Bool, step2Word (prependOf u e) v r = u ++ step2Word e v r :=
+  semAt_prependOf e ![v, r]
+
+/-- A constant arity-two step contributes its word, whatever it reads. -/
+theorem step2Word_constAtOf (u v r : List Bool) :
+    step2Word (constAtOf 2 u) v r = u :=
+  (step2Word_prependOf (zeroAtOf 2) v r u).trans (List.append_nil u)
+
+/-- A projection contributes the slot it names. -/
+theorem step2Word_projOf (i : Fin 2) (v r : List Bool) :
+    step2Word (projOf 2 i) v r = ![v, r] i := semAt_projOf 2 i ![v, r]
+
+/-- A composition contributes its head's value at its argument's. -/
+theorem step2Word_comp1Of (e : COf 1) (a : COf 2) (v r : List Bool) :
+    step2Word (comp1Of e a) v r = stepWord e (step2Word a v r) :=
+  congrArg (semAt 1 e.1.1 e.2) (funext fun i ↦ match i with | ⟨0, _⟩ => rfl)
+
+/-- A concatenation contributes its second argument's value followed by its
+first's. -/
+theorem step2Word_concatCompOf (a b : COf 2) (v r : List Bool) :
+    step2Word (concatCompOf 2 a b) v r =
+      step2Word b v r ++ step2Word a v r :=
+  semAt_concatCompOf 2 a b ![v, r]
+
+/-- The predecessor's value at an arity-one step. -/
+theorem stepWord_pred (u : List Bool) : stepWord pred u = u.tail :=
+  (stepWord_eq_eval pred u).trans (predSem_eq u)
+
+/-- The first bit of a word, absent at the empty word. -/
+def firstBitSem : Sem 1 :=
+  scan2Sem (zeroAtOf 0) (constAtOf 2 [false]) (constAtOf 2 [true])
+
+/-- What the first-bit primitive computes. -/
+theorem firstBitSem_eq : ∀ w : List Bool,
+    firstBitSem ![w] = match w with | [] => [] | b :: _ => [b]
+  | [] => rfl
+  | b :: v => by
+    change scan2Sem _ _ _ ![b :: v] = _
+    rw [scan2Sem_cons]
+    cases b <;> exact step2Word_constAtOf _ _ _
+
+/-- The first-bit primitive never lengthens its argument. -/
+theorem length_firstBitSem_le (w : List Bool) : (firstBitSem ![w]).length ≤ w.length := by
+  rw [firstBitSem_eq]
+  match w with
+  | [] => exact Nat.le_refl 0
+  | _ :: _ =>
+    rw [List.length_cons, List.length_cons, List.length_nil]
+    omega
+
+/-- The first bit of a word as an expression of arity one. -/
+def firstBitOf : COf 1 :=
+  scan2Of (zeroAtOf 0) (constAtOf 2 [false]) (constAtOf 2 [true])
+    length_firstBitSem_le
+
+/-- The first-bit expression's value at a step. -/
+@[simp] theorem stepWord_firstBitOf (w : List Bool) :
+    stepWord firstBitOf w = firstBitSem ![w] := rfl
+
+/-- A word's length in unary. -/
+def unarySem : Sem 1 :=
+  scan2Sem (zeroAtOf 0) (prependOf [true] (projOf 2 1))
+    (prependOf [true] (projOf 2 1))
+
+/-- One step of the unary primitive: each bit read contributes a `true`. -/
+theorem unarySem_cons (b : Bool) (v : List Bool) :
+    unarySem ![b :: v] = true :: unarySem ![v] := by
+  change scan2Sem _ _ _ ![b :: v] = _
+  rw [scan2Sem_cons]
+  cases b <;>
+    exact (step2Word_prependOf (projOf 2 1) v _ [true]).trans
+      (congrArg (fun t ↦ true :: t) (step2Word_projOf 1 v _))
+
+/-- The unary primitive spells its argument's length. -/
+theorem unarySem_eq : ∀ w : List Bool,
+    unarySem ![w] = List.replicate w.length true :=
+  List.rec rfl fun b v ih ↦ by
+    rw [unarySem_cons, ih, List.length_cons, List.replicate_succ]
+
+/-- The unary primitive never lengthens its argument. -/
+theorem length_unarySem_le (w : List Bool) : (unarySem ![w]).length ≤ w.length := by
+  rw [unarySem_eq, List.length_replicate]
+
+/-- A word's length in unary, as an expression of arity one. -/
+def unaryOf : COf 1 :=
+  scan2Of (zeroAtOf 0) (prependOf [true] (projOf 2 1))
+    (prependOf [true] (projOf 2 1)) length_unarySem_le
+
+/-- The unary expression's value at a step. -/
+@[simp] theorem stepWord_unaryOf (w : List Bool) :
+    stepWord unaryOf w = unarySem ![w] := rfl
+
+/-- The word past a unary length prefix and its sentinel. -/
+def dropUnarySem : Sem 1 := scan2Sem (zeroAtOf 0) (projOf 2 0) (projOf 2 1)
+
+/-- The prefix-dropping primitive on the empty word. -/
+theorem dropUnarySem_nil : dropUnarySem ![[]] = [] := rfl
+
+/-- What the prefix-dropping primitive computes: a `true` keeps the recursive
+value, a `false` ends the prefix and returns the remaining word. -/
+theorem dropUnarySem_cons (b : Bool) (v : List Bool) :
+    dropUnarySem ![b :: v] = if b then dropUnarySem ![v] else v := by
+  change scan2Sem _ _ _ ![b :: v] = _
+  rw [scan2Sem_cons]
+  cases b
+  · exact step2Word_projOf 0 v _
+  · exact step2Word_projOf 1 v _
+
+/-- The prefix-dropping primitive never lengthens its argument. -/
+theorem length_dropUnarySem_le : ∀ w : List Bool,
+    (dropUnarySem ![w]).length ≤ w.length :=
+  List.rec (Nat.le_refl 0) fun b v ih ↦ by
+    rw [dropUnarySem_cons, List.length_cons]
+    cases b
+    · rw [if_neg (by simp)]
+      omega
+    · rw [if_pos rfl]
+      omega
+
+/-- The word past a unary length prefix, as an expression of arity one. -/
+def dropUnaryOf : COf 1 :=
+  scan2Of (zeroAtOf 0) (projOf 2 0) (projOf 2 1) length_dropUnarySem_le
+
+/-- The prefix-dropping expression's value at a step. -/
+@[simp] theorem stepWord_dropUnaryOf (w : List Bool) :
+    stepWord dropUnaryOf w = dropUnarySem ![w] := rfl
+
+/-- The word past a whole self-delimiting entry. -/
+def dropEntrySem : Sem 1 :=
+  scan2Sem (zeroAtOf 0) (projOf 2 0) (comp1Of pred (projOf 2 1))
+
+/-- The entry-dropping primitive on the empty word. -/
+theorem dropEntrySem_nil : dropEntrySem ![[]] = [] := rfl
+
+/-- What the entry-dropping primitive computes: a `true` lengthens the prefix by
+one and so drops one more payload bit, and a `false` ends the prefix. -/
+theorem dropEntrySem_cons (b : Bool) (v : List Bool) :
+    dropEntrySem ![b :: v] = if b then (dropEntrySem ![v]).tail else v := by
+  change scan2Sem _ _ _ ![b :: v] = _
+  rw [scan2Sem_cons]
+  cases b
+  · exact step2Word_projOf 0 v _
+  · refine (step2Word_comp1Of pred (projOf 2 1) v _).trans ?_
+    rw [step2Word_projOf]
+    exact stepWord_pred _
+
+/-- The entry-dropping primitive never lengthens its argument. -/
+theorem length_dropEntrySem_le : ∀ w : List Bool,
+    (dropEntrySem ![w]).length ≤ w.length :=
+  List.rec (Nat.le_refl 0) fun b v ih ↦ by
+    rw [dropEntrySem_cons, List.length_cons]
+    cases b
+    · rw [if_neg (by simp)]
+      omega
+    · rw [if_pos rfl, List.length_tail]
+      omega
+
+/-- The word past a whole self-delimiting entry, as an expression of arity
+one. -/
+def dropEntryOf : COf 1 :=
+  scan2Of (zeroAtOf 0) (projOf 2 0) (comp1Of pred (projOf 2 1))
+    length_dropEntrySem_le
+
+/-- The entry-dropping expression's value at a step. -/
+@[simp] theorem stepWord_dropEntryOf (w : List Bool) :
+    stepWord dropEntryOf w = dropEntrySem ![w] := rfl
+
+/-- The payload of a self-delimiting entry. -/
+def takeEntrySem : Sem 1 :=
+  scan2Sem (zeroAtOf 0) (zeroAtOf 2)
+    (concatCompOf 2 (comp1Of firstBitOf (comp1Of dropEntryOf (projOf 2 0)))
+      (projOf 2 1))
+
+/-- The payload primitive on the empty word. -/
+theorem takeEntrySem_nil : takeEntrySem ![[]] = [] := rfl
+
+/-- What the payload primitive computes. The `true` clause appends one bit at
+the payload's end, which the `concat` generator supplies and which is read off the
+remaining word rather than off the recursive value. -/
+theorem takeEntrySem_cons (b : Bool) (v : List Bool) :
+    takeEntrySem ![b :: v] =
+      if b then takeEntrySem ![v] ++ firstBitSem ![dropEntrySem ![v]] else [] := by
+  change scan2Sem _ _ _ ![b :: v] = _
+  rw [scan2Sem_cons]
+  cases b
+  · exact step2Word_constAtOf [] v _
+  · refine (step2Word_concatCompOf _ _ v _).trans ?_
+    rw [step2Word_projOf, step2Word_comp1Of, step2Word_comp1Of,
+      step2Word_projOf]
+    rfl
+
+/-- The payload primitive never lengthens its argument. -/
+theorem length_takeEntrySem_le : ∀ w : List Bool,
+    (takeEntrySem ![w]).length ≤ w.length :=
+  List.rec (Nat.le_refl 0) fun b v ih ↦ by
+    rw [takeEntrySem_cons, List.length_cons]
+    cases b
+    · rw [if_neg (by simp), List.length_nil]
+      omega
+    · rw [if_pos rfl, List.length_append]
+      have := length_firstBitSem_le (dropEntrySem ![v])
+      have := length_dropEntrySem_le v
+      have hfb : (firstBitSem ![dropEntrySem ![v]]).length ≤ 1 := by
+        rw [firstBitSem_eq]
+        match dropEntrySem ![v] with
+        | [] => exact Nat.zero_le 1
+        | _ :: _ => exact Nat.le_refl 1
+      omega
+
+/-- The payload and the remainder together fit inside the word, the payload
+counted twice: a `true` lengthens the payload by at most one bit while the
+remainder loses one, so the weighted total does not grow. This is what bounds
+a general paramorphism step's contribution. -/
+theorem two_mul_length_takeEntrySem_add_length_dropEntrySem_le :
+    ∀ w : List Bool,
+      2 * (takeEntrySem ![w]).length + (dropEntrySem ![w]).length ≤ w.length :=
+  List.rec (Nat.le_refl 0) fun b v ih ↦ by
+    rw [takeEntrySem_cons, dropEntrySem_cons, List.length_cons]
+    cases b
+    · rw [if_neg (by simp), if_neg (by simp), List.length_nil]
+      omega
+    · rw [if_pos rfl, if_pos rfl, List.length_append, List.length_tail,
+        firstBitSem_eq]
+      match hd : dropEntrySem ![v] with
+      | [] =>
+        rw [hd] at ih
+        simp only [List.length_nil]
+        omega
+      | c :: t =>
+        rw [hd, List.length_cons] at ih
+        simp only [List.length_cons, List.length_nil]
+        omega
+
+/-- The payload of a self-delimiting entry, as an expression of arity one. -/
+def takeEntryOf : COf 1 :=
+  scan2Of (zeroAtOf 0) (zeroAtOf 2)
+    (concatCompOf 2 (comp1Of firstBitOf (comp1Of dropEntryOf (projOf 2 0)))
+      (projOf 2 1)) length_takeEntrySem_le
+
+/-- The payload expression's value at a step. -/
+@[simp] theorem stepWord_takeEntryOf (w : List Bool) :
+    stepWord takeEntryOf w = takeEntrySem ![w] := rfl
+
+/-- A composition's value at an arity-one step. -/
+theorem stepWord_compOf {m : ℕ} (head : COf m) (args : Fin m → COf 1)
+    (u : List Bool) :
+    stepWord (compOf head args) u =
+      semAt m head.1.1 head.2 fun i ↦ stepWord (args i) u :=
+  semAt_compOf head args ![u]
+
+/-- An arity-one composition's value at an arity-one step. -/
+theorem stepWord_comp1Of (e a : COf 1) (u : List Bool) :
+    stepWord (comp1Of e a) u = stepWord e (stepWord a u) :=
+  semAt_comp1Of e a ![u]
+
+/-- A concatenation's value at an arity-one step. -/
+theorem stepWord_concatCompOf (a b : COf 1) (u : List Bool) :
+    stepWord (concatCompOf 1 a b) u = stepWord b u ++ stepWord a u :=
+  semAt_concatCompOf 1 a b ![u]
+
+/-- The identity, as an expression of arity one: the sole projection at that
+arity, named for the use it is put to. -/
+def idOf : COf 1 := projOf 1 0
+
+/-- The identity's value at a step. -/
+@[simp] theorem stepWord_idOf (u : List Bool) : stepWord idOf u = u :=
+  semAt_projOf 1 0 ![u]
+
+/-- The leading run of `true` of a word. -/
+def takeUnarySem : Sem 1 :=
+  scan2Sem (zeroAtOf 0) (zeroAtOf 2) (prependOf [true] (projOf 2 1))
+
+/-- The run primitive on the empty word. -/
+theorem takeUnarySem_nil : takeUnarySem ![[]] = [] := rfl
+
+/-- What the run primitive computes: a `true` extends the run, a `false` ends
+it. -/
+theorem takeUnarySem_cons (b : Bool) (v : List Bool) :
+    takeUnarySem ![b :: v] = if b then true :: takeUnarySem ![v] else [] := by
+  change scan2Sem _ _ _ ![b :: v] = _
+  rw [scan2Sem_cons]
+  cases b
+  · exact step2Word_constAtOf [] v _
+  · exact (step2Word_prependOf (projOf 2 1) v _ [true]).trans
+      (congrArg (fun t ↦ true :: t) (step2Word_projOf 1 v _))
+
+/-- The run primitive never lengthens its argument. -/
+theorem length_takeUnarySem_le : ∀ w : List Bool,
+    (takeUnarySem ![w]).length ≤ w.length :=
+  List.rec (Nat.le_refl 0) fun b v ih ↦ by
+    rw [takeUnarySem_cons, List.length_cons]
+    cases b
+    · rw [if_neg (by simp), List.length_nil]
+      omega
+    · rw [if_pos rfl, List.length_cons]
+      omega
+
+/-- The leading run of `true`, as an expression of arity one. -/
+def takeUnaryOf : COf 1 :=
+  scan2Of (zeroAtOf 0) (zeroAtOf 2) (prependOf [true] (projOf 2 1))
+    length_takeUnarySem_le
+
+/-- The run expression's value at a step. -/
+@[simp] theorem stepWord_takeUnaryOf (w : List Bool) :
+    stepWord takeUnaryOf w = takeUnarySem ![w] := rfl
+
+/-- The run primitive returns the unary prefix a word carries. -/
+theorem takeUnarySem_replicate (X : List Bool) : ∀ k : ℕ,
+    takeUnarySem ![List.replicate k true ++ false :: X] = List.replicate k true :=
+  Nat.rec (by rw [List.replicate_zero, List.nil_append, takeUnarySem_cons,
+      if_neg (by simp)])
+    fun k ih ↦ by
+      rw [List.replicate_succ, List.cons_append, takeUnarySem_cons, if_pos rfl,
+        ih]
+
+/-- Dropping a fixed number of whole self-delimiting entries. -/
+def dropEntriesOf : ℕ → COf 1 :=
+  Nat.rec idOf fun _ ih ↦ comp1Of ih dropEntryOf
+
+/-- Dropping no entries is the identity. -/
+@[simp] theorem dropEntriesOf_zero : dropEntriesOf 0 = idOf := rfl
+
+/-- Dropping one more entry drops one first. -/
+theorem stepWord_dropEntriesOf_succ (k : ℕ) (u : List Bool) :
+    stepWord (dropEntriesOf (k + 1)) u =
+      stepWord (dropEntriesOf k) (dropEntrySem ![u]) :=
+  stepWord_comp1Of _ _ u
+
+/-- The payload of the `j`-th self-delimiting entry. -/
+def entryOf (j : ℕ) : COf 1 := comp1Of takeEntryOf (dropEntriesOf j)
+
+/-- The `j`-th entry is the payload past `j` dropped entries. -/
+theorem stepWord_entryOf (j : ℕ) (u : List Bool) :
+    stepWord (entryOf j) u = takeEntrySem ![stepWord (dropEntriesOf j) u] :=
+  stepWord_comp1Of _ _ u
+
+/-- The self-delimiting spelling of a payload: its length in unary, a `false`
+sentinel, then the payload. -/
+def entryWord (u : List Bool) : List Bool :=
+  List.replicate u.length true ++ false :: u
+
+/-- An entry's length: twice the payload's, plus the sentinel. -/
+@[simp] theorem length_entryWord (u : List Bool) :
+    (entryWord u).length = 2 * u.length + 1 := by
+  rw [entryWord, List.length_append, List.length_replicate, List.length_cons]
+  omega
+
+/-- The first-bit primitive is the one-bit truncation. -/
+theorem firstBitSem_eq_take_one : ∀ z : List Bool, firstBitSem ![z] = z.take 1
+  | [] => rfl
+  | b :: t => by
+    rw [firstBitSem_eq (b :: t)]
+    rfl
+
+/-- The prefix-dropping primitive reads a unary prefix off and returns what
+follows the sentinel. -/
+theorem dropUnarySem_replicate (X : List Bool) : ∀ k : ℕ,
+    dropUnarySem ![List.replicate k true ++ false :: X] = X :=
+  Nat.rec rfl fun k ih ↦ by
+    rw [List.replicate_succ, List.cons_append, dropUnarySem_cons, if_pos rfl, ih]
+
+/-- The entry-dropping primitive drops as many payload bits as the unary prefix
+counts. -/
+theorem dropEntrySem_replicate (X : List Bool) : ∀ k : ℕ,
+    dropEntrySem ![List.replicate k true ++ false :: X] = X.drop k :=
+  Nat.rec (by rw [List.replicate_zero, List.nil_append, dropEntrySem_cons,
+      if_neg (by simp), List.drop_zero])
+    fun k ih ↦ by
+      rw [List.replicate_succ, List.cons_append, dropEntrySem_cons, if_pos rfl,
+        ih, List.tail_drop]
+
+/-- Splitting a truncation at its last bit. Proved here rather than by
+`List.take_add`, which was measured to depend on `Classical.choice`. -/
+theorem take_succ_append_take_one : ∀ (k : ℕ) (X : List Bool),
+    X.take (k + 1) = X.take k ++ (X.drop k).take 1 :=
+  Nat.rec (fun X ↦ by rw [List.take_zero, List.nil_append, List.drop_zero])
+    fun k ih X ↦ match X with
+      | [] => rfl
+      | b :: t => by
+        rw [List.take_succ_cons, List.take_succ_cons, List.drop_succ_cons,
+          List.cons_append, ih t]
+
+/-- The payload primitive reads exactly as many bits as the unary prefix
+counts. -/
+theorem takeEntrySem_replicate (X : List Bool) : ∀ k : ℕ,
+    takeEntrySem ![List.replicate k true ++ false :: X] = X.take k :=
+  Nat.rec (by rw [List.replicate_zero, List.nil_append, takeEntrySem_cons,
+      if_neg (by simp), List.take_zero])
+    fun k ih ↦ by
+      rw [List.replicate_succ, List.cons_append, takeEntrySem_cons, if_pos rfl,
+        ih, dropEntrySem_replicate, firstBitSem_eq_take_one,
+        ← take_succ_append_take_one]
+
+/-- The payload primitive returns an entry's payload, whatever follows it. -/
+theorem takeEntrySem_entryWord (u rest : List Bool) :
+    takeEntrySem ![entryWord u ++ rest] = u := by
+  rw [entryWord, List.append_assoc, List.cons_append, takeEntrySem_replicate,
+    List.take_left]
+
+/-- The entry-dropping primitive returns whatever follows an entry. -/
+theorem dropEntrySem_entryWord (u rest : List Bool) :
+    dropEntrySem ![entryWord u ++ rest] = rest := by
+  rw [entryWord, List.append_assoc, List.cons_append, dropEntrySem_replicate,
+    List.drop_left]
+
+end Geb.CobhamFold
+
+end

--- a/geb-lean/vendor/geb-mathlib/Geb/Internal/Computability/CobhamFoldProto/SmashFree.lean
+++ b/geb-lean/vendor/geb-mathlib/Geb/Internal/Computability/CobhamFoldProto/SmashFree.lean
@@ -1,0 +1,553 @@
+/-
+Copyright (c) 2026 Terence Rokop. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Terence Rokop
+-/
+-- Modified from geb-mathlib by scripts/geb-mathlib-backport.patch.
+module
+
+public import Geb.Internal.Computability.CobhamFoldProto.Expr
+public import Geb.Internal.Computability.CobhamFoldProto.Variable
+
+/-!
+# Smash-freeness at a symbolic tree
+
+`Cobham.smashFreeBool` is a `WType.elim` whose clause at a node applies `decide`
+to a quantification over `Cobham.sig.B`. Instance search does not find the
+`Cobham.sigFinitary`-derived enumeration at that form, and the `WType.elim` does
+not reduce at a variable shape, so a `Cobham.SmashFree` claim about a symbolic
+tree is not available by `decide_eq_true`.
+
+This module supplies the two missing steps: `instFinEnumSigB` names the
+enumeration at the form the quantification reads, and splitting the shape
+reduces the `WType.elim`, giving at each shape but `smash` an equivalence
+between a node's smash-freeness and its children's. The implications compose
+through the combinators.
+
+## Main definitions
+
+* `Geb.CobhamFold.instFinEnumSigB` — the direction family's enumeration, at the
+  form `Cobham.smashFreeBool`'s quantification reads.
+
+## Main statements
+
+* `Geb.CobhamFold.smashFreeBool_mk_iff` — a node other than `smash` is
+  smash-free exactly when its children are.
+* `Geb.CobhamFold.smashFreeBool_mk` — its `mpr`, which the generator lemmas
+  below apply directly and every other lemma reaches through
+  `Geb.CobhamFold.smashFreeBool_projRaw`,
+  `Geb.CobhamFold.smashFreeBool_compRaw` or
+  `Geb.CobhamFold.smashFreeBool_boundedRecRaw`.
+* `Geb.CobhamFold.smashFreeBool_boundMulRaw` — the multiplicative bound child
+  carries no `smash`, at every multiplicity and growth.
+* `Geb.CobhamFold.smashFree_foldOutExpr` — the fixed-width construction's
+  output expression is smash-free at every alphabet and carrier width.
+* `Geb.CobhamFold.smashFree_foldOutExprV` — the bitstring construction's is
+  smash-free when the algebra's own expressions are.
+
+## Implementation notes
+
+Two separate obstructions stand between `Cobham.smashFreeBool` and a symbolic
+claim, and each step removes one. `instFinEnumSigB` supplies decidability, which
+instance search does not: `Cobham.sigFinitary`'s branches ascribe the
+enumeration of the literal `Cobham.Direction` each shape produces, and instance
+search does not delta-reduce the semireducible `Cobham.sig` to match `sig.B a`
+against them, as `Geb/Mathlib/Computability/Cobham/Basic.lean` records. That
+holds at a constructor shape as much as at a variable one. Splitting the shape
+addresses the other obstruction, reducing the `WType.elim`, without which the
+equivalence's two sides are not defeq. Neither step alone suffices.
+
+## References
+
+* [HeraudNowak2011]
+* [Strahm2003]
+
+## Tags
+
+Cobham, smash-free, subalgebra
+-/
+
+@[expose] public section
+
+namespace Geb.CobhamFold
+
+open Cobham RankedAlphabet
+
+universe u
+
+/-- The direction family's enumeration, named at the projection
+`Cobham.sig.B` rather than at the literal `Cobham.Direction` that
+`Cobham.sigFinitary`'s branches ascribe. Instance search does not delta-reduce
+the semireducible `Cobham.sig`, so it does not reach that enumeration at the
+form `Cobham.smashFreeBool`'s `decide` quantifies over, at any shape. -/
+instance instFinEnumSigB (a : Shape) : FinEnum (sig.B a) := sigFinitary a
+
+/-- A node other than `smash` is smash-free exactly when its children are. -/
+theorem smashFreeBool_mk_iff : ∀ (a : Shape) (_ha : a ≠ .smash)
+    (f : sig.toPFunctor.B a → sig.toPFunctor.W),
+    smashFreeBool (WType.mk a f) = true ↔ ∀ d, smashFreeBool (f d) = true
+  | .zero, _, _f => ⟨fun h ↦ of_decide_eq_true h, fun h ↦ decide_eq_true h⟩
+  | .proj _ _, _, _f =>
+    ⟨fun h ↦ of_decide_eq_true h, fun h ↦ decide_eq_true h⟩
+  | .succ _, _, _f =>
+    ⟨fun h ↦ of_decide_eq_true h, fun h ↦ decide_eq_true h⟩
+  | .smash, h, _ => absurd rfl h
+  | .concat, _, _f =>
+    ⟨fun h ↦ of_decide_eq_true h, fun h ↦ decide_eq_true h⟩
+  | .comp _ _, _, _f =>
+    ⟨fun h ↦ of_decide_eq_true h, fun h ↦ decide_eq_true h⟩
+  | .boundedRec _, _, _f =>
+    ⟨fun h ↦ of_decide_eq_true h, fun h ↦ decide_eq_true h⟩
+
+/-- A node other than `smash` is smash-free when its children are. -/
+theorem smashFreeBool_mk (a : Shape) (ha : a ≠ .smash)
+    (f : sig.toPFunctor.B a → sig.toPFunctor.W)
+    (h : ∀ d, smashFreeBool (f d) = true) :
+    smashFreeBool (WType.mk a f) = true :=
+  (smashFreeBool_mk_iff a ha f).mpr h
+
+/-- A projection carries no `smash`. -/
+theorem smashFreeBool_projRaw (n : ℕ) (i : Fin n) :
+    smashFreeBool (WType.mk (.proj n i) Fin.elim0) = true :=
+  smashFreeBool_mk _ (by nofun) _ fun d ↦ d.elim0
+
+/-- The empty bitstring carries no `smash`. -/
+theorem smashFreeBool_zeroRaw :
+    smashFreeBool (WType.mk .zero Fin.elim0) = true :=
+  smashFreeBool_mk _ (by nofun) _ fun d ↦ d.elim0
+
+/-- A successor carries no `smash`. -/
+theorem smashFreeBool_succRaw (b : Bool) :
+    smashFreeBool (WType.mk (.succ b) Fin.elim0) = true :=
+  smashFreeBool_mk _ (by nofun) _ fun d ↦ d.elim0
+
+/-- The `concat` generator carries no `smash`. -/
+theorem smashFreeBool_concatRaw : smashFreeBool concatRaw = true :=
+  smashFreeBool_mk _ (by nofun) _ fun d ↦ d.elim0
+
+/-- A composition carries no `smash` when its head and arguments do. -/
+theorem smashFreeBool_compRaw (n m : ℕ) (f : Direction (.comp n m) → sig.toPFunctor.W)
+    (h : ∀ d, smashFreeBool (f d) = true) :
+    smashFreeBool (WType.mk (.comp n m) f) = true :=
+  smashFreeBool_mk _ (by nofun) _ h
+
+/-- A bounded recursion carries no `smash` when its four children do. -/
+theorem smashFreeBool_boundedRecRaw (n : ℕ)
+    (f : Direction (.boundedRec n) → sig.toPFunctor.W)
+    (h : ∀ d, smashFreeBool (f d) = true) :
+    smashFreeBool (WType.mk (.boundedRec n) f) = true :=
+  smashFreeBool_mk _ (by nofun) _ h
+
+/-- The empty bitstring at an arity carries no `smash`. -/
+theorem smashFreeBool_zeroAtRaw (n : ℕ) :
+    smashFreeBool (zeroAtRaw n) = true :=
+  smashFreeBool_compRaw n 0 _ fun d ↦ match d with
+    | .inl () => smashFreeBool_zeroRaw
+    | .inr i => i.elim0
+
+/-- Prepending a word carries no `smash` when what it prepends to does. -/
+theorem smashFreeBool_prependRaw (n : ℕ) (e : sig.toPFunctor.W)
+    (he : smashFreeBool e = true) :
+    ∀ u : List Bool, smashFreeBool (prependRaw n u e) = true :=
+  List.rec he fun b _ ih ↦
+    smashFreeBool_compRaw n 1 _ fun d ↦ match d with
+      | .inl () => smashFreeBool_succRaw b
+      | .inr _ => ih
+
+/-- The empty bitstring at an arity, as an expression, carries no `smash`. -/
+theorem smashFreeBool_zeroAtOf (n : ℕ) :
+    smashFreeBool (zeroAtOf n).1.1.1 = true := smashFreeBool_zeroAtRaw n
+
+/-- A constant word carries no `smash`. -/
+theorem smashFreeBool_constAtOf (n : ℕ) (u : List Bool) :
+    smashFreeBool (constAtOf n u).1.1.1 = true :=
+  smashFreeBool_prependRaw n _ (smashFreeBool_zeroAtRaw n) u
+
+/-- The predecessor carries no `smash`. -/
+theorem smashFreeBool_predRaw : smashFreeBool predRaw = true :=
+  smashFreeBool_boundedRecRaw 0 _ fun d : Fin 4 ↦ match d with
+    | 0 => smashFreeBool_zeroRaw
+    | 1 | 2 => smashFreeBool_projRaw 2 0
+    | 3 => smashFreeBool_projRaw 1 0
+
+/-- The iterated predecessor carries no `smash`. -/
+theorem smashFreeBool_predIterRaw : ∀ k : ℕ,
+    smashFreeBool (predIterRaw k) = true :=
+  Nat.rec (smashFreeBool_projRaw 1 0) fun _ ih ↦
+    smashFreeBool_compRaw 1 1 _ fun d ↦ match d with
+      | .inl () => smashFreeBool_predRaw
+      | .inr _ => ih
+
+/-- The iterated predecessor expression carries no `smash`. -/
+theorem smashFreeBool_predIterOf (k : ℕ) :
+    smashFreeBool (predIterOf k).1.1.1 = true := smashFreeBool_predIterRaw k
+
+/-- The diagonal carries no `smash` when what it diagonalises does. -/
+theorem smashFreeBool_diagRaw (e : sig.toPFunctor.W)
+    (he : smashFreeBool e = true) : smashFreeBool (diagRaw e) = true :=
+  smashFreeBool_compRaw 1 2 _ fun d ↦ match d with
+    | .inl () => he
+    | .inr _ => smashFreeBool_projRaw 1 0
+
+/-- A concatenation node carries no `smash` when its arguments do. -/
+theorem smashFreeBool_concatCompRaw (n : ℕ) (a b : sig.toPFunctor.W)
+    (ha : smashFreeBool a = true) (hb : smashFreeBool b = true) :
+    smashFreeBool (concatCompRaw n a b) = true :=
+  smashFreeBool_compRaw n 2 _ fun d ↦ match d with
+    | .inl () => smashFreeBool_concatRaw
+    | .inr i => match i with
+      | 0 => ha
+      | 1 => hb
+
+/-- The four-way conditional carries no `smash`: its bound child is a
+concatenation where [HeraudNowak2011] takes a smash. -/
+theorem smashFreeBool_condRaw : smashFreeBool condRaw = true :=
+  smashFreeBool_boundedRecRaw 3 _ fun d : Fin 4 ↦ match d with
+    | 0 => smashFreeBool_projRaw 3 0
+    | 1 => smashFreeBool_projRaw 5 4
+    | 2 => smashFreeBool_projRaw 5 3
+    | 3 =>
+      smashFreeBool_concatCompRaw 4 _ _
+        (smashFreeBool_concatCompRaw 4 _ _ (smashFreeBool_projRaw 4 1)
+          (smashFreeBool_projRaw 4 2))
+        (smashFreeBool_projRaw 4 3)
+
+/-- A shifted expression carries no `smash` when what it shifts does. Its
+argument zero is the predecessor of the outer one, so the predecessor's own
+freedom enters. -/
+theorem smashFreeBool_shiftRaw (e : sig.toPFunctor.W)
+    (he : smashFreeBool e = true) : smashFreeBool (shiftRaw e) = true :=
+  smashFreeBool_compRaw 2 2 _ fun d ↦ match d with
+    | .inl () => he
+    | .inr i => match i with
+      | 0 =>
+        smashFreeBool_compRaw 2 1 _ fun c ↦ match c with
+          | .inl () => smashFreeBool_predRaw
+          | .inr _ => smashFreeBool_projRaw 2 0
+      | 1 => smashFreeBool_projRaw 2 1
+
+/-- A lifted step carries no `smash` when what it lifts does. -/
+theorem smashFreeBool_liftRaw (e : sig.toPFunctor.W)
+    (he : smashFreeBool e = true) : smashFreeBool (liftRaw e) = true :=
+  smashFreeBool_compRaw 2 1 _ fun d ↦ match d with
+    | .inl () => he
+    | .inr _ => smashFreeBool_projRaw 2 1
+
+/-- A case tree carries no `smash` when every branch does. The recursion is the
+one `Cobham.wValid_casesRaw` performs, the motive generalizing over the branch
+family. -/
+theorem smashFreeBool_casesRaw : ∀ (p : ℕ) (br : (Fin p → Bool) → sig.toPFunctor.W),
+    (∀ v, smashFreeBool (br v) = true) → smashFreeBool (casesRaw p br) = true :=
+  Nat.rec (fun _br h ↦ smashFreeBool_liftRaw _ (h _))
+    fun _p ih _br h ↦
+      smashFreeBool_compRaw 2 4 _ fun d ↦ match d with
+        | .inl () => smashFreeBool_condRaw
+        | .inr i => match i with
+          | 0 => smashFreeBool_projRaw 2 0
+          | 1 => smashFreeBool_shiftRaw _ (ih _ fun _ ↦ h _)
+          | 2 => smashFreeBool_shiftRaw _ (ih _ fun _ ↦ h _)
+          | 3 => smashFreeBool_shiftRaw _ (ih _ fun _ ↦ h _)
+
+/-- The multiplier carries no `smash`. -/
+theorem smashFreeBool_multRaw : ∀ mult : ℕ,
+    smashFreeBool (multRaw mult) = true :=
+  Nat.rec (smashFreeBool_zeroAtRaw 1) fun _ ih ↦
+    smashFreeBool_concatCompRaw 1 _ _ ih (smashFreeBool_projRaw 1 0)
+
+/-- The multiplicative bound child carries no `smash`, at every multiplicity and
+growth. -/
+theorem smashFreeBool_boundMulRaw (mult growth : ℕ) :
+    smashFreeBool (boundMulRaw mult growth) = true :=
+  smashFreeBool_prependRaw 1 _ (smashFreeBool_multRaw mult) _
+
+/-- The arity-two scan node carries no `smash` when its four children do. -/
+theorem smashFreeBool_scan2Raw (base step₀ step₁ bnd : sig.toPFunctor.W)
+    (hb : smashFreeBool base = true) (h₀ : smashFreeBool step₀ = true)
+    (h₁ : smashFreeBool step₁ = true) (hn : smashFreeBool bnd = true) :
+    smashFreeBool (scan2Raw base step₀ step₁ bnd) = true :=
+  smashFreeBool_boundedRecRaw 0 _ fun d : Fin 4 ↦ match d with
+    | 0 => hb
+    | 1 => h₀
+    | 2 => h₁
+    | 3 => hn
+
+/-- The scan node at an arbitrary bound child carries no `smash` when its
+components do. -/
+theorem smashFreeBool_scanBRaw (base step₀ step₁ bnd : sig.toPFunctor.W)
+    (hb : smashFreeBool base = true) (h₀ : smashFreeBool step₀ = true)
+    (h₁ : smashFreeBool step₁ = true) (hn : smashFreeBool bnd = true) :
+    smashFreeBool (scanBRaw base step₀ step₁ bnd) = true :=
+  smashFreeBool_scan2Raw base _ _ bnd hb (smashFreeBool_liftRaw _ h₀)
+    (smashFreeBool_liftRaw _ h₁) hn
+
+/-- A composition of expressions carries no `smash` when its head and arguments
+do. -/
+theorem smashFreeBool_compOf {n m : ℕ} (head : COf m) (args : Fin m → COf n)
+    (hh : smashFreeBool head.1.1.1 = true)
+    (ha : ∀ i, smashFreeBool (args i).1.1.1 = true) :
+    smashFreeBool (compOf head args).1.1.1 = true :=
+  smashFreeBool_compRaw n m _ fun d ↦ match d with
+    | .inl () => hh
+    | .inr i => ha i
+
+/-- The case combinator carries no `smash` when every branch does. -/
+theorem smashFreeBool_casesOf (p : ℕ) (br : (Fin p → Bool) → COf 1)
+    (h : ∀ v, smashFreeBool (br v).1.1.1 = true) :
+    smashFreeBool (casesOf p br).1.1.1 = true :=
+  smashFreeBool_casesRaw p _ h
+
+/-- The diagonal of a case tree whose branches all carry no `smash` carries
+none: the shape every step and readout of both fold constructions takes. -/
+theorem smashFreeBool_diagCasesOf (p : ℕ) (br : (Fin p → Bool) → COf 1)
+    (h : ∀ v, smashFreeBool (br v).1.1.1 = true) :
+    smashFreeBool (diagOf (casesOf p br)).1.1.1 = true :=
+  smashFreeBool_diagRaw _ (smashFreeBool_casesOf p br h)
+
+/-- The fixed-width readout carries no `smash`: every branch is a constant
+word. -/
+theorem smashFreeBool_readOf {α : Type u} {p : ℕ} (R : RankedAlphabet)
+    (enc : α → Fin p → Bool) (dec : (Fin p → Bool) → α) :
+    smashFreeBool (readOf R p enc dec).1.1.1 = true :=
+  smashFreeBool_diagCasesOf _ _ fun _ ↦ smashFreeBool_constAtOf 1 _
+
+/-- A step of the fixed-width fold carries no `smash`: every branch prepends a
+constant word to an iterated predecessor. -/
+theorem smashFreeBool_foldStepF {α : Type u} {p : ℕ} (R : RankedAlphabet)
+    (enc : α → Fin p → Bool) (dec : (Fin p → Bool) → α)
+    (alg : (i : Fin R.card) → (Fin (R.arity i) → α) → α) (b : Bool) :
+    smashFreeBool (foldStepF R p enc dec alg b).1.1.1 = true :=
+  smashFreeBool_diagCasesOf _ _ fun _ ↦
+    smashFreeBool_prependRaw 1 _ (smashFreeBool_predIterOf _) _
+
+/-- The fixed-width fold lies in the subalgebra `Cobham.SmashFree` names, at a
+symbolic alphabet, a symbolic carrier width and an arbitrary algebra. With
+[Strahm2003] Theorem 1(2)'s left-to-right inclusion it is computable
+simultaneously in polynomial time and linear space. -/
+theorem smashFree_foldOutExpr {α : Type u} {p : ℕ} (R : RankedAlphabet)
+    (enc : α → Fin p → Bool) (dec : (Fin p → Bool) → α)
+    (hdec : ∀ a, dec (enc a) = a)
+    (alg : (i : Fin R.card) → (Fin (R.arity i) → α) → α) (mult : ℕ)
+    (hmult : p + 1 ≤ mult * R.width) :
+    SmashFree (foldOutExpr R p enc dec hdec alg mult hmult) :=
+  smashFreeBool_compRaw 1 1 _ fun d ↦ match d with
+    | .inl () => smashFreeBool_readOf R enc dec
+    | .inr _ =>
+      smashFreeBool_scanBRaw _ _ _ _ (smashFreeBool_constAtOf 0 _)
+        (smashFreeBool_foldStepF R enc dec alg false)
+        (smashFreeBool_foldStepF R enc dec alg true)
+        (smashFreeBool_boundMulRaw mult (foldGrowth R))
+
+/-- The additive bound child carries no `smash`. -/
+theorem smashFreeBool_boundRaw : ∀ growth : ℕ,
+    smashFreeBool (boundRaw growth) = true :=
+  Nat.rec (smashFreeBool_projRaw 1 0) fun _ ih ↦
+    smashFreeBool_compRaw 1 1 _ fun d ↦ match d with
+      | .inl () => smashFreeBool_succRaw true
+      | .inr _ => ih
+
+/-- The arity-two scan combinator carries no `smash` when its base and steps
+do. -/
+theorem smashFreeBool_scan2Of (base : COf 0) (step₀ step₁ : COf 2)
+    (hbound : ∀ w : List Bool, (scan2Sem base step₀ step₁ ![w]).length ≤ w.length)
+    (hb : smashFreeBool base.1.1.1 = true)
+    (h₀ : smashFreeBool step₀.1.1.1 = true)
+    (h₁ : smashFreeBool step₁.1.1.1 = true) :
+    smashFreeBool (scan2Of base step₀ step₁ hbound).1.1.1 = true :=
+  smashFreeBool_scan2Raw _ _ _ _ hb h₀ h₁ (smashFreeBool_boundRaw 0)
+
+/-- A projection expression carries no `smash`. -/
+theorem smashFreeBool_projOf (n : ℕ) (i : Fin n) :
+    smashFreeBool (projOf n i).1.1.1 = true := smashFreeBool_projRaw n i
+
+/-- An arity-one composition carries no `smash` when its parts do. -/
+theorem smashFreeBool_comp1Of {n : ℕ} (e : COf 1) (a : COf n)
+    (he : smashFreeBool e.1.1.1 = true) (ha : smashFreeBool a.1.1.1 = true) :
+    smashFreeBool (comp1Of e a).1.1.1 = true :=
+  smashFreeBool_compOf e _ he fun _ ↦ ha
+
+/-- A concatenation of expressions carries no `smash` when its parts do. -/
+theorem smashFreeBool_concatCompOf (n : ℕ) (a b : COf n)
+    (ha : smashFreeBool a.1.1.1 = true) (hb : smashFreeBool b.1.1.1 = true) :
+    smashFreeBool (concatCompOf n a b).1.1.1 = true :=
+  smashFreeBool_compOf concatOf _ smashFreeBool_concatRaw fun i ↦ match i with
+    | 0 => ha
+    | 1 => hb
+
+/-- Prepending a word to an expression carries no `smash` when the expression
+does. -/
+theorem smashFreeBool_prependOf {n : ℕ} (u : List Bool) (e : COf n)
+    (he : smashFreeBool e.1.1.1 = true) :
+    smashFreeBool (prependOf u e).1.1.1 = true :=
+  smashFreeBool_prependRaw n _ he u
+
+/-- The identity carries no `smash`. -/
+theorem smashFreeBool_idOf : smashFreeBool idOf.1.1.1 = true :=
+  smashFreeBool_projOf 1 0
+
+/-- The first-bit primitive carries no `smash`. -/
+theorem smashFreeBool_firstBitOf : smashFreeBool firstBitOf.1.1.1 = true :=
+  smashFreeBool_scan2Of _ _ _ _ (smashFreeBool_zeroAtRaw 0)
+    (smashFreeBool_constAtOf 2 _) (smashFreeBool_constAtOf 2 _)
+
+/-- The unary primitive carries no `smash`. -/
+theorem smashFreeBool_unaryOf : smashFreeBool unaryOf.1.1.1 = true :=
+  smashFreeBool_scan2Of _ _ _ _ (smashFreeBool_zeroAtRaw 0)
+    (smashFreeBool_prependOf _ _ (smashFreeBool_projOf 2 1))
+    (smashFreeBool_prependOf _ _ (smashFreeBool_projOf 2 1))
+
+/-- The run primitive carries no `smash`. -/
+theorem smashFreeBool_takeUnaryOf :
+    smashFreeBool takeUnaryOf.1.1.1 = true :=
+  smashFreeBool_scan2Of _ _ _ _ (smashFreeBool_zeroAtRaw 0)
+    (smashFreeBool_zeroAtRaw 2)
+    (smashFreeBool_prependOf _ _ (smashFreeBool_projOf 2 1))
+
+/-- The prefix-dropping primitive carries no `smash`. -/
+theorem smashFreeBool_dropUnaryOf :
+    smashFreeBool dropUnaryOf.1.1.1 = true :=
+  smashFreeBool_scan2Of _ _ _ _ (smashFreeBool_zeroAtRaw 0)
+    (smashFreeBool_projOf 2 0) (smashFreeBool_projOf 2 1)
+
+/-- The entry-dropping primitive carries no `smash`. -/
+theorem smashFreeBool_dropEntryOf :
+    smashFreeBool dropEntryOf.1.1.1 = true :=
+  smashFreeBool_scan2Of _ _ _ _ (smashFreeBool_zeroAtRaw 0)
+    (smashFreeBool_projOf 2 0)
+    (smashFreeBool_comp1Of _ _ smashFreeBool_predRaw (smashFreeBool_projOf 2 1))
+
+/-- The payload primitive carries no `smash`. -/
+theorem smashFreeBool_takeEntryOf :
+    smashFreeBool takeEntryOf.1.1.1 = true :=
+  smashFreeBool_scan2Of _ _ _ _ (smashFreeBool_zeroAtRaw 0)
+    (smashFreeBool_zeroAtRaw 2)
+    (smashFreeBool_concatCompOf 2 _ _
+      (smashFreeBool_comp1Of _ _ smashFreeBool_firstBitOf
+        (smashFreeBool_comp1Of _ _ smashFreeBool_dropEntryOf
+          (smashFreeBool_projOf 2 0)))
+      (smashFreeBool_projOf 2 1))
+
+/-- Dropping a fixed number of entries carries no `smash`. -/
+theorem smashFreeBool_dropEntriesOf : ∀ k : ℕ,
+    smashFreeBool (dropEntriesOf k).1.1.1 = true :=
+  Nat.rec smashFreeBool_idOf fun _ ih ↦
+    smashFreeBool_comp1Of _ _ ih smashFreeBool_dropEntryOf
+
+/-- The `j`-th entry carries no `smash`. -/
+theorem smashFreeBool_entryOf (j : ℕ) :
+    smashFreeBool (entryOf j).1.1.1 = true :=
+  smashFreeBool_comp1Of _ _ smashFreeBool_takeEntryOf
+    (smashFreeBool_dropEntriesOf j)
+
+/-- The self-delimiting spelling carries no `smash`. -/
+theorem smashFreeBool_entryWordOf :
+    smashFreeBool entryWordOf.1.1.1 = true :=
+  smashFreeBool_concatCompOf 1 _ _
+    (smashFreeBool_prependOf _ _ smashFreeBool_idOf) smashFreeBool_unaryOf
+
+/-- The algebra applied to the stack's entries carries no `smash` when the
+algebra's expression does. This is where the bitstring construction's hypothesis
+enters: the algebra is spliced into the tree, so its own freedom is needed. -/
+theorem smashFreeBool_applyAlgOf {r : ℕ} (algI : COf r)
+    (h : smashFreeBool algI.1.1.1 = true) :
+    smashFreeBool (applyAlgOf algI).1.1.1 = true :=
+  smashFreeBool_compOf algI _ h fun j ↦ smashFreeBool_entryOf j.val
+
+/-- The rebuilt stack carries no `smash` when the algebra's expression does. -/
+theorem smashFreeBool_newStackOf {r : ℕ} (algI : COf r)
+    (h : smashFreeBool algI.1.1.1 = true) :
+    smashFreeBool (newStackOf algI).1.1.1 = true :=
+  smashFreeBool_concatCompOf 1 _ _ (smashFreeBool_dropEntriesOf r)
+    (smashFreeBool_comp1Of _ _ smashFreeBool_entryWordOf
+      (smashFreeBool_applyAlgOf algI h))
+
+/-- The state past the flag and the slot, rebuilt, carries no `smash` when the
+algebra's expression does. -/
+theorem smashFreeBool_rebuildOf {r : ℕ} (algI : COf r)
+    (h : smashFreeBool algI.1.1.1 = true) :
+    smashFreeBool (rebuildOf algI).1.1.1 = true :=
+  smashFreeBool_concatCompOf 1 _ _
+    (smashFreeBool_prependOf _ _
+      (smashFreeBool_comp1Of _ _ (smashFreeBool_newStackOf algI h)
+        smashFreeBool_dropUnaryOf))
+    smashFreeBool_takeUnaryOf
+
+/-- Every branch of a step of the bitstring fold carries no `smash` when the
+algebra's expressions do. -/
+theorem smashFreeBool_branchV (R : RankedAlphabet)
+    (algOf : (i : Fin R.card) → COf (R.arity i))
+    (halg : ∀ i, smashFreeBool (algOf i).1.1.1 = true) (b : Bool) (t : Scan) :
+    smashFreeBool (branchV R algOf b t).1.1.1 = true := by
+  obtain ⟨buf, depth, live⟩ := t
+  rw [branchV]
+  dsimp only
+  cases live
+  · exact smashFreeBool_idOf
+  · dsimp only
+    by_cases hlen : (b :: buf).length = R.width
+    · rw [if_pos hlen]
+      match symOf R (decodeBits (b :: buf)) with
+      | none => exact smashFreeBool_prependOf _ _ (smashFreeBool_predIterOf _)
+      | some i =>
+        dsimp only
+        by_cases hst : R.arity i ≤ depth
+        · rw [if_pos hst]
+          exact smashFreeBool_prependOf _ _
+            (smashFreeBool_comp1Of _ _ (smashFreeBool_rebuildOf _ (halg i))
+              (smashFreeBool_predIterOf _))
+        · rw [if_neg hst]
+          exact smashFreeBool_prependOf _ _ (smashFreeBool_predIterOf _)
+    · rw [if_neg hlen]
+      exact smashFreeBool_prependOf _ _ (smashFreeBool_predIterOf _)
+
+/-- A step of the bitstring fold carries no `smash` when the algebra's
+expressions do. -/
+theorem smashFreeBool_foldStepV (R : RankedAlphabet)
+    (algOf : (i : Fin R.card) → COf (R.arity i))
+    (halg : ∀ i, smashFreeBool (algOf i).1.1.1 = true) (b : Bool) :
+    smashFreeBool (foldStepV R algOf b).1.1.1 = true :=
+  smashFreeBool_diagCasesOf _ _ fun _ ↦ smashFreeBool_branchV R algOf halg b _
+
+/-- The bitstring readout carries no `smash`: one branch prepends a marker to
+the payload primitive, the other is a constant word. -/
+theorem smashFreeBool_readOfV (R : RankedAlphabet) :
+    smashFreeBool (readOfV R).1.1.1 = true :=
+  smashFreeBool_diagCasesOf _ _ fun v ↦ by
+    by_cases hacc : ((decodeVAt R (readoutWidthV R) v).live &&
+        (decodeVAt R (readoutWidthV R) v).buf.isEmpty &&
+        (decodeVAt R (readoutWidthV R) v).depth == 1) = true
+    · rw [if_pos hacc]
+      exact smashFreeBool_prependOf _ _
+        (smashFreeBool_comp1Of _ _ smashFreeBool_takeEntryOf
+          (smashFreeBool_predIterOf _))
+    · rw [if_neg hacc]
+      exact smashFreeBool_constAtOf 1 _
+
+/-- The fold at a bitstring carrier lies in the subalgebra `Cobham.SmashFree`
+names when the algebra's expressions do, at a symbolic alphabet. The hypothesis
+is on the algebra alone, the construction's own nodes contributing no `smash`;
+whether it is necessary is not stated here. With [Strahm2003] Theorem 1(2)'s
+left-to-right inclusion
+the fold is then computable simultaneously in polynomial time and linear
+space. -/
+theorem smashFree_foldOutExprV (R : RankedAlphabet)
+    (algOf : (i : Fin R.card) → COf (R.arity i))
+    (halg' : ∀ i, smashFreeBool (algOf i).1.1.1 = true)
+    (alg : (i : Fin R.card) → (Fin (R.arity i) → List Bool) → List Bool)
+    (halg : ∀ (i : Fin R.card) (f : Fin (R.arity i) → List Bool),
+      semAt (R.arity i) (algOf i).1.1 (algOf i).2 f = alg i f)
+    (mult c : ℕ)
+    (hsize : ∀ w : List Bool,
+      stackSize (foldScanFinal R alg w).stack ≤ c * w.length)
+    (hmult : 2 * c + 2 ≤ mult) :
+    SmashFree (foldOutExprV R algOf alg halg mult c hsize hmult) :=
+  smashFreeBool_compRaw 1 1 _ fun d ↦ match d with
+    | .inl () => smashFreeBool_readOfV R
+    | .inr _ =>
+      smashFreeBool_scanBRaw _ _ _ _ (smashFreeBool_constAtOf 0 _)
+        (smashFreeBool_foldStepV R algOf halg' false)
+        (smashFreeBool_foldStepV R algOf halg' true)
+        (smashFreeBool_boundMulRaw mult (foldGrowthV R))
+
+end Geb.CobhamFold
+
+end

--- a/geb-lean/vendor/geb-mathlib/Geb/Internal/Computability/CobhamFoldProto/Variable.lean
+++ b/geb-lean/vendor/geb-mathlib/Geb/Internal/Computability/CobhamFoldProto/Variable.lean
@@ -1,0 +1,1065 @@
+/-
+Copyright (c) 2026 Terence Rokop. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Terence Rokop
+-/
+-- Modified from geb-mathlib by scripts/geb-mathlib-backport.patch.
+module
+
+public import Geb.Internal.Computability.CobhamFoldProto.Bound
+public import Geb.Internal.Computability.CobhamFoldProto.Fold
+public import Geb.Internal.Computability.CobhamFoldProto.SelfDelim
+public import Geb.Mathlib.Computability.Cobham.RankedTree
+
+/-!
+# The fold at a bitstring carrier
+
+`Geb/Internal/Computability/CobhamFoldProto/Expr.lean` folds at a carrier with a
+fixed-width bit encoding, dispatching each step on a constant window that holds
+the whole stack the step reads. This module folds at the carrier `List Bool`
+with the algebra's operations supplied as expressions of Cobham's class, so the
+carrier is unrestricted and the algebra is whatever the class can define.
+
+## Main definitions
+
+* `Geb.CobhamFold.stackWordV`, `Geb.CobhamFold.stateWordV` — the stack and the
+  state as bitstrings.
+* `Geb.CobhamFold.stackSize` — the total length of the pending values.
+* `Geb.CobhamFold.entryWordOf`, `Geb.CobhamFold.applyAlgOf`,
+  `Geb.CobhamFold.newStackOf`, `Geb.CobhamFold.rebuildOf` — the step's stack
+  rewrite, as expressions.
+* `Geb.CobhamFold.branchV`, `Geb.CobhamFold.foldStepV` — one step of the fold.
+* `Geb.CobhamFold.decodeVAt` — the inverse of the layout at a window.
+* `Geb.CobhamFold.foldGrowthV` — the growth the state layout's fixed part
+  contributes.
+* `Geb.CobhamFold.foldSemV`, `Geb.CobhamFold.foldExprV`,
+  `Geb.CobhamFold.foldExprOfV` — the scan, and the scan as a member of
+  `Cobham.C`.
+* `Geb.CobhamFold.readoutWidthV`, `Geb.CobhamFold.outWordV`,
+  `Geb.CobhamFold.readOfV` — the readout's window, its output word, and the
+  readout as an expression.
+* `Geb.CobhamFold.foldOutOfV`, `Geb.CobhamFold.foldOutExprV`,
+  `Geb.CobhamFold.foldOutSemV` — the readout composed onto the scan by
+  `Geb.CobhamFold.comp1Of`.
+* `Geb.CobhamFold.algOfFixed` — a fixed-width carrier's algebra transported
+  here.
+
+## Main statements
+
+* `Geb.CobhamFold.stackWordV_cons`, `Geb.CobhamFold.length_stackWordV` — the
+  stack's layout and its length.
+* `Geb.CobhamFold.stepWord_dropEntriesOf_stackWordV`,
+  `Geb.CobhamFold.stepWord_entryOf_stackWordV` — the primitives read the stack.
+* `Geb.CobhamFold.stepWord_dropEntriesOf_stackWordV_append`,
+  `Geb.CobhamFold.stepWord_entryOf_stackWordV_append` — the same two reads at
+  a stack layout followed by an arbitrary remainder, which each need the
+  count to be within the stack.
+* `Geb.CobhamFold.decodeState_stateWordV` — the dispatch window decodes the
+  flag, the block and the count capped at the window.
+* `Geb.CobhamFold.stepWord_foldStepV` — a step of the expression computes a step
+  of the fold scan.
+* `Geb.CobhamFold.foldSemV_eq`, `Geb.CobhamFold.length_foldSemV_le` — the
+  expression computes the fold scan's state word, and the recursion bound it
+  satisfies under the linear-growth hypothesis.
+* `Geb.CobhamFold.stepWord_readOfV` — the readout's value at a state word.
+* `Geb.CobhamFold.length_fold_le_of_growth` — an algebra lengthening by at most
+  a constant per symbol folds a term to a value linear in its node count.
+* `Geb.CobhamFold.potential_foldScanStep_le`,
+  `Geb.CobhamFold.potential_foldScanFinal_le`,
+  `Geb.CobhamFold.stackSize_le_of_growth` — the same condition bounds the scan's
+  potential `R.width * stackSize + c * |buf|`, and so discharges the
+  linear-growth hypothesis `length_foldSemV_le` takes.
+* `Geb.CobhamFold.potential_foldScanStep_le_of_invariant`,
+  `Geb.CobhamFold.potential_foldScanFinal_le_of_invariant`,
+  `Geb.CobhamFold.stackSize_le_of_growth_of_invariant` — the same three with
+  the growth condition assumed only of values satisfying a predicate the
+  scan's stack carries, which an algebra duplicating its children's payloads
+  needs; the unrestricted forms are these at the trivial predicate.
+* `Geb.CobhamFold.foldOutSemV_eq` — the expression computes
+  `Geb.CobhamFold.foldOut`, spelled by `outWordV`; with `foldOut_eq` this is
+  `RankedAlphabet.parse` followed by the algebra morphism.
+* `Geb.CobhamFold.foldOut_algOfFixed` — at an algebra whose carrier stays within
+  a fixed width, the fold this construction computes and the one the fixed-width
+  construction computes agree, up to the encoding. It is a statement about the
+  two algebras at the shared semantic layer, which each construction is
+  separately proved to compute (`foldOutSemV_eq` here, `foldOutSem_eq` there).
+
+* `Geb.CobhamFold.foldSemV_eq_eval`, `Geb.CobhamFold.foldOutSemV_eq_eval` — the
+  meanings read at the raw trees are the meanings the expressions carry.
+
+## Implementation notes
+
+Names here carry a `V` suffix where their fixed-width counterparts in
+`Geb/Internal/Computability/CobhamFoldProto/Layout.lean` and
+`Geb/Internal/Computability/CobhamFoldProto/Expr.lean` carry an `F` or, where
+the fixed-width name came first, no suffix at all: the two constructions define
+the same notions at a variable-width and at a fixed-width carrier, and the
+suffix is what keeps them apart in one namespace.
+
+### The state layout
+
+```text
+stateWordV R s = stateWord R (toScan s) ++ false :: stackWordV s.stack
+```
+
+The state word is the recognizer's — the liveness flag, the block slot, and the
+pending count in unary — followed by a `false` sentinel and the stack, whose
+entries are `Geb.CobhamFold.entryWord`'s self-delimiting spellings.
+
+Two consequences. The pending count stays inside a constant dispatch window, so
+the test `R.arity i ≤ depth` is still a bounded one and the branch family is
+`Cobham.dispatchWidth R` wide — the recognizer's own width, independent of the
+carrier. And the sentinel is required: an entry begins with its length in
+unary, so without a `false` between the count and the stack the decoder's
+`takeWhile` would run out of the count and into the first entry's prefix.
+
+### Cost
+
+Each primitive the step reads the stack with is itself a recursion whose step is
+not constant. `Geb.CobhamFold.dropEntryOf`'s step applies `Cobham.pred`, itself
+a `boundedRec`; `Geb.CobhamFold.takeEntryOf`'s step runs a fresh `dropEntryOf`
+over the remaining word. Counting a `boundedRec`'s cost as the sum over its
+levels of its step's cost, `dropEntryOf` is quadratic in its argument and
+`takeEntryOf` cubic, so a fold's state-reading here is polynomial of a degree above
+two rather than quadratic.
+
+Nothing here measures a number of reduction steps, as
+`Geb/Mathlib/Computability/Cobham/Tree.lean` records of its own subject; the
+paragraph above is an analysis of the expression under one cost model, and a
+machine evaluating it is not obliged to follow that model.
+
+The accompanying lower bound rests only on the class's shape rather than on a
+cost model: reading an unbounded field of the state requires a recursion over
+the state, `boundedRec` being the class's only recursion, so no step reading
+such a field is constant. It bears on this layout, whose steps do read one; it
+does not exclude some other expression computing the same fold without reading
+an unbounded field. It is an argument about the expression, not a theorem stated
+here.
+
+The algebra is an arbitrary member of the class and so carries whatever cost the
+class admits, putting a fold above its algebra by whatever the state-reading costs.
+The state-reading is therefore not what limits a fold: any cost the class admits at
+all is reached by spending it inside the algebra. How far that goes is a
+question about the class, not about this construction, and it is not settled
+here — only the left-to-right inclusion of [Strahm2003] Theorem 1(2) is relied
+on anywhere in this repository, and `docs/references.bib` records that the
+equality fails read literally.
+
+Space is what binds. The state holds every pending value, so a linear-space
+reading forces a constant `c` bounding the pending values' total length by
+`c * n`, which is the hypothesis `Geb.CobhamFold.length_foldSemV_le` takes.
+That hypothesis is not an artifact of this construction: [Clote1999]'s
+arithmetic analogue reads its class as one of functions of linear growth.
+
+The dispatch is no wider here than at a fixed-width carrier, and narrower at
+every positive carrier width; at `p = 0` the two coincide, which
+`Geb.CobhamFold.dispatchWidthF_zero` states. The fixed-width dispatch reads the
+stack, so its branch family is
+`2 ^ (1 + R.width + (p + 1) * (R.maxArity + 1))`; here it reads only the flag,
+the slot and the count, so the family is `2 ^ Cobham.dispatchWidth R` whatever
+the carrier. This is a statement about the branch family alone: the completing
+branch here carries a `rebuildOf` subtree no fixed-width branch does, and the
+two expressions' sizes are not compared.
+
+## References
+
+* [Clote1999]
+* [Cobham1965]
+* [Strahm2003]
+
+## Tags
+
+Cobham, bounded recursion on notation, fold, self-delimiting, bitstring carrier
+-/
+
+@[expose] public section
+
+namespace Geb.CobhamFold
+
+open Cobham RankedAlphabet
+
+universe u
+
+/-- The stack as a bitstring: the self-delimiting spelling of each entry, the
+top entry first. -/
+def stackWordV (st : List (List Bool)) : List Bool := st.flatMap entryWord
+
+/-- The empty stack's layout. -/
+@[simp] theorem stackWordV_nil : stackWordV [] = [] := rfl
+
+/-- The stack's layout, one entry at a time. -/
+@[simp] theorem stackWordV_cons (a : List Bool) (st : List (List Bool)) :
+    stackWordV (a :: st) = entryWord a ++ stackWordV st := rfl
+
+/-- The total length of the pending values. -/
+def stackSize (st : List (List Bool)) : ℕ := st.flatten.length
+
+/-- The empty stack's values are empty. -/
+@[simp] theorem stackSize_nil : stackSize [] = 0 := rfl
+
+/-- The pending values' total length, one entry at a time. -/
+@[simp] theorem stackSize_cons (a : List Bool) (st : List (List Bool)) :
+    stackSize (a :: st) = a.length + stackSize st := by
+  rw [stackSize, List.flatten_cons, List.length_append, stackSize]
+
+/-- The stack's layout is twice the pending values' total length plus one bit
+per entry. -/
+theorem length_stackWordV : ∀ st : List (List Bool),
+    (stackWordV st).length = 2 * stackSize st + st.length :=
+  List.rec rfl fun a t ih ↦ by
+    rw [stackWordV_cons, List.length_append, length_entryWord, ih, stackSize_cons,
+      List.length_cons]
+    omega
+
+/-- The state as a bitstring: the recognizer's state word, a `false` sentinel,
+then the stack. -/
+def stateWordV (R : RankedAlphabet) (s : FoldScan (List Bool)) : List Bool :=
+  stateWord R (toScan s) ++ false :: stackWordV s.stack
+
+/-- The state word's length. -/
+theorem length_stateWordV_of_lt (R : RankedAlphabet) (s : FoldScan (List Bool))
+    (h : s.buf.length < R.width) :
+    (stateWordV R s).length =
+      1 + R.width + s.stack.length + 1 + (2 * stackSize s.stack + s.stack.length) := by
+  have hd : (toScan s).depth = s.stack.length := rfl
+  rw [stateWordV, List.length_append, length_stateWord_of_lt R (toScan s) h,
+    List.length_cons, length_stackWordV, hd]
+  omega
+
+/-- Dropping whole entries from the stack's layout drops whole entries from the
+stack. -/
+theorem stepWord_dropEntriesOf_stackWordV : ∀ (k : ℕ) (st : List (List Bool)),
+    stepWord (dropEntriesOf k) (stackWordV st) = stackWordV (st.drop k) :=
+  Nat.rec (fun st ↦ by rw [dropEntriesOf_zero, stepWord_idOf, List.drop_zero])
+    fun k ih st ↦ by
+      rw [stepWord_dropEntriesOf_succ]
+      match st with
+      | [] =>
+        rw [List.drop_nil]
+        exact (ih []).trans (congrArg stackWordV List.drop_nil)
+      | a :: t =>
+        rw [stackWordV_cons, dropEntrySem_entryWord, ih t, List.drop_succ_cons]
+
+/-- The `j`-th entry primitive reads the `j`-th pending value. -/
+theorem stepWord_entryOf_stackWordV (j : ℕ) (st : List (List Bool)) :
+    stepWord (entryOf j) (stackWordV st) = (st.drop j).headD [] := by
+  rw [stepWord_entryOf, stepWord_dropEntriesOf_stackWordV]
+  match hd : st.drop j with
+  | [] => rw [stackWordV_nil]; rfl
+  | a :: t => rw [stackWordV_cons, takeEntrySem_entryWord]; rfl
+
+/-- Dropping as many entries as a stack layout holds leaves what follows
+it. `Geb.CobhamFold.stepWord_dropEntriesOf_stackWordV` is this at the empty
+remainder, where the hypothesis is unnecessary. -/
+theorem stepWord_dropEntriesOf_stackWordV_append :
+    ∀ (k : ℕ) (st : List (List Bool)) (rest : List Bool), k ≤ st.length →
+      stepWord (dropEntriesOf k) (stackWordV st ++ rest) =
+        stackWordV (st.drop k) ++ rest :=
+  Nat.rec (fun st rest _ ↦ by rw [dropEntriesOf_zero, stepWord_idOf,
+      List.drop_zero])
+    fun k ih st rest h ↦ match st with
+      | [] => absurd h (Nat.not_succ_le_zero k)
+      | a :: t => by
+        rw [stackWordV_cons, List.append_assoc, stepWord_dropEntriesOf_succ,
+          dropEntrySem_entryWord, ih t rest (Nat.le_of_succ_le_succ h),
+          List.drop_succ_cons]
+
+/-- The `j`-th entry of a stack layout is its `j`-th value, whatever follows
+the layout. `Geb.CobhamFold.stepWord_entryOf_stackWordV` agrees with it where
+`j < st.length`; neither is an instance of the other, that one being
+unconditional in `j` and read through `List.headD`. -/
+theorem stepWord_entryOf_stackWordV_append (j : ℕ) (st : List (List Bool))
+    (rest : List Bool) (h : j < st.length) :
+    stepWord (entryOf j) (stackWordV st ++ rest) = st[j] := by
+  rw [stepWord_entryOf,
+    stepWord_dropEntriesOf_stackWordV_append j st rest (Nat.le_of_lt h),
+    List.drop_eq_getElem_cons h, stackWordV_cons, List.append_assoc,
+    takeEntrySem_entryWord]
+
+/-- The run of `true` a window over a unary count reads, when the count is
+followed by a `false` sentinel and the window may overrun the word. Whether the
+window ends inside the count or past the sentinel, the run is the count capped
+at the window. -/
+private theorem takeWhile_id_take_replicate (Z : List Bool) :
+    ∀ (m k p : ℕ),
+      (((List.replicate k true ++ false :: Z).take m) ++
+        List.replicate p false).takeWhile id = List.replicate (min m k) true :=
+  Nat.rec
+    (fun k p ↦ by
+      rw [List.take_zero, List.nil_append, Nat.zero_min, List.replicate_zero]
+      match p with
+      | 0 => rfl
+      | _ + 1 => rfl)
+    fun m ih k p ↦ match k with
+      | 0 => by
+        rw [List.replicate_zero, List.nil_append, List.take_succ_cons,
+          List.cons_append, Nat.min_zero, List.replicate_zero]
+        rfl
+      | k + 1 => by
+        rw [List.replicate_succ, List.cons_append, List.take_succ_cons,
+          List.cons_append, Nat.succ_min_succ, List.replicate_succ]
+        exact congrArg (fun t ↦ true :: t) (ih k p)
+
+/-- The state word truncated to a window and zero-padded: the flag, the slot,
+then the count and whatever of the stack the window reaches. -/
+theorem ofFn_bits_stateWordV (R : RankedAlphabet) (s : FoldScan (List Bool))
+    (n m : ℕ) (hn : n = 1 + R.width + m) (h : s.buf.length < R.width) :
+    List.ofFn (bits n (stateWordV R s)) =
+      s.live :: (bufBits R s.buf ++
+        (((List.replicate s.stack.length true ++ false :: stackWordV s.stack).take m) ++
+          List.replicate (n - (stateWordV R s).length) false)) := by
+  have hbuf : (bufBits R s.buf).length = R.width := length_bufBits_of_lt R s.buf h
+  have hdw : n = (bufBits R s.buf).length + m + 1 := by
+    rw [hbuf, hn]
+    omega
+  have hcons : stateWordV R s =
+      s.live :: (bufBits R s.buf ++
+        (List.replicate s.stack.length true ++ false :: stackWordV s.stack)) := by
+    rw [stateWordV, stateWord, toScan]
+    dsimp only
+    simp only [List.cons_append, List.append_assoc]
+  rw [ofFn_bits, hcons, hdw, List.take_succ_cons, List.take_length_add_append,
+    List.cons_append, List.append_assoc, ← hcons]
+
+/-- The inverse of the layout at a window of `n` bits: the flag, the block past
+the slot's padding, and the run of the pending count. `Cobham.decodeState` is
+this at the dispatch window. -/
+def decodeVAt (R : RankedAlphabet) (n : ℕ) (v : Fin n → Bool) : Scan :=
+  ⟨(((List.ofFn v).tail.take R.width).dropWhile (fun b ↦ !b)).tail,
+    (((List.ofFn v).tail.drop R.width).takeWhile id).length,
+    (List.ofFn v).headD false⟩
+
+/-- A window decodes the flag, the incomplete block, and the pending count
+capped at the window. The `false` sentinel is what stops the count's run from
+continuing into the first entry's own unary prefix. -/
+theorem decodeVAt_stateWordV (R : RankedAlphabet) (s : FoldScan (List Bool))
+    (n m : ℕ) (hn : n = 1 + R.width + m) (h : s.buf.length < R.width) :
+    decodeVAt R n (bits n (stateWordV R s)) =
+      ⟨s.buf, min s.stack.length m, s.live⟩ := by
+  have hbuf : (bufBits R s.buf).length = R.width := length_bufBits_of_lt R s.buf h
+  have hword := ofFn_bits_stateWordV R s n m hn h
+  refine Scan.ext ?_ ?_ ?_
+  · rw [decodeVAt, hword, List.tail_cons, List.take_left' hbuf, dropWhile_bufBits]
+    rfl
+  · rw [decodeVAt, hword, List.tail_cons, List.drop_left' hbuf,
+      takeWhile_id_take_replicate, List.length_replicate]
+    exact Nat.min_comm _ _
+  · rw [decodeVAt, hword, List.headD_cons]
+
+/-- The dispatch window's decode, which is `Cobham.decodeState`. -/
+theorem decodeState_stateWordV (R : RankedAlphabet) (s : FoldScan (List Bool))
+    (h : s.buf.length < R.width) :
+    decodeState R (bits (dispatchWidth R) (stateWordV R s)) =
+      ⟨s.buf, min s.stack.length (R.maxArity + 1), s.live⟩ :=
+  decodeVAt_stateWordV R s (dispatchWidth R) (R.maxArity + 1)
+    (by rw [dispatchWidth]; omega) h
+
+/-- The self-delimiting spelling, as an expression of arity one. -/
+def entryWordOf : COf 1 := concatCompOf 1 (prependOf [false] idOf) unaryOf
+
+/-- The spelling expression's value at a step. -/
+theorem stepWord_entryWordOf (u : List Bool) :
+    stepWord entryWordOf u = entryWord u := by
+  rw [entryWordOf, stepWord_concatCompOf, stepWord_unaryOf, unarySem_eq,
+    stepWord_prependOf, stepWord_idOf, entryWord]
+  rfl
+
+/-- The algebra's operation applied to the entries the stack holds. -/
+def applyAlgOf {r : ℕ} (algI : COf r) : COf 1 :=
+  compOf algI fun j ↦ entryOf j.val
+
+/-- The algebra application's value at a step. -/
+theorem stepWord_applyAlgOf {r : ℕ} (algI : COf r) (u : List Bool) :
+    stepWord (applyAlgOf algI) u =
+      semAt r algI.1.1 algI.2 fun j ↦ stepWord (entryOf j.val) u :=
+  stepWord_compOf algI _ u
+
+/-- The stack after the pop: the algebra's value spelled as an entry, then the
+stack past the entries it consumed. -/
+def newStackOf {r : ℕ} (algI : COf r) : COf 1 :=
+  concatCompOf 1 (dropEntriesOf r) (comp1Of entryWordOf (applyAlgOf algI))
+
+/-- The new stack's value at a step. -/
+theorem stepWord_newStackOf {r : ℕ} (algI : COf r) (u : List Bool) :
+    stepWord (newStackOf algI) u =
+      entryWord (stepWord (applyAlgOf algI) u) ++ stepWord (dropEntriesOf r) u := by
+  rw [newStackOf, stepWord_concatCompOf, stepWord_comp1Of, stepWord_entryWordOf]
+
+/-- The state past the flag and the slot, rebuilt: the pending count is kept and
+the stack is rewritten. -/
+def rebuildOf {r : ℕ} (algI : COf r) : COf 1 :=
+  concatCompOf 1 (prependOf [false] (comp1Of (newStackOf algI) dropUnaryOf))
+    takeUnaryOf
+
+/-- The rebuild's value at a step. -/
+theorem stepWord_rebuildOf {r : ℕ} (algI : COf r) (z : List Bool) :
+    stepWord (rebuildOf algI) z =
+      takeUnarySem ![z] ++ false :: stepWord (newStackOf algI) (dropUnarySem ![z]) := by
+  rw [rebuildOf, stepWord_concatCompOf, stepWord_takeUnaryOf, stepWord_prependOf,
+    stepWord_comp1Of, stepWord_dropUnaryOf]
+  rfl
+
+/-- The state word past the flag, the slot and `k` of the pending count: the
+count short by `k`, then the sentinel and the stack. -/
+theorem drop_stateWordV (R : RankedAlphabet) (s : FoldScan (List Bool))
+    (h : s.buf.length < R.width) (k : ℕ) (hk : k ≤ s.stack.length) :
+    (stateWordV R s).drop (1 + R.width + k) =
+      List.replicate (s.stack.length - k) true ++ false :: stackWordV s.stack := by
+  have hpre : (s.live :: bufBits R s.buf).length = 1 + R.width := by
+    rw [List.length_cons, length_bufBits_of_lt R s.buf h]
+    omega
+  have hsplit : List.replicate s.stack.length true =
+      List.replicate k true ++ List.replicate (s.stack.length - k) true := by
+    rw [← List.replicate_add]
+    exact congrArg (fun j ↦ List.replicate j true) (by omega)
+  have hcons : stateWordV R s =
+      (s.live :: bufBits R s.buf) ++
+        (List.replicate s.stack.length true ++ false :: stackWordV s.stack) := by
+    rw [stateWordV, stateWord, toScan]
+    dsimp only
+    simp only [List.append_assoc]
+  rw [← List.drop_drop, hcons, List.drop_left' hpre, hsplit, List.append_assoc,
+    List.drop_left' (List.length_replicate (n := k) (a := true))]
+
+/-- One step of the fold at a bitstring carrier, as a function of the state the
+dispatch window decodes. A failed state absorbs; an incomplete block takes the
+bit; a completed block's symbol pops its arity from the count and rewrites the
+stack. -/
+def branchV (R : RankedAlphabet) (algOf : (i : Fin R.card) → COf (R.arity i))
+    (b : Bool) (t : Scan) : COf 1 :=
+  match t.live with
+  | false => idOf
+  | true =>
+    if (b :: t.buf).length = R.width then
+      match symOf R (decodeBits (b :: t.buf)) with
+      | none => prependOf (false :: bufBits R []) (predIterOf (1 + R.width))
+      | some i =>
+        if R.arity i ≤ t.depth then
+          prependOf (true :: bufBits R [] ++ [true])
+            (comp1Of (rebuildOf (algOf i)) (predIterOf (1 + R.width + R.arity i)))
+        else prependOf (false :: bufBits R []) (predIterOf (1 + R.width))
+    else prependOf (true :: bufBits R (b :: t.buf)) (predIterOf (1 + R.width))
+
+/-- One step of the fold expression: dispatch on the flag, the slot and the
+pending count, and rewrite. -/
+def foldStepV (R : RankedAlphabet) (algOf : (i : Fin R.card) → COf (R.arity i))
+    (b : Bool) : COf 1 :=
+  diagOf (casesOf (dispatchWidth R) fun v ↦ branchV R algOf b (decodeState R v))
+
+/-- The step's value at a state word, before the branch is resolved. -/
+theorem stepWord_foldStepV_apply (R : RankedAlphabet)
+    (algOf : (i : Fin R.card) → COf (R.arity i)) (b : Bool)
+    (s : FoldScan (List Bool)) (h : s.buf.length < R.width) :
+    stepWord (foldStepV R algOf b) (stateWordV R s) =
+      stepWord (branchV R algOf b ⟨s.buf, min s.stack.length (R.maxArity + 1), s.live⟩)
+        (stateWordV R s) := by
+  rw [foldStepV, stepWord_diagOf]
+  change casesSem (dispatchWidth R) _ ![stateWordV R s, stateWordV R s] = _
+  rw [casesSem_eq, decodeState_stateWordV R s h]
+
+/-- Capping the pending count at the dispatch window leaves the branch
+unchanged: the only test reading the count compares it with an arity, which
+`RankedAlphabet.arity_le_maxArity` bounds by `R.maxArity`. -/
+theorem branchV_min (R : RankedAlphabet)
+    (algOf : (i : Fin R.card) → COf (R.arity i)) (b : Bool)
+    (t : Scan) :
+    branchV R algOf b { t with depth := min t.depth (R.maxArity + 1) } =
+      branchV R algOf b t := by
+  obtain ⟨buf, depth, live⟩ := t
+  rw [branchV, branchV]
+  dsimp only
+  cases live
+  · rfl
+  · dsimp only
+    by_cases hlen : (b :: buf).length = R.width
+    · rw [if_pos hlen, if_pos hlen]
+      match hsym : symOf R (decodeBits (b :: buf)) with
+      | none => rfl
+      | some i =>
+        dsimp only
+        have hle : R.arity i ≤ R.maxArity := arity_le_maxArity R i
+        by_cases hst : R.arity i ≤ depth
+        · rw [if_pos hst, if_pos (by omega)]
+        · rw [if_neg hst, if_neg (by omega)]
+    · rw [if_neg hlen, if_neg hlen]
+
+/-- The state layout at an explicit state. -/
+theorem stateWordV_mk (R : RankedAlphabet) (buf : List Bool)
+    (st : List (List Bool)) (live : Bool) :
+    stateWordV R ⟨buf, st, live⟩ =
+      (live :: bufBits R buf ++ List.replicate st.length true) ++
+        false :: stackWordV st := rfl
+
+/-- The head of a suffix is the element it starts at. -/
+private theorem headD_drop (j : ℕ) (st : List (List Bool)) (hj : j < st.length) :
+    (st.drop j).headD [] = st[j] := by
+  rw [List.drop_eq_getElem_cons hj]
+  rfl
+
+/-- A step of the expression computes a step of the fold scan. The algebra's
+operations enter only through `halg`, which reads each expression's meaning as
+the corresponding carrier-level operation. -/
+theorem stepWord_foldStepV (R : RankedAlphabet)
+    (algOf : (i : Fin R.card) → COf (R.arity i))
+    (alg : (i : Fin R.card) → (Fin (R.arity i) → List Bool) → List Bool)
+    (halg : ∀ (i : Fin R.card) (f : Fin (R.arity i) → List Bool),
+      semAt (R.arity i) (algOf i).1.1 (algOf i).2 f = alg i f)
+    (b : Bool) (s : FoldScan (List Bool)) (h : s.buf.length < R.width) :
+    stepWord (foldStepV R algOf b) (stateWordV R s) =
+      stateWordV R (foldScanStep R alg b s) := by
+  rw [stepWord_foldStepV_apply R algOf b s h]
+  have hcap : branchV R algOf b ⟨s.buf, min s.stack.length (R.maxArity + 1), s.live⟩ =
+      branchV R algOf b ⟨s.buf, s.stack.length, s.live⟩ :=
+    branchV_min R algOf b ⟨s.buf, s.stack.length, s.live⟩
+  rw [hcap]
+  have hdrop0 : (stateWordV R s).drop (1 + R.width) =
+      List.replicate s.stack.length true ++ false :: stackWordV s.stack := by
+    have := drop_stateWordV R s h 0 (Nat.zero_le _)
+    rwa [Nat.add_zero, Nat.sub_zero] at this
+  obtain ⟨buf, stack, live⟩ := s
+  dsimp only at h hdrop0 ⊢
+  rw [branchV, foldScanStep]
+  dsimp only
+  cases live
+  · rw [stepWord_idOf]
+  · dsimp only
+    by_cases hlen : (b :: buf).length = R.width
+    · rw [if_pos hlen, if_pos hlen]
+      match hsym : symOf R (decodeBits (b :: buf)) with
+      | none =>
+        rw [stepWord_prependOf, stepWord_predIterOf, hdrop0, stateWordV_mk]
+        simp only [List.cons_append, List.append_assoc]
+      | some i =>
+        dsimp only
+        by_cases hst : R.arity i ≤ stack.length
+        · rw [if_pos hst, dif_pos hst, stepWord_prependOf,
+            stepWord_comp1Of, stepWord_predIterOf, drop_stateWordV R _ h _ hst,
+            stepWord_rebuildOf, takeUnarySem_replicate, dropUnarySem_replicate,
+            stepWord_newStackOf, stepWord_dropEntriesOf_stackWordV,
+            stepWord_applyAlgOf, halg, stateWordV_mk]
+          have hargs : (fun j : Fin (R.arity i) ↦
+              stepWord (entryOf j.val) (stackWordV stack)) =
+              fun j : Fin (R.arity i) ↦ stack[j.val]'(Nat.lt_of_lt_of_le j.isLt hst) := by
+            funext j
+            rw [stepWord_entryOf_stackWordV]
+            exact headD_drop j.val stack (Nat.lt_of_lt_of_le j.isLt hst)
+          rw [hargs, List.length_cons, List.length_drop, stackWordV_cons]
+          have hrep : List.replicate (stack.length - R.arity i + 1) true =
+              [true] ++ List.replicate (stack.length - R.arity i) true := by
+            rw [Nat.add_comm, List.replicate_add]
+            rfl
+          rw [hrep]
+          simp only [List.cons_append, List.append_assoc]
+        · rw [if_neg hst, dif_neg hst, stepWord_prependOf,
+            stepWord_predIterOf, hdrop0, stateWordV_mk]
+          simp only [List.cons_append, List.append_assoc]
+    · rw [if_neg hlen, if_neg hlen, stepWord_prependOf,
+        stepWord_predIterOf, hdrop0, stateWordV_mk]
+      simp only [List.cons_append, List.append_assoc]
+
+/-- The growth the state layout's fixed part contributes: the flag, the slot and
+the sentinel. -/
+def foldGrowthV (R : RankedAlphabet) : ℕ := 2 + R.width
+
+/-- The fold's scan at a bitstring carrier. -/
+def foldSemV (R : RankedAlphabet) (algOf : (i : Fin R.card) → COf (R.arity i))
+    (mult : ℕ) : Sem 1 :=
+  scanBSem (constAtOf 0 (stateWordV R ⟨[], [], true⟩))
+    (foldStepV R algOf false) (foldStepV R algOf true)
+    (boundMulRaw mult (foldGrowthV R)) (wValid_boundMulRaw mult (foldGrowthV R))
+    (wIndexRoot_boundMulRaw mult (foldGrowthV R))
+
+/-- The expression computes the fold scan's state word on every input. -/
+theorem foldSemV_eq (R : RankedAlphabet)
+    (algOf : (i : Fin R.card) → COf (R.arity i))
+    (alg : (i : Fin R.card) → (Fin (R.arity i) → List Bool) → List Bool)
+    (halg : ∀ (i : Fin R.card) (f : Fin (R.arity i) → List Bool),
+      semAt (R.arity i) (algOf i).1.1 (algOf i).2 f = alg i f)
+    (mult : ℕ) (w : List Bool) :
+    foldSemV R algOf mult ![w] = stateWordV R (foldScanFinal R alg w) := by
+  rw [foldSemV, scanBSem_eq]
+  refine List.rec ?_ ?_ w
+  · rw [List.foldr_nil, baseWord_constAtOf]
+    rfl
+  · intro b v ih
+    rw [List.foldr_cons, ih]
+    cases b
+    · exact stepWord_foldStepV R algOf alg halg false _
+        (length_buf_foldScanFinal_lt R alg v)
+    · exact stepWord_foldStepV R algOf alg halg true _
+        (length_buf_foldScanFinal_lt R alg v)
+
+/-- The recursion bound, under the hypothesis that the pending values stay
+linear in the input. That hypothesis is what linear space forces of this layout:
+the state holds every pending value at once. Whether a fold whose values grow
+faster is excluded from the subalgebra `Cobham.SmashFree` names outright, rather
+than from this layout, is not stated here. -/
+theorem length_foldSemV_le (R : RankedAlphabet)
+    (algOf : (i : Fin R.card) → COf (R.arity i))
+    (alg : (i : Fin R.card) → (Fin (R.arity i) → List Bool) → List Bool)
+    (halg : ∀ (i : Fin R.card) (f : Fin (R.arity i) → List Bool),
+      semAt (R.arity i) (algOf i).1.1 (algOf i).2 f = alg i f)
+    (mult c : ℕ)
+    (hsize : ∀ w : List Bool,
+      stackSize (foldScanFinal R alg w).stack ≤ c * w.length)
+    (hmult : 2 * c + 2 ≤ mult) (w : List Bool) :
+    (scanBSem (constAtOf 0 (stateWordV R ⟨[], [], true⟩))
+      (foldStepV R algOf false) (foldStepV R algOf true)
+      (boundMulRaw mult (foldGrowthV R)) (wValid_boundMulRaw mult (foldGrowthV R))
+      (wIndexRoot_boundMulRaw mult (foldGrowthV R))
+      ![w]).length ≤ mult * w.length + foldGrowthV R := by
+  have hstate : (scanBSem (constAtOf 0 (stateWordV R ⟨[], [], true⟩))
+      (foldStepV R algOf false) (foldStepV R algOf true)
+      (boundMulRaw mult (foldGrowthV R)) (wValid_boundMulRaw mult (foldGrowthV R))
+      (wIndexRoot_boundMulRaw mult (foldGrowthV R)) ![w]).length =
+      1 + R.width + (R.scanFinal w).depth + 1 +
+        (2 * stackSize (foldScanFinal R alg w).stack + (R.scanFinal w).depth) := by
+    rw [← foldSemV, foldSemV_eq R algOf alg halg mult w,
+      length_stateWordV_of_lt R _ (length_buf_foldScanFinal_lt R alg w),
+      length_stack_foldScanFinal]
+  have hd : (R.scanFinal w).depth ≤ w.length := depth_scanFinal_le_length R w
+  have hs := hsize w
+  have h1 : (2 * c + 2) * w.length ≤ mult * w.length :=
+    Nat.mul_le_mul_right w.length hmult
+  have h2 : (2 * c + 2) * w.length = 2 * (c * w.length) + 2 * w.length := by
+    rw [Nat.add_mul, Nat.mul_assoc]
+  rw [hstate, foldGrowthV]
+  omega
+
+/-- The scan as a member of `Cobham.C`, at its arity: the form consumers take,
+`foldExprV` being its underlying expression. -/
+def foldExprOfV (R : RankedAlphabet) (algOf : (i : Fin R.card) → COf (R.arity i))
+    (alg : (i : Fin R.card) → (Fin (R.arity i) → List Bool) → List Bool)
+    (halg : ∀ (i : Fin R.card) (f : Fin (R.arity i) → List Bool),
+      semAt (R.arity i) (algOf i).1.1 (algOf i).2 f = alg i f)
+    (mult c : ℕ)
+    (hsize : ∀ w : List Bool,
+      stackSize (foldScanFinal R alg w).stack ≤ c * w.length)
+    (hmult : 2 * c + 2 ≤ mult) : COf 1 :=
+  scanMulOf (constAtOf 0 (stateWordV R ⟨[], [], true⟩))
+    (foldStepV R algOf false) (foldStepV R algOf true) mult (foldGrowthV R)
+    (length_foldSemV_le R algOf alg halg mult c hsize hmult)
+
+/-- The fold at a bitstring carrier, as an expression of Cobham's class. -/
+def foldExprV (R : RankedAlphabet) (algOf : (i : Fin R.card) → COf (R.arity i))
+    (alg : (i : Fin R.card) → (Fin (R.arity i) → List Bool) → List Bool)
+    (halg : ∀ (i : Fin R.card) (f : Fin (R.arity i) → List Bool),
+      semAt (R.arity i) (algOf i).1.1 (algOf i).2 f = alg i f)
+    (mult c : ℕ)
+    (hsize : ∀ w : List Bool,
+      stackSize (foldScanFinal R alg w).stack ≤ c * w.length)
+    (hmult : 2 * c + 2 ≤ mult) : C :=
+  (foldExprOfV R algOf alg halg mult c hsize hmult).1
+
+/-- The meaning `foldSemV` reads at the raw tree is the meaning `foldExprV`
+carries. -/
+theorem foldSemV_eq_eval (R : RankedAlphabet)
+    (algOf : (i : Fin R.card) → COf (R.arity i))
+    (alg : (i : Fin R.card) → (Fin (R.arity i) → List Bool) → List Bool)
+    (halg : ∀ (i : Fin R.card) (f : Fin (R.arity i) → List Bool),
+      semAt (R.arity i) (algOf i).1.1 (algOf i).2 f = alg i f)
+    (mult c : ℕ)
+    (hsize : ∀ w : List Bool,
+      stackSize (foldScanFinal R alg w).stack ≤ c * w.length)
+    (hmult : 2 * c + 2 ≤ mult) :
+    transport (foldExprOfV R algOf alg halg mult c hsize hmult).2
+        (foldExprOfV R algOf alg halg mult c hsize hmult).1.eval =
+      foldSemV R algOf mult := rfl
+
+/-- A fixed-width carrier's algebra transported to the bitstring carrier: decode
+each argument, apply the algebra, and spell the result. -/
+def algOfFixed {α : Type u} {p : ℕ} (R : RankedAlphabet) (enc : α → Fin p → Bool)
+    (dec : (Fin p → Bool) → α)
+    (alg : (i : Fin R.card) → (Fin (R.arity i) → α) → α) :
+    (i : Fin R.card) → (Fin (R.arity i) → List Bool) → List Bool :=
+  fun i f ↦ List.ofFn (enc (alg i fun d ↦ dec (bits p (f d))))
+
+/-- The two fold constructions agree on results. Called at an algebra whose
+carrier does stay within a fixed width, the bitstring fold computes the encoding
+of what the fixed-width fold computes, on every input — including the inputs
+that spell no term, where both are absent.
+
+This is an equality of results only, and it relates the two algebras at the
+shared semantic layer rather than the two expressions directly; each expression
+is tied to that layer separately, by `foldOutSemV_eq` here and by
+`Geb.CobhamFold.foldOutSem_eq` for the fixed-width construction. The two differ
+in cost, though not as a constant-time step against a linear-time one: under the
+model of § Cost neither construction has constant-time steps, `Cobham.casesOf`
+dispatching through `Cobham.cond` and `Cobham.predIterOf` iterating
+`Cobham.pred`, both `boundedRec` nodes over the state. What differs is the
+degree, a fixed-width step being linear in the state where `takeEntryOf` is
+cubic. -/
+theorem foldOut_algOfFixed {α : Type u} {p : ℕ} (R : RankedAlphabet)
+    (enc : α → Fin p → Bool) (dec : (Fin p → Bool) → α)
+    (hdec : ∀ a, dec (enc a) = a)
+    (alg : (i : Fin R.card) → (Fin (R.arity i) → α) → α) (w : List Bool) :
+    foldOut R (algOfFixed R enc dec alg) w =
+      (foldOut R alg w).map fun a ↦ List.ofFn (enc a) :=
+  foldOut_map R alg (algOfFixed R enc dec alg) (fun a ↦ List.ofFn (enc a))
+    (fun i g ↦ congrArg (fun h ↦ List.ofFn (enc (alg i h)))
+      (funext fun d ↦ by rw [bits_ofFn, hdec])) w
+
+/-- The readout's output word: a `true` marker followed by the value, and
+`[false]` at no value. The marker separates the two branches, a value being
+free to be empty. -/
+def outWordV : Option (List Bool) → List Bool
+  | none => [false]
+  | some a => true :: a
+
+/-- The number of state bits the readout dispatches on: the flag, the slot, and
+`R.maxArity + 2` count bits. Any count region of two or more bits separates a
+count of one from a longer one; this width is chosen to exceed the dispatch
+window's, which is one bit at an alphabet whose symbols are all nullary. -/
+def readoutWidthV (R : RankedAlphabet) : ℕ := 1 + R.width + (R.maxArity + 2)
+
+/-- The readout at a bitstring carrier, dispatching on
+`Geb.CobhamFold.readoutWidthV`'s window: on acceptance the sole stack entry's
+payload, prefixed with a presence marker, and `[false]` otherwise. -/
+def readOfV (R : RankedAlphabet) : COf 1 :=
+  diagOf (casesOf (readoutWidthV R) fun v ↦
+    if (decodeVAt R (readoutWidthV R) v).live &&
+        (decodeVAt R (readoutWidthV R) v).buf.isEmpty &&
+        (decodeVAt R (readoutWidthV R) v).depth == 1 then
+      prependOf [true] (comp1Of takeEntryOf (predIterOf (R.width + 3)))
+    else constAtOf 1 [false])
+
+/-- The state word past the flag, the slot, one pending count and the
+sentinel is the stack. -/
+theorem drop_stateWordV_succ (R : RankedAlphabet) (s : FoldScan (List Bool))
+    (h : s.buf.length < R.width) (h1 : s.stack.length = 1) :
+    (stateWordV R s).drop (R.width + 3) = stackWordV s.stack := by
+  have hd := drop_stateWordV R s h 1 (by omega)
+  rw [h1] at hd
+  have hdd : (stateWordV R s).drop (R.width + 3) =
+      ((stateWordV R s).drop (1 + R.width + 1)).drop 1 := by
+    rw [List.drop_drop]
+    exact congrArg (fun k ↦ (stateWordV R s).drop k) (by omega)
+  rw [hdd, hd]
+  rfl
+
+/-- The readout's value at a state word. -/
+theorem stepWord_readOfV (R : RankedAlphabet) (s : FoldScan (List Bool))
+    (h : s.buf.length < R.width) :
+    stepWord (readOfV R) (stateWordV R s) =
+      outWordV (if s.live && s.buf.isEmpty && s.stack.length == 1
+        then s.stack.head? else none) := by
+  rw [readOfV, stepWord_diagOf]
+  change casesSem (readoutWidthV R) _ ![stateWordV R s, stateWordV R s] = _
+  rw [casesSem_eq, decodeVAt_stateWordV R s (readoutWidthV R) (R.maxArity + 2)
+    (by rw [readoutWidthV]) h]
+  dsimp only
+  have hmin : ∀ n : ℕ, (min n (R.maxArity + 2) == 1) = (n == 1) := by
+    intro n
+    by_cases hn : n = 1
+    · have h2 : min n (R.maxArity + 2) = 1 := by omega
+      rw [h2, hn]
+    · rw [beq_eq_false_iff_ne.mpr (by omega : ¬ min n (R.maxArity + 2) = 1),
+        beq_eq_false_iff_ne.mpr hn]
+  rw [hmin]
+  by_cases hacc : (s.live && s.buf.isEmpty && (s.stack.length == 1)) = true
+  · rw [if_pos hacc, if_pos hacc, stepWord_prependOf, stepWord_comp1Of,
+      stepWord_predIterOf]
+    obtain ⟨_, hone⟩ := (Bool.and_eq_true _ _).mp hacc
+    have h1 : s.stack.length = 1 := eq_of_beq hone
+    have hsing : ∃ a, s.stack = [a] := by
+      match hs2 : s.stack with
+      | [] =>
+        rw [hs2, List.length_nil] at h1
+        exact absurd h1 Nat.zero_ne_one
+      | a :: [] => exact ⟨a, rfl⟩
+      | _ :: _ :: t =>
+        rw [hs2, List.length_cons, List.length_cons] at h1
+        exact absurd h1 (by omega)
+    obtain ⟨a, ha⟩ := hsing
+    rw [drop_stateWordV_succ R s h h1, stepWord_takeEntryOf, ha,
+      stackWordV_cons, stackWordV_nil, takeEntrySem_entryWord]
+    rfl
+  · rw [if_neg hacc, if_neg hacc, stepWord_constAtOf]
+    rfl
+
+/-- The readout composed onto the scan, at its declared arity. -/
+def foldOutOfV (R : RankedAlphabet) (algOf : (i : Fin R.card) → COf (R.arity i))
+    (alg : (i : Fin R.card) → (Fin (R.arity i) → List Bool) → List Bool)
+    (halg : ∀ (i : Fin R.card) (f : Fin (R.arity i) → List Bool),
+      semAt (R.arity i) (algOf i).1.1 (algOf i).2 f = alg i f)
+    (mult c : ℕ)
+    (hsize : ∀ w : List Bool,
+      stackSize (foldScanFinal R alg w).stack ≤ c * w.length)
+    (hmult : 2 * c + 2 ≤ mult) : COf 1 :=
+  comp1Of (readOfV R) (foldExprOfV R algOf alg halg mult c hsize hmult)
+
+/-- The fold at a bitstring carrier, as an expression of Cobham's class. -/
+def foldOutExprV (R : RankedAlphabet) (algOf : (i : Fin R.card) → COf (R.arity i))
+    (alg : (i : Fin R.card) → (Fin (R.arity i) → List Bool) → List Bool)
+    (halg : ∀ (i : Fin R.card) (f : Fin (R.arity i) → List Bool),
+      semAt (R.arity i) (algOf i).1.1 (algOf i).2 f = alg i f)
+    (mult c : ℕ)
+    (hsize : ∀ w : List Bool,
+      stackSize (foldScanFinal R alg w).stack ≤ c * w.length)
+    (hmult : 2 * c + 2 ≤ mult) : C :=
+  (foldOutOfV R algOf alg halg mult c hsize hmult).1
+
+/-- The fold's meaning at its arity, read at the raw tree. -/
+def foldOutSemV (R : RankedAlphabet) (algOf : (i : Fin R.card) → COf (R.arity i))
+    (alg : (i : Fin R.card) → (Fin (R.arity i) → List Bool) → List Bool)
+    (halg : ∀ (i : Fin R.card) (f : Fin (R.arity i) → List Bool),
+      semAt (R.arity i) (algOf i).1.1 (algOf i).2 f = alg i f)
+    (mult c : ℕ)
+    (hsize : ∀ w : List Bool,
+      stackSize (foldScanFinal R alg w).stack ≤ c * w.length)
+    (hmult : 2 * c + 2 ≤ mult) : Sem 1 :=
+  semAt 1 (foldOutOfV R algOf alg halg mult c hsize hmult).1.1
+    (foldOutOfV R algOf alg halg mult c hsize hmult).2
+
+/-- The meaning read at the raw tree is the meaning the expression carries. -/
+theorem foldOutSemV_eq_eval (R : RankedAlphabet)
+    (algOf : (i : Fin R.card) → COf (R.arity i))
+    (alg : (i : Fin R.card) → (Fin (R.arity i) → List Bool) → List Bool)
+    (halg : ∀ (i : Fin R.card) (f : Fin (R.arity i) → List Bool),
+      semAt (R.arity i) (algOf i).1.1 (algOf i).2 f = alg i f)
+    (mult c : ℕ)
+    (hsize : ∀ w : List Bool,
+      stackSize (foldScanFinal R alg w).stack ≤ c * w.length)
+    (hmult : 2 * c + 2 ≤ mult) :
+    transport (foldOutOfV R algOf alg halg mult c hsize hmult).2
+        (foldOutOfV R algOf alg halg mult c hsize hmult).1.eval =
+      foldOutSemV R algOf alg halg mult c hsize hmult := rfl
+
+/-- The expression at a bitstring carrier computes the fold: the readout on the
+scan is `Geb.CobhamFold.foldOut`, spelled by `outWordV`. With
+`Geb.CobhamFold.foldOut_eq` this is `RankedAlphabet.parse` followed by the
+algebra morphism out of the term algebra. -/
+theorem foldOutSemV_eq (R : RankedAlphabet)
+    (algOf : (i : Fin R.card) → COf (R.arity i))
+    (alg : (i : Fin R.card) → (Fin (R.arity i) → List Bool) → List Bool)
+    (halg : ∀ (i : Fin R.card) (f : Fin (R.arity i) → List Bool),
+      semAt (R.arity i) (algOf i).1.1 (algOf i).2 f = alg i f)
+    (mult c : ℕ)
+    (hsize : ∀ w : List Bool,
+      stackSize (foldScanFinal R alg w).stack ≤ c * w.length)
+    (hmult : 2 * c + 2 ≤ mult) (w : List Bool) :
+    foldOutSemV R algOf alg halg mult c hsize hmult ![w] =
+      outWordV (foldOut R alg w) := by
+  have happly : foldOutSemV R algOf alg halg mult c hsize hmult ![w] =
+      stepWord (readOfV R) (foldSemV R algOf mult ![w]) :=
+    congrArg (semAt 1 (readOfV R).1.1 (readOfV R).2)
+      (funext fun i ↦ match i with | ⟨0, _⟩ => rfl)
+  rw [happly, foldSemV_eq R algOf alg halg mult w,
+    stepWord_readOfV R _ (length_buf_foldScanFinal_lt R alg w), foldOut]
+
+/-- A scaled family's sum is the scaled sum. -/
+private theorem sum_ofFn_mul (c n : ℕ) (g : Fin n → ℕ) :
+    (List.ofFn fun d ↦ c * g d).sum = c * (List.ofFn g).sum := by
+  rw [List.ofFn_eq_map, List.ofFn_eq_map, List.sum_map_mul_left]
+
+/-- Sums of families order pointwise. `List.sum_le_sum` states this over
+`List.map`, but in `Mathlib.Algebra.Order.BigOperators.Group.List`, outside this
+module's import closure. -/
+private theorem sum_ofFn_le : ∀ (n : ℕ) (g h : Fin n → ℕ), (∀ d, g d ≤ h d) →
+    (List.ofFn g).sum ≤ (List.ofFn h).sum :=
+  Nat.rec (fun _ _ _ ↦ by rw [List.ofFn_zero, List.ofFn_zero])
+    fun n ih g h hgh ↦ by
+      rw [List.ofFn_succ, List.ofFn_succ, List.sum_cons, List.sum_cons]
+      exact Nat.add_le_add (hgh 0)
+        (ih (fun i ↦ g i.succ) (fun i ↦ h i.succ) fun i ↦ hgh i.succ)
+
+/-- An algebra that lengthens by at most a constant per symbol folds a term to a
+value linear in the term's node count. The term-level companion of
+`stackSize_le_of_growth`, which derives `length_foldSemV_le`'s hypothesis from
+the same condition: this states what the condition says about the fold's value,
+that a fold meeting it is one whose output the class can hold. -/
+theorem length_fold_le_of_growth (R : RankedAlphabet)
+    (alg : (i : Fin R.card) → (Fin (R.arity i) → List Bool) → List Bool) (c : ℕ)
+    (hgrow : ∀ (i : Fin R.card) (f : Fin (R.arity i) → List Bool),
+      (alg i f).length ≤ (List.ofFn fun d ↦ (f d).length).sum + c) :
+    ∀ t : R.Term, (Term.fold R alg t).length ≤ c * t.size :=
+  Term.induction
+    (motive := fun t ↦ (Term.fold R alg t).length ≤ c * t.size)
+    fun i ch ih ↦ by
+      beta_reduce
+      rw [Term.fold_mk, size_mk, Nat.mul_add, Nat.mul_one]
+      refine Nat.le_trans (hgrow i fun d ↦ Term.fold R alg (ch d)) ?_
+      refine Nat.add_le_add_right ?_ c
+      refine Nat.le_trans
+        (sum_ofFn_le (R.arity i) _ (fun d ↦ c * (ch d).size) ih) ?_
+      exact Nat.le_of_eq (sum_ofFn_mul c (R.arity i) fun d ↦ (ch d).size)
+
+/-- The pending values' total length is additive over a concatenation. -/
+theorem stackSize_append (a b : List (List Bool)) :
+    stackSize (a ++ b) = stackSize a + stackSize b := by
+  rw [stackSize, stackSize, stackSize, List.flatten_append, List.length_append]
+
+/-- The pending values' total length splits at any point. -/
+theorem stackSize_take_add_drop (st : List (List Bool)) (r : ℕ) :
+    stackSize (st.take r) + stackSize (st.drop r) = stackSize st := by
+  rw [← stackSize_append, List.take_append_drop]
+
+/-- The lengths of the first `r` entries sum to their total length. -/
+private theorem sum_ofFn_getElem : ∀ (r : ℕ) (st : List (List Bool)) (h : r ≤ st.length),
+    (List.ofFn fun d : Fin r ↦
+      (st[d.val]'(Nat.lt_of_lt_of_le d.isLt h)).length).sum = stackSize (st.take r) :=
+  Nat.rec (fun st _ ↦ by rw [List.ofFn_zero, List.sum_nil, List.take_zero, stackSize_nil])
+    fun r ih st h ↦ match st with
+      | [] => absurd h (Nat.not_succ_le_zero r)
+      | a :: t => by
+        rw [List.ofFn_succ, List.sum_cons, List.take_succ_cons, stackSize_cons]
+        exact congrArg (a.length + ·) (ih t (Nat.le_of_succ_le_succ h))
+
+/-- One step raises the potential `R.width * stackSize + c * |buf|` by at
+most `c`, the growth condition assumed only of arguments the stack holds.
+`Geb.CobhamFold.potential_foldScanStep_le` is this where the condition holds
+at arbitrary arguments. -/
+theorem potential_foldScanStep_le_of_invariant (R : RankedAlphabet)
+    (alg : (i : Fin R.card) → (Fin (R.arity i) → List Bool) → List Bool)
+    (P : List Bool → Prop) (c : ℕ)
+    (hgrow : ∀ (i : Fin R.card) (f : Fin (R.arity i) → List Bool),
+      (∀ d, P (f d)) →
+      (alg i f).length ≤ (List.ofFn fun d ↦ (f d).length).sum + c)
+    (b : Bool) (s : FoldScan (List Bool)) (hs : ∀ v ∈ s.stack, P v) :
+    R.width * stackSize (foldScanStep R alg b s).stack +
+        c * (foldScanStep R alg b s).buf.length ≤
+      R.width * stackSize s.stack + c * s.buf.length + c := by
+  obtain ⟨buf, stack, live⟩ := s
+  dsimp only at hs
+  rw [foldScanStep]
+  dsimp only
+  cases live
+  · dsimp only
+    omega
+  · dsimp only
+    by_cases hlen : (b :: buf).length = R.width
+    · rw [if_pos hlen]
+      have hbw : buf.length + 1 = R.width := by
+        rw [List.length_cons] at hlen
+        omega
+      match hsym : symOf R (decodeBits (b :: buf)) with
+      | none =>
+        dsimp only
+        simp only [List.length_nil, Nat.mul_zero]
+        omega
+      | some i =>
+        dsimp only
+        by_cases hst : R.arity i ≤ stack.length
+        · rw [dif_pos hst]
+          dsimp only
+          have hsum := sum_ofFn_getElem (R.arity i) stack hst
+          -- the popped arguments are members of the stack, so `hs` supplies
+          -- `P` at each
+          have halg := hgrow i
+            (fun d ↦ stack[d.val]'(Nat.lt_of_lt_of_le d.isLt hst))
+            fun d ↦ hs _ (List.getElem_mem _)
+          rw [hsum] at halg
+          have hsplit := stackSize_take_add_drop stack (R.arity i)
+          have hnew : stackSize ((alg i fun d ↦
+              stack[d.val]'(Nat.lt_of_lt_of_le d.isLt hst)) ::
+                stack.drop (R.arity i)) ≤ stackSize stack + c := by
+            rw [stackSize_cons]
+            omega
+          have hmul : R.width * stackSize ((alg i fun d ↦
+              stack[d.val]'(Nat.lt_of_lt_of_le d.isLt hst)) ::
+                stack.drop (R.arity i)) ≤ R.width * (stackSize stack + c) :=
+            Nat.mul_le_mul_left _ hnew
+          rw [Nat.mul_add] at hmul
+          have hcw : R.width * c = c * R.width := Nat.mul_comm _ _
+          have hcb : c * buf.length + c = c * R.width := by
+            rw [← hbw, Nat.mul_add, Nat.mul_one]
+          simp only [List.length_nil, Nat.mul_zero, Nat.add_zero]
+          omega
+        · rw [dif_neg hst]
+          dsimp only
+          simp only [List.length_nil, Nat.mul_zero]
+          omega
+    · rw [if_neg hlen]
+      dsimp only
+      have hcb : c * (buf.length + 1) = c * buf.length + c := by
+        rw [Nat.mul_add, Nat.mul_one]
+      simp only [List.length_cons]
+      omega
+
+/-- One step raises the potential `R.width * stackSize + c * |buf|` by at most
+`c`. Every clause but the completing pop leaves the stack alone, and the pop
+adds at most `c` to it while clearing a block worth `R.width` bits. -/
+theorem potential_foldScanStep_le (R : RankedAlphabet)
+    (alg : (i : Fin R.card) → (Fin (R.arity i) → List Bool) → List Bool) (c : ℕ)
+    (hgrow : ∀ (i : Fin R.card) (f : Fin (R.arity i) → List Bool),
+      (alg i f).length ≤ (List.ofFn fun d ↦ (f d).length).sum + c)
+    (b : Bool) (s : FoldScan (List Bool)) :
+    R.width * stackSize (foldScanStep R alg b s).stack +
+        c * (foldScanStep R alg b s).buf.length ≤
+      R.width * stackSize s.stack + c * s.buf.length + c :=
+  potential_foldScanStep_le_of_invariant R alg (fun _ ↦ True) c
+    (fun i f _ ↦ hgrow i f) b s fun _ _ ↦ trivial
+
+/-- The potential never exceeds `c` per input bit, the growth condition
+assumed only of values satisfying `P`, which
+`Geb.CobhamFold.mem_stack_foldScanFinal` carries along the scan.
+`Geb.CobhamFold.potential_foldScanFinal_le` is this at the trivial
+predicate. -/
+theorem potential_foldScanFinal_le_of_invariant (R : RankedAlphabet)
+    (alg : (i : Fin R.card) → (Fin (R.arity i) → List Bool) → List Bool)
+    (P : List Bool → Prop) (c : ℕ)
+    (hpush : ∀ (i : Fin R.card) (f : Fin (R.arity i) → List Bool), P (alg i f))
+    (hgrow : ∀ (i : Fin R.card) (f : Fin (R.arity i) → List Bool),
+      (∀ d, P (f d)) →
+      (alg i f).length ≤ (List.ofFn fun d ↦ (f d).length).sum + c) :
+    ∀ w : List Bool,
+      R.width * stackSize (foldScanFinal R alg w).stack +
+        c * (foldScanFinal R alg w).buf.length ≤ c * w.length :=
+  List.rec (by
+      rw [List.length_nil, Nat.mul_zero]
+      exact Nat.le_of_eq rfl)
+    fun b v ih ↦ by
+      have hstep := potential_foldScanStep_le_of_invariant R alg P c hgrow b
+        (foldScanFinal R alg v) (mem_stack_foldScanFinal R alg P hpush v)
+      have hcons : foldScanFinal R alg (b :: v) =
+          foldScanStep R alg b (foldScanFinal R alg v) := rfl
+      have hc : c * (v.length + 1) = c * v.length + c := by
+        rw [Nat.mul_add, Nat.mul_one]
+      rw [hcons, List.length_cons]
+      omega
+
+/-- An algebra whose values satisfy an invariant under which it lengthens by
+at most a constant per symbol keeps the pending values linear in the input.
+`Geb.CobhamFold.stackSize_le_of_growth` is this at the trivial invariant. -/
+theorem stackSize_le_of_growth_of_invariant (R : RankedAlphabet)
+    (alg : (i : Fin R.card) → (Fin (R.arity i) → List Bool) → List Bool)
+    (P : List Bool → Prop) (c : ℕ)
+    (hpush : ∀ (i : Fin R.card) (f : Fin (R.arity i) → List Bool), P (alg i f))
+    (hgrow : ∀ (i : Fin R.card) (f : Fin (R.arity i) → List Bool),
+      (∀ d, P (f d)) →
+      (alg i f).length ≤ (List.ofFn fun d ↦ (f d).length).sum + c)
+    (w : List Bool) :
+    stackSize (foldScanFinal R alg w).stack ≤ c * w.length := by
+  have h := potential_foldScanFinal_le_of_invariant R alg P c hpush hgrow w
+  have hm : stackSize (foldScanFinal R alg w).stack ≤
+      R.width * stackSize (foldScanFinal R alg w).stack :=
+    Nat.le_mul_of_pos_left _ R.width_pos
+  omega
+
+/-- The potential never exceeds `c` per input bit. -/
+theorem potential_foldScanFinal_le (R : RankedAlphabet)
+    (alg : (i : Fin R.card) → (Fin (R.arity i) → List Bool) → List Bool) (c : ℕ)
+    (hgrow : ∀ (i : Fin R.card) (f : Fin (R.arity i) → List Bool),
+      (alg i f).length ≤ (List.ofFn fun d ↦ (f d).length).sum + c) :
+    ∀ w : List Bool,
+      R.width * stackSize (foldScanFinal R alg w).stack +
+        c * (foldScanFinal R alg w).buf.length ≤ c * w.length :=
+  potential_foldScanFinal_le_of_invariant R alg (fun _ ↦ True) c
+    (fun _ _ ↦ trivial) fun i f _ ↦ hgrow i f
+
+/-- An algebra that lengthens by at most a constant per symbol keeps the pending
+values linear in the input, which is the hypothesis
+`Geb.CobhamFold.length_foldSemV_le` takes. This is the bridge from a condition on
+the algebra alone to the condition the recursion bound consumes. -/
+theorem stackSize_le_of_growth (R : RankedAlphabet)
+    (alg : (i : Fin R.card) → (Fin (R.arity i) → List Bool) → List Bool) (c : ℕ)
+    (hgrow : ∀ (i : Fin R.card) (f : Fin (R.arity i) → List Bool),
+      (alg i f).length ≤ (List.ofFn fun d ↦ (f d).length).sum + c)
+    (w : List Bool) :
+    stackSize (foldScanFinal R alg w).stack ≤ c * w.length :=
+  stackSize_le_of_growth_of_invariant R alg (fun _ ↦ True) c
+    (fun _ _ ↦ trivial) (fun i f _ ↦ hgrow i f) w
+
+end Geb.CobhamFold
+
+end

--- a/geb-lean/vendor/geb-mathlib/Geb/Mathlib.lean
+++ b/geb-lean/vendor/geb-mathlib/Geb/Mathlib.lean
@@ -14,9 +14,9 @@ public import Geb.Mathlib.Logic
 # Geb.Mathlib — upstream-eligible content for mathlib4, Lean core or Batteries
 
 Modules under this namespace are intended for eventual upstream
-extraction to mathlib4, and import only from `Mathlib.*`, `Batteries.*`
-or `Geb.Mathlib.*`. Where those import rules leave no alternative, a
-module here may instead target Lean core or Batteries; that destination
-is open, per `TODO.md` § Upstream destination of core- and
-Batteries-targeted content.
+extraction to mathlib4, and import only from `Mathlib.*`,
+`Batteries.*`, `Geb.Mathlib.*` or `GebLang.*`. Where those import
+rules leave no alternative, a module here may instead target Lean core
+or Batteries; that destination is open, per `TODO.md` § Upstream
+destination of core- and Batteries-targeted content.
 -/

--- a/geb-lean/vendor/geb-mathlib/Geb/Mathlib/CategoryTheory.lean
+++ b/geb-lean/vendor/geb-mathlib/Geb/Mathlib/CategoryTheory.lean
@@ -5,6 +5,7 @@ Authors: Terence Rokop
 -/
 module
 
+public import Geb.Mathlib.CategoryTheory.DiscreteFibration
 public import Geb.Mathlib.CategoryTheory.ElementaryTopos
 public import Geb.Mathlib.CategoryTheory.FinCat
 public import Geb.Mathlib.CategoryTheory.FinSetSkel

--- a/geb-lean/vendor/geb-mathlib/Geb/Mathlib/CategoryTheory/DiscreteFibration.lean
+++ b/geb-lean/vendor/geb-mathlib/Geb/Mathlib/CategoryTheory/DiscreteFibration.lean
@@ -1,0 +1,16 @@
+/-
+Copyright (c) 2026 Terence Rokop. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Terence Rokop
+-/
+module
+
+public import Geb.Mathlib.CategoryTheory.DiscreteFibration.Basic
+public import Geb.Mathlib.CategoryTheory.DiscreteFibration.Elements
+public import Geb.Mathlib.CategoryTheory.DiscreteFibration.FiberPresheaf
+public import Geb.Mathlib.CategoryTheory.DiscreteFibration.Packaged
+public import Geb.Mathlib.CategoryTheory.DiscreteFibration.Pullback
+
+/-!
+# Discrete fibrations — index
+-/

--- a/geb-lean/vendor/geb-mathlib/Geb/Mathlib/CategoryTheory/DiscreteFibration/Basic.lean
+++ b/geb-lean/vendor/geb-mathlib/Geb/Mathlib/CategoryTheory/DiscreteFibration/Basic.lean
@@ -1,0 +1,242 @@
+/-
+Copyright (c) 2026 Terence Rokop. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Terence Rokop
+-/
+-- Modified from geb-mathlib by scripts/geb-mathlib-backport.patch.
+module
+
+public import Mathlib.CategoryTheory.Comma.Arrow
+public import Mathlib.CategoryTheory.FiberedCategory.Fiber
+public import Mathlib.CategoryTheory.FiberedCategory.Fibered
+public import Mathlib.CategoryTheory.FiberedCategory.HomLift
+public import Mathlib.Data.Sigma.Basic
+public import Mathlib.Tactic.Attr.Core
+
+/-!
+# Discrete fibrations: lifting data
+
+A functor `p : C ⥤ B` is a discrete fibration when every `g : b ⟶ p.obj c`
+has a unique lift with codomain `c` ([LoregianRiehl2018] § 2.1;
+[nLabDiscreteFibration]).  This module carries that lifting data as a
+structure and relates it to mathlib's fibred-category API.
+
+## Main definitions
+
+* `DiscreteFibration p`, the lifting data: for each `g : b ⟶ p.obj c` a
+  lift `hom g : src g ⟶ c`, together with the statement that it is the
+  only lift.
+
+## Main statements
+
+* `DiscreteFibration.map_injective` and `DiscreteFibration.faithful`: a
+  discrete fibration is faithful.
+* `isHomLift_iff_arrow_mk_eq`: mathlib's `Functor.IsHomLift` is equality
+  of arrows.
+* `DiscreteFibration.isCartesian`, `DiscreteFibration.isPreFibered` and
+  `DiscreteFibration.isFibered`: every morphism is cartesian, so a
+  discrete fibration is a fibred category.
+* `DiscreteFibration.fiber_eq_of_hom` and
+  `DiscreteFibration.fiber_hom_ext`: the fibres are discrete categories.
+
+## Implementation notes
+
+Lifts are unique, so `DiscreteFibration p` is a `Subsingleton`: carrying
+it as data costs nothing, and it lets the fibre presheaf of
+`Geb/Mathlib/CategoryTheory/DiscreteFibration/FiberPresheaf.lean` be
+defined without `Classical.choice`.
+
+`eq_of_isHomLift_id` and `fiber_eq_of_hom` route through
+`Functor.Fiber.fiberInclusion` rather than the subtype projections of
+`Functor.Fiber`, which is semireducible: a goal mentioning `b.1` is not
+type-correct at implicit transparency and stops `rw` and `simp`.
+
+## References
+
+* [LoregianRiehl2018]
+* [nLabDiscreteFibration]
+
+## Tags
+
+discrete fibration, fibred category, cartesian morphism, fibre
+-/
+
+@[expose] public section
+
+universe v₁ v₂ u₁ u₂
+
+namespace CategoryTheory
+
+variable {C : Type u₁} [Category.{v₁} C] {B : Type u₂} [Category.{v₂} B]
+
+/-- Lifting data for `p`: for every `g : b ⟶ p.obj c` a lift
+`hom g : src g ⟶ c` over `g`, unique among all lifts.  The base-side
+`eqToHom` is forced by the *bundle* presentation (objects of `C` are only
+propositionally over `b`); it vanishes in the *family* presentation
+`Functor.CoElements` below. -/
+structure DiscreteFibration (p : C ⥤ B) where
+  /-- Domain of the lift of `g`. -/
+  src : ∀ {b : B} {c : C}, (b ⟶ p.obj c) → C
+  /-- The lift of `g`. -/
+  hom : ∀ {b : B} {c : C} (g : b ⟶ p.obj c), src g ⟶ c
+  /-- The domain of the lift of `g` lies over the domain of `g`. -/
+  obj_src : ∀ {b : B} {c : C} (g : b ⟶ p.obj c), p.obj (src g) = b
+  /-- The lift of `g` lies over `g`. -/
+  map_hom : ∀ {b : B} {c : C} (g : b ⟶ p.obj c),
+    p.map (hom g) = eqToHom (obj_src g) ≫ g
+  /-- Uniqueness of lifts, as an equality in `Σ c', c' ⟶ c`. -/
+  unique : ∀ {b : B} {c : C} (g : b ⟶ p.obj c) {c' : C} (h : c' ⟶ c)
+    (e : p.obj c' = b), p.map h = eqToHom e ≫ g →
+      (⟨c', h⟩ : Σ c', c' ⟶ c) = ⟨src g, hom g⟩
+
+namespace DiscreteFibration
+
+variable {p : C ⥤ B} (D : DiscreteFibration p)
+include D
+
+/-- The uniqueness clause with the source fixed: `p` reflects equality of
+parallel arrows, i.e. `p` is faithful. -/
+theorem map_injective {c c' : C} {h₁ h₂ : c' ⟶ c}
+    (H : p.map h₁ = p.map h₂) : h₁ = h₂ := by
+  have h := (D.unique (p.map h₂) h₁ rfl (by simpa using H)).trans
+    (D.unique (p.map h₂) h₂ rfl (by simp)).symm
+  exact eq_of_heq (Sigma.mk.inj_iff.1 h).2
+
+/-- A discrete fibration is faithful. -/
+theorem faithful : p.Faithful := ⟨fun H => D.map_injective H⟩
+
+/-- Uniqueness of the source of a lift. -/
+theorem src_eq {b : B} {c c' : C} (g : b ⟶ p.obj c) (h : c' ⟶ c)
+    (e : p.obj c' = b) (H : p.map h = eqToHom e ≫ g) : D.src g = c' :=
+  (congrArg Sigma.fst (D.unique g h e H)).symm
+
+/-- The lift of an identity is an identity. -/
+theorem src_id (c : C) : D.src (𝟙 (p.obj c)) = c :=
+  D.src_eq _ (𝟙 c) rfl (by simp)
+
+/-- Lifting data is unique: `DiscreteFibration p` is a mere proposition. -/
+instance : Subsingleton (DiscreteFibration p) := by
+  constructor
+  intro D₁ D₂
+  have h : ∀ {b : B} {c : C} (g : b ⟶ p.obj c),
+      (⟨D₁.src g, D₁.hom g⟩ : Σ c', c' ⟶ c) =
+        ⟨D₂.src g, D₂.hom g⟩ :=
+    fun g => D₂.unique g (D₁.hom g) (D₁.obj_src g) (D₁.map_hom g)
+  obtain ⟨src₁, hom₁, _, _, _⟩ := D₁
+  obtain ⟨src₂, hom₂, _, _, _⟩ := D₂
+  have hs : @src₁ = @src₂ := by
+    funext b c g
+    exact congrArg Sigma.fst (h g)
+  subst hs
+  have hh : @hom₁ = @hom₂ := by
+    funext b c g
+    exact eq_of_heq (Sigma.mk.inj_iff.1 (h g)).2
+  subst hh
+  rfl
+
+end DiscreteFibration
+
+/-! ### Mathlib's `IsHomLift` -/
+
+/-- Mathlib's `IsHomLift` is the proposition
+`Arrow.mk (p.map φ) = Arrow.mk f`. -/
+theorem isHomLift_iff_arrow_mk_eq (p : C ⥤ B) {R S : B} {a b : C}
+    (f : R ⟶ S) (φ : a ⟶ b) :
+    p.IsHomLift f φ ↔ Arrow.mk (p.map φ) = Arrow.mk f := by
+  constructor
+  · intro h
+    exact (Arrow.mk_eq_mk_iff _ _).2
+      ⟨IsHomLift.domain_eq p f φ, IsHomLift.codomain_eq p f φ,
+        IsHomLift.fac' p f φ⟩
+  · intro h
+    obtain ⟨hR, hS, hf⟩ := (Arrow.mk_eq_mk_iff _ _).1 h
+    exact IsHomLift.of_fac' p f φ hR hS hf
+
+namespace DiscreteFibration
+
+variable {p : C ⥤ B} (D : DiscreteFibration p)
+include D
+
+/-- The lift of `g` as an arrow of `C`. -/
+def liftArrow {b : B} {c : C} (g : b ⟶ p.obj c) : Arrow C :=
+  Arrow.mk (D.hom g)
+
+/-- The image of the lift of `g` is `g`, as an equality of arrows. -/
+theorem arrow_mk_map_hom {b : B} {c : C} (g : b ⟶ p.obj c) :
+    Arrow.mk (p.map (D.hom g)) = Arrow.mk g :=
+  (Arrow.mk_eq_mk_iff _ _).2 ⟨D.obj_src g, rfl, by simp [D.map_hom]⟩
+
+/-- The lift of `g` lies over `g` in mathlib's sense. -/
+theorem isHomLift_hom {b : B} {c : C} (g : b ⟶ p.obj c) :
+    p.IsHomLift g (D.hom g) :=
+  (isHomLift_iff_arrow_mk_eq p g (D.hom g)).2 (D.arrow_mk_map_hom g)
+
+/-- Uniqueness of lifts, `Arrow`-style. -/
+theorem eq_liftArrow {b : B} {c : C} (g : b ⟶ p.obj c) {c' : C}
+    (h : c' ⟶ c) (hh : Arrow.mk (p.map h) = Arrow.mk g) :
+    Arrow.mk h = D.liftArrow g := by
+  obtain ⟨e, hY, hf⟩ := (Arrow.mk_eq_mk_iff _ _).1 hh
+  have hu := D.unique g h e (by simpa using hf)
+  obtain ⟨h1, h2⟩ := Sigma.mk.inj_iff.1 hu
+  simp only [liftArrow]
+  subst h1
+  rw [eq_of_heq h2]
+
+/-- A morphism lying over an identity has equal endpoints. -/
+theorem eq_of_isHomLift_id {S : B} {a b : C} (ψ : a ⟶ b)
+    [p.IsHomLift (𝟙 S) ψ] : a = b :=
+  (D.src_eq (eqToHom (IsHomLift.codomain_eq p (𝟙 S) ψ).symm) ψ
+      (IsHomLift.domain_eq p (𝟙 S) ψ)
+      (by simpa using IsHomLift.fac' p (𝟙 S) ψ)).symm.trans
+    (D.src_eq (eqToHom (IsHomLift.codomain_eq p (𝟙 S) ψ).symm) (𝟙 b)
+      (IsHomLift.codomain_eq p (𝟙 S) ψ) (by simp))
+
+/-- The endpoints of a morphism of a fibre agree.  With `fiber_hom_ext`
+below, the fibres of a discrete fibration are discrete categories. -/
+theorem fiber_eq_of_hom {S : B} {a b : p.Fiber S} (φ : a ⟶ b) : a = b :=
+  Functor.Fiber.fiberInclusion_obj_inj
+    (D.eq_of_isHomLift_id (S := S) (Functor.Fiber.fiberInclusion.map φ))
+
+/-- Parallel morphisms of a fibre agree, since `p` is faithful. -/
+theorem fiber_hom_ext {S : B} {a b : p.Fiber S} (φ ψ : a ⟶ b) : φ = ψ :=
+  Functor.Fiber.hom_ext (D.map_injective
+    ((IsHomLift.fac' p (𝟙 S) (Functor.Fiber.fiberInclusion.map φ)).trans
+      (IsHomLift.fac' p (𝟙 S) (Functor.Fiber.fiberInclusion.map ψ)).symm))
+
+/-- Every morphism over `f` is cartesian in mathlib's sense: uniqueness of
+lifts supplies the universal property outright. -/
+theorem isCartesian {R S : B} {a b : C} (f : R ⟶ S) (φ : a ⟶ b)
+    [p.IsHomLift f φ] : p.IsCartesian f φ where
+  universal_property {a'} φ' _ := by
+    have key : (⟨a', φ'⟩ : Σ c, c ⟶ b) = ⟨a, φ⟩ :=
+      (D.unique (f ≫ eqToHom (IsHomLift.codomain_eq p f φ).symm) φ'
+          (IsHomLift.domain_eq p f φ')
+          (by simpa using IsHomLift.fac' p f φ')).trans
+        (D.unique (f ≫ eqToHom (IsHomLift.codomain_eq p f φ).symm) φ
+          (IsHomLift.domain_eq p f φ)
+          (by simpa using IsHomLift.fac' p f φ)).symm
+    obtain ⟨ha, hφ⟩ := Sigma.mk.inj_iff.1 key
+    subst ha
+    obtain rfl := eq_of_heq hφ
+    refine ⟨𝟙 _, ⟨IsHomLift.id (IsHomLift.domain_eq p f φ'),
+      Category.id_comp _⟩, fun χ hχ => D.map_injective ?_⟩
+    have := hχ.1
+    rw [p.map_id]
+    simpa using IsHomLift.fac' p (𝟙 R) χ
+
+/-- Every object of `C` admits a cartesian lift of every morphism into its
+image. -/
+theorem isPreFibered : p.IsPreFibered where
+  exists_isCartesian' f :=
+    ⟨D.src f, D.hom f, have := D.isHomLift_hom f; D.isCartesian _ _⟩
+
+/-- A discrete fibration is a fibred category. -/
+theorem isFibered : p.IsFibered where
+  toIsPreFibered := D.isPreFibered
+  comp := by
+    intro _ _ _ f g _ _ _ φ ψ _ _
+    exact D.isCartesian (f ≫ g) (φ ≫ ψ)
+
+end DiscreteFibration
+
+end CategoryTheory

--- a/geb-lean/vendor/geb-mathlib/Geb/Mathlib/CategoryTheory/DiscreteFibration/Elements.lean
+++ b/geb-lean/vendor/geb-mathlib/Geb/Mathlib/CategoryTheory/DiscreteFibration/Elements.lean
@@ -1,0 +1,172 @@
+/-
+Copyright (c) 2026 Terence Rokop. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Terence Rokop
+-/
+module
+
+public import Geb.Mathlib.CategoryTheory.DiscreteFibration.Pullback
+public import Mathlib.CategoryTheory.Elements
+
+/-!
+# The category of elements of a presheaf, over its base
+
+Mathlib's `CategoryTheory.Functor.Elements` presents the category of
+elements of `F : Bᵒᵖ ⥤ Type v₃` over `Bᵒᵖ`.  This module transposes it so
+that its morphisms are morphisms of `B`, the presentation in which the
+projection to `B` is a discrete fibration ([LoregianRiehl2018] § 2.1;
+[nLabDiscreteFibration]).
+
+## Main definitions
+
+* `Functor.CoElements F`, the opposite of `F.Elements`, with the
+  interface `mk`, `base`, `elt`, `homMk`, `homBase`.
+* `Functor.CoElements.π F`, the projection to `B`.
+* `Functor.CoElements.discreteFibration F`, the lifting data on `π F`.
+
+## Main statements
+
+* `Functor.CoElements.sigma_eq`: every morphism is the canonical lift of
+  its image in `B`.
+* `Functor.CoElements.isDiscreteFibration_π`: `π F` is a discrete
+  fibration in the pullback sense too.
+
+## Implementation notes
+
+The transposition is what makes the lift of `g` with codomain
+`⟨b', x'⟩` literally `g : ⟨b, F g x'⟩ ⟶ ⟨b', x'⟩`, with the source
+computed rather than known only up to an `eqToHom`.  `CoElements` is a
+semireducible `def`, as `CoGrothendieck` is in
+`Geb/Mathlib/CategoryTheory/Grothendieck.lean`, so that dot notation and
+instance search stop at it.
+
+## References
+
+* [LoregianRiehl2018]
+* [nLabDiscreteFibration]
+
+## Tags
+
+category of elements, presheaf, discrete fibration, Grothendieck
+construction
+-/
+
+@[expose] public section
+
+universe v₂ v₃ u₂
+
+namespace CategoryTheory
+
+open Opposite
+
+variable {B : Type u₂} [Category.{v₂} B]
+
+/-- The category of elements of a presheaf `F : Bᵒᵖ ⥤ Type v₃`, presented
+over `B`: the opposite of mathlib's `Functor.Elements`, which presents it
+over `Bᵒᵖ`.  An object is an object `b` of `B` with an element of `F b`,
+and a morphism `⟨b, x⟩ ⟶ ⟨b', x'⟩` is a morphism `g : b ⟶ b'` of `B` with
+`F g x' = x`.
+
+The `Co` prefix marks the presentation whose morphisms are morphisms of
+the base rather than of its opposite, as in `CoGrothendieck`. -/
+@[implicit_reducible]
+def Functor.CoElements (F : Bᵒᵖ ⥤ Type v₃) : Type (max u₂ v₃) := F.Elementsᵒᵖ
+
+namespace Functor.CoElements
+
+/-- The category structure on `F.CoElements`, inherited from the opposite
+of `F.Elements`. -/
+instance category (F : Bᵒᵖ ⥤ Type v₃) : Category.{v₂} F.CoElements :=
+  inferInstanceAs (Category F.Elementsᵒᵖ)
+
+variable {F : Bᵒᵖ ⥤ Type v₃}
+
+/-- The object of `B` an element lies over. -/
+def base (x : F.CoElements) : B := (Opposite.unop x).1.unop
+
+/-- The element of `F` at `base x`. -/
+def elt (x : F.CoElements) : F.obj (op x.base) := (Opposite.unop x).2
+
+/-- An object of `F.CoElements` from an object of `B` and an element. -/
+def mk (b : B) (x : F.obj (op b)) : F.CoElements := Opposite.op ⟨op b, x⟩
+
+@[simp] theorem base_mk (b : B) (x : F.obj (op b)) : (mk b x).base = b := rfl
+
+@[simp] theorem elt_mk (b : B) (x : F.obj (op b)) : (mk b x).elt = x := rfl
+
+@[simp] theorem mk_base_elt (x : F.CoElements) : mk x.base x.elt = x := rfl
+
+/-- The morphism of `B` underlying a morphism of `F.CoElements`. -/
+def homBase {x y : F.CoElements} (f : x ⟶ y) : x.base ⟶ y.base :=
+  (Quiver.Hom.unop f).1.unop
+
+/-- The compatibility equation a morphism of `F.CoElements` satisfies. -/
+theorem map_homBase_elt {x y : F.CoElements} (f : x ⟶ y) :
+    F.map (homBase f).op y.elt = x.elt := (Quiver.Hom.unop f).2
+
+/-- A morphism of `F.CoElements` from a morphism of `B` and the
+compatibility equation. -/
+def homMk {x y : F.CoElements} (g : x.base ⟶ y.base)
+    (hg : F.map g.op y.elt = x.elt) : x ⟶ y :=
+  Quiver.Hom.op (CategoryOfElements.homMk (Opposite.unop y) (Opposite.unop x) g.op hg)
+
+@[simp] theorem homBase_homMk {x y : F.CoElements} (g : x.base ⟶ y.base)
+    (hg : F.map g.op y.elt = x.elt) : homBase (homMk g hg) = g := rfl
+
+@[ext] theorem hom_ext {x y : F.CoElements} {f g : x ⟶ y}
+    (h : homBase f = homBase g) : f = g :=
+  Quiver.Hom.unop_inj (Subtype.ext (Quiver.Hom.unop_inj h))
+
+@[simp] theorem homBase_id (x : F.CoElements) : homBase (𝟙 x) = 𝟙 x.base := rfl
+
+@[simp] theorem homBase_comp {x y z : F.CoElements} (f : x ⟶ y) (g : y ⟶ z) :
+    homBase (f ≫ g) = homBase f ≫ homBase g := rfl
+
+@[simp] theorem homBase_eqToHom {x y : F.CoElements} (h : x = y) :
+    homBase (eqToHom h) = eqToHom (congrArg base h) := by
+  subst h; rfl
+
+/-- The projection `∫F ⥤ B`. -/
+def π (F : Bᵒᵖ ⥤ Type v₃) : F.CoElements ⥤ B where
+  obj x := x.base
+  map f := homBase f
+
+@[simp] theorem π_obj (x : F.CoElements) : (π F).obj x = x.base := rfl
+
+@[simp] theorem π_map {x y : F.CoElements} (f : x ⟶ y) :
+    (π F).map f = homBase f := rfl
+
+/-- Every morphism of `F.CoElements` is the canonical lift of its image in
+`B`: a morphism into `y` over `g : b ⟶ y.base` has source `mk b (F g y.elt)`
+and equals `homMk g rfl`.  The compatibility equation is left loose so that
+it can be substituted. -/
+theorem sigma_eq (b : B) (e : F.obj (op b)) (y : F.CoElements)
+    (g : b ⟶ y.base) (hg : F.map g.op y.elt = e) :
+    (⟨mk b e, homMk g hg⟩ : Σ x, x ⟶ y) =
+      ⟨mk b (F.map g.op y.elt), homMk g rfl⟩ := by
+  subst hg
+  rfl
+
+/-- The lift of `g : b ⟶ b'` with codomain `⟨b', x'⟩` is
+`g : ⟨b, F g x'⟩ ⟶ ⟨b', x'⟩`.  No `eqToHom` occurs: the source is
+*computed*, not merely known to exist. -/
+def discreteFibration (F : Bᵒᵖ ⥤ Type v₃) : DiscreteFibration (π F) where
+  src {b y} g := mk b (F.map g.op y.elt)
+  hom {_ _} g := homMk g rfl
+  obj_src _ := rfl
+  map_hom _ := (Category.id_comp _).symm
+  unique {b y} g {x} f e hh := by
+    obtain rfl : x.base = b := e
+    have hg : homBase f = g := hh.trans (Category.id_comp g)
+    subst hg
+    exact sigma_eq x.base x.elt y (homBase f) (map_homBase_elt f)
+
+/-- The projection from a category of elements is a discrete fibration in
+the pullback sense. -/
+theorem isDiscreteFibration_π (F : Bᵒᵖ ⥤ Type v₃) :
+    IsDiscreteFibration (π F) :=
+  (discreteFibration F).isDiscreteFibration
+
+end Functor.CoElements
+
+end CategoryTheory

--- a/geb-lean/vendor/geb-mathlib/Geb/Mathlib/CategoryTheory/DiscreteFibration/FiberPresheaf.lean
+++ b/geb-lean/vendor/geb-mathlib/Geb/Mathlib/CategoryTheory/DiscreteFibration/FiberPresheaf.lean
@@ -1,0 +1,276 @@
+/-
+Copyright (c) 2026 Terence Rokop. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Terence Rokop
+-/
+-- Modified from geb-mathlib by scripts/geb-mathlib-backport.patch.
+module
+
+public import Geb.Mathlib.CategoryTheory.DiscreteFibration.Elements
+
+/-!
+# The fibre presheaf of a discrete fibration
+
+The presheaf `b ↦ p⁻¹(b)` of a discrete fibration, restriction along `g`
+being the domain of the unique lift of `g` ([LoregianRiehl2018] § 2.1;
+[nLabDiscreteFibration]), together with the functors between `C` and the
+category of elements of that presheaf.
+
+## Main definitions
+
+* `DiscreteFibration.restrict` and `DiscreteFibration.fiberPresheaf`, the
+  fibre presheaf.
+* `DiscreteFibration.toElements` and `DiscreteFibration.ofElements`, the
+  functors between `C` and `(fiberPresheaf D).CoElements`.
+* `Functor.CoElements.fiberPresheafEquiv`, the bijection between the
+  fibre of `π F` over `b` and `F b`.
+
+## Main statements
+
+* `DiscreteFibration.π_toElements_obj`, `.π_toElements_map` and
+  `.obj_ofElements_obj`: both functors lie over `B`.
+* `DiscreteFibration.ofElements_map_toElements_map`,
+  `.ofElements_obj_toElements_obj`,
+  `.coElements_eq_toElements_obj` and
+  `.toElements_map_ofElements_map`: the two functors are mutually
+  inverse.
+* `Functor.CoElements.fiberPresheafEquiv_restrict`: restriction in the
+  fibre presheaf of `π F` is restriction in `F`.
+
+## Implementation notes
+
+The statements here are elementwise, on objects and on morphisms
+separately.  Their packaged forms, which mention `⋙` or bundle the
+bijections, inherit `Classical.choice` from the mathlib constructions
+they use and live in
+`Geb/Mathlib/CategoryTheory/DiscreteFibration/Packaged.lean`.
+
+`obj_elt` restates a fibre element's defining property with `x.base` in
+place of `unop (op x.base)`, which the `eqToHom` composites below need in
+order to match.
+
+## References
+
+* [LoregianRiehl2018]
+* [nLabDiscreteFibration]
+
+## Tags
+
+discrete fibration, fibre, presheaf, category of elements
+-/
+
+@[expose] public section
+
+universe v₁ v₂ v₃ u₁ u₂
+
+namespace CategoryTheory
+
+open Opposite
+
+variable {C : Type u₁} [Category.{v₁} C] {B : Type u₂} [Category.{v₂} B]
+
+namespace DiscreteFibration
+
+variable {p : C ⥤ B} (D : DiscreteFibration p)
+include D
+
+/-- Restriction along `g : b ⟶ b'` of a fiber element `c'` over `b'`: the
+domain of the unique lift of `g` with codomain `c'`. -/
+def restrict {b b' : B} (g : b ⟶ b') (c' : p.Fiber b') : p.Fiber b :=
+  ⟨D.src (g ≫ eqToHom c'.2.symm), D.obj_src _⟩
+
+@[simp] theorem restrict_val {b b' : B} (g : b ⟶ b') (c' : p.Fiber b') :
+    (D.restrict g c').1 = D.src (g ≫ eqToHom c'.2.symm) := rfl
+
+/-- Restriction along an identity is the identity. -/
+theorem restrict_id {b : B} (c : p.Fiber b) : D.restrict (𝟙 b) c = c :=
+  Subtype.ext (D.src_eq _ (𝟙 c.1) c.2 (by simp))
+
+/-- Restriction is contravariantly functorial. -/
+theorem restrict_comp {b b' b'' : B} (g : b ⟶ b') (g' : b' ⟶ b'')
+    (c : p.Fiber b'') :
+    D.restrict (g ≫ g') c = D.restrict g (D.restrict g' c) := by
+  apply Subtype.ext
+  exact D.src_eq ((g ≫ g') ≫ eqToHom c.2.symm)
+    (D.hom (g ≫ eqToHom (D.obj_src (g' ≫ eqToHom c.2.symm)).symm) ≫
+      D.hom (g' ≫ eqToHom c.2.symm))
+    (D.obj_src _) (by simp [D.map_hom])
+
+/-- The fiber presheaf `b ↦ p⁻¹(b)` of a discrete fibration. -/
+def fiberPresheaf : Bᵒᵖ ⥤ Type u₁ where
+  obj b := p.Fiber b.unop
+  map g := fun c => D.restrict g.unop c
+  map_id _ := funext fun c => D.restrict_id c
+  map_comp g g' := funext fun c => D.restrict_comp g'.unop g.unop c
+
+/-- The fiber presheaf's value on objects.  Not a `simp` lemma: it rewrites
+the object arguments carried by the coercion in `fiberPresheaf_map`'s left-hand
+side, which would take that lemma out of simp-normal form.  Mathlib omits
+the corresponding `yoneda_obj_obj` for the same reason, supplying
+`unif_hint`s instead. -/
+theorem fiberPresheaf_obj (b : Bᵒᵖ) : D.fiberPresheaf.obj b = p.Fiber b.unop := rfl
+
+@[simp] theorem fiberPresheaf_map {b b' : Bᵒᵖ} (g : b ⟶ b')
+    (c : p.Fiber b.unop) : D.fiberPresheaf.map g c = D.restrict g.unop c := rfl
+
+/-! ### `C` and the category of elements of `fiberPresheaf D` -/
+
+attribute [local simp] eqToHom_map
+
+/-- An element of the fiber presheaf at `x` lies over `x.base`.  This
+restates the fiber element's own property, whose type reads
+`p.obj x.elt.1 = unop (op x.base)`: the `unop (op _)` blocks the `eqToHom`
+composites below from matching. -/
+theorem obj_elt (x : D.fiberPresheaf.CoElements) : p.obj x.elt.1 = x.base :=
+  x.elt.2
+
+/-- `c ↦ (p c, c)`. -/
+def toElements : C ⥤ D.fiberPresheaf.CoElements where
+  obj c := Functor.CoElements.mk (p.obj c) ⟨c, rfl⟩
+  map {c c'} f :=
+    Functor.CoElements.homMk (p.map f)
+      (Subtype.ext (D.src_eq (p.map f ≫ eqToHom rfl) f rfl
+        (by change p.map f = eqToHom rfl ≫ p.map f ≫ eqToHom rfl; simp)))
+  map_id c := Functor.CoElements.hom_ext (p.map_id c)
+  map_comp f g := Functor.CoElements.hom_ext (p.map_comp f g)
+
+@[simp] theorem toElements_obj (c : C) :
+    D.toElements.obj c =
+      Functor.CoElements.mk (F := D.fiberPresheaf) (p.obj c) ⟨c, rfl⟩ := rfl
+
+@[simp] theorem homBase_toElements_map {c c' : C} (f : c ⟶ c') :
+    Functor.CoElements.homBase (D.toElements.map f) = p.map f := rfl
+
+/-- The object underlying the source of `f` is the domain of the unique
+lift of `homBase f`. -/
+theorem obj_eq_src {x y : D.fiberPresheaf.CoElements} (f : x ⟶ y) :
+    x.elt.1 = D.src (Functor.CoElements.homBase f ≫ eqToHom (D.obj_elt y).symm) :=
+  (congrArg Subtype.val (Functor.CoElements.map_homBase_elt f)).symm
+
+/-- The unique lift of `homBase f`, transported to a morphism between the
+underlying objects of `C`. -/
+def ofElementsMap {x y : D.fiberPresheaf.CoElements} (f : x ⟶ y) :
+    x.elt.1 ⟶ y.elt.1 :=
+  eqToHom (D.obj_eq_src f) ≫
+    D.hom (Functor.CoElements.homBase f ≫ eqToHom (D.obj_elt y).symm)
+
+/-- `ofElementsMap f` lies over `homBase f`. -/
+theorem map_ofElementsMap {x y : D.fiberPresheaf.CoElements} (f : x ⟶ y) :
+    p.map (D.ofElementsMap f) =
+      eqToHom (D.obj_elt x) ≫ Functor.CoElements.homBase f ≫
+        eqToHom (D.obj_elt y).symm := by
+  rw [ofElementsMap, Functor.map_comp, eqToHom_map, D.map_hom]
+  simp
+
+/-- `(b, c) ↦ c`. -/
+def ofElements : D.fiberPresheaf.CoElements ⥤ C where
+  obj x := x.elt.1
+  map f := D.ofElementsMap f
+  map_id x :=
+    D.map_injective (by rw [D.map_ofElementsMap, p.map_id]; simp)
+  map_comp f g :=
+    D.map_injective (by
+      rw [D.map_ofElementsMap, p.map_comp, D.map_ofElementsMap,
+        D.map_ofElementsMap]
+      simp)
+
+@[simp] theorem ofElements_obj (x : D.fiberPresheaf.CoElements) :
+    D.ofElements.obj x = x.elt.1 := rfl
+
+/-- `ofElements` lies over `Functor.CoElements.π`, elementwise on
+morphisms. -/
+theorem map_ofElements_map {x y : D.fiberPresheaf.CoElements} (f : x ⟶ y) :
+    p.map (D.ofElements.map f) =
+      eqToHom (D.obj_elt x) ≫ Functor.CoElements.homBase f ≫
+        eqToHom (D.obj_elt y).symm :=
+  D.map_ofElementsMap f
+
+/-- `toElements` lies over `B`, elementwise on objects. -/
+theorem π_toElements_obj (c : C) :
+    (Functor.CoElements.π D.fiberPresheaf).obj (D.toElements.obj c) = p.obj c := rfl
+
+/-- `toElements` lies over `B`, elementwise on morphisms. -/
+theorem π_toElements_map {c c' : C} (f : c ⟶ c') :
+    (Functor.CoElements.π D.fiberPresheaf).map (D.toElements.map f) = p.map f := rfl
+
+/-- `ofElements` lies over `B`, elementwise on objects. -/
+theorem obj_ofElements_obj (x : D.fiberPresheaf.CoElements) :
+    p.obj (D.ofElements.obj x) = (Functor.CoElements.π D.fiberPresheaf).obj x :=
+  D.obj_elt x
+
+/-- `ofElements` undoes `toElements` on morphisms. -/
+theorem ofElements_map_toElements_map {c c' : C} (f : c ⟶ c') :
+    D.ofElements.map (D.toElements.map f) = f := by
+  apply D.map_injective
+  rw [D.map_ofElements_map]
+  change 𝟙 _ ≫ p.map f ≫ 𝟙 _ = p.map f
+  simp
+
+/-- `ofElements` undoes `toElements` on objects. -/
+theorem ofElements_obj_toElements_obj (c : C) :
+    D.ofElements.obj (D.toElements.obj c) = c := rfl
+
+/-- An element of a fiber is `toElements` of its underlying object of
+`C`. -/
+theorem mk_eq_toElements_obj {b : B} (c : p.Fiber b) :
+    Functor.CoElements.mk (F := D.fiberPresheaf) b c = D.toElements.obj c.1 := by
+  obtain ⟨c, rfl⟩ := c
+  rfl
+
+/-- Every object of the category of elements of `fiberPresheaf D` is
+`toElements` of its underlying object of `C`. -/
+theorem coElements_eq_toElements_obj (x : D.fiberPresheaf.CoElements) :
+    x = D.toElements.obj x.elt.1 :=
+  (Functor.CoElements.mk_base_elt x).symm.trans (D.mk_eq_toElements_obj x.elt)
+
+/-- `toElements` undoes `ofElements` on morphisms. -/
+theorem toElements_map_ofElements_map {c c' : C}
+    (f : D.toElements.obj c ⟶ D.toElements.obj c') :
+    D.toElements.map (D.ofElements.map f) = f :=
+  Functor.CoElements.hom_ext (by
+    rw [homBase_toElements_map, D.map_ofElements_map]
+    change 𝟙 _ ≫ Functor.CoElements.homBase f ≫ 𝟙 _ =
+      Functor.CoElements.homBase f
+    rw [Category.id_comp, Category.comp_id])
+
+end DiscreteFibration
+
+/-! ### The fibre presheaf of `π F` -/
+
+namespace Functor.CoElements
+
+variable (F : Bᵒᵖ ⥤ Type v₃)
+
+/-- Choice-free and universe-free form of `fiberPresheafIso` below: the fiber of
+`π F` over `b` is in bijection with `F b`. -/
+def fiberPresheafEquiv (b : B) : (π F).Fiber b ≃ F.obj (op b)
+    where
+  toFun x := F.map (eqToHom x.2.symm).op x.1.elt
+  invFun y := ⟨mk b y, rfl⟩
+  left_inv x := by
+    obtain ⟨x, hb⟩ := x
+    subst hb
+    refine Subtype.ext ?_
+    exact (congrArg (mk x.base)
+      (congrFun (F.map_id (op x.base)) x.elt)).trans
+      (mk_base_elt x)
+  right_inv y :=
+    show F.map (𝟙 (op b)) y = y from
+      congrFun (F.map_id _) y
+
+/-- Naturality of `fiberPresheafEquiv`: restriction in the fiber presheaf of
+`π F` is restriction in `F`. -/
+theorem fiberPresheafEquiv_restrict {b b' : B} (g : b ⟶ b')
+    (x : (π F).Fiber b') :
+    fiberPresheafEquiv F b ((discreteFibration F).restrict g x) =
+      F.map g.op (fiberPresheafEquiv F b' x) := by
+  obtain ⟨x, hb⟩ := x
+  subst hb
+  change F.map (𝟙 _) (F.map (g ≫ 𝟙 _).op x.elt) =
+    F.map g.op (F.map (𝟙 _) x.elt)
+  rw [Category.comp_id, F.map_id, F.map_id]
+  rfl
+
+end Functor.CoElements
+
+end CategoryTheory

--- a/geb-lean/vendor/geb-mathlib/Geb/Mathlib/CategoryTheory/DiscreteFibration/Packaged.lean
+++ b/geb-lean/vendor/geb-mathlib/Geb/Mathlib/CategoryTheory/DiscreteFibration/Packaged.lean
@@ -1,0 +1,185 @@
+/-
+Copyright (c) 2026 Terence Rokop. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Terence Rokop
+-/
+-- Modified from geb-mathlib by scripts/geb-mathlib-backport.patch.
+module
+
+public import Geb.Mathlib.CategoryTheory.DiscreteFibration.FiberPresheaf
+
+/-!
+# Discrete fibrations: the packaged statements
+
+The forms of the discrete-fibration correspondence that bundle their
+content into a mathlib construction: the converse of the pullback
+formulation, the equalities of composite functors, the equivalence of
+categories, and the natural isomorphism.
+
+## Main definitions
+
+* `IsDiscreteFibration.equiv` and
+  `IsDiscreteFibration.toDiscreteFibration`, recovering lifting data from
+  a bijective `codPair`.
+* `DiscreteFibration.elementsEquivalence`, the equivalence between `C`
+  and the category of elements of its own fibre presheaf.
+* `Functor.CoElements.fiberPresheafIso`, the natural isomorphism between
+  the fibre presheaf of `π F` and `F`.
+
+## Main statements
+
+* `isDiscreteFibration_iff_nonempty`: the two formulations of a discrete
+  fibration agree.
+* `DiscreteFibration.toElements_comp_π` and
+  `DiscreteFibration.ofElements_comp`: both functors lie over `B`.
+* `DiscreteFibration.toElements_comp_ofElements` and
+  `DiscreteFibration.ofElements_comp_toElements`: both composites are
+  identity functors.
+
+## Implementation notes
+
+Every declaration here depends on `Classical.choice`, and only through a
+mathlib construction that does: `Equiv.ofBijective`, `Functor.comp` in
+each statement mentioning `⋙`, `Equivalence.mk`, and
+`NatIso.ofComponents`.  Each has an elementwise counterpart in
+`Geb/Mathlib/CategoryTheory/DiscreteFibration/Pullback.lean` or
+`Geb/Mathlib/CategoryTheory/DiscreteFibration/FiberPresheaf.lean` that
+carries the same content within the `propext`/`Quot.sound` budget, which
+is why this module is the only one of the group admitted to
+`GebMeta.classicalAllowedModules`.
+
+## References
+
+* [LoregianRiehl2018]
+* [nLabDiscreteFibration]
+
+## Tags
+
+discrete fibration, equivalence of categories, category of elements
+-/
+
+@[expose] public section
+
+universe v₁ v₂ v₃ u₁ u₂
+
+namespace CategoryTheory
+
+open Opposite
+
+variable {C : Type u₁} [Category.{v₁} C] {B : Type u₂} [Category.{v₂} B]
+
+/-- The bijection `Arrow C ≃ Arrow B ×_B C` of a discrete fibration in the
+pullback-square sense.  Classical: `Equiv.ofBijective` uses choice. -/
+noncomputable def IsDiscreteFibration.equiv {p : C ⥤ B}
+    (H : IsDiscreteFibration p) : Arrow C ≃ CodPullback p :=
+  Equiv.ofBijective _ H
+
+/-- `equiv` acts as `codPair`. -/
+theorem IsDiscreteFibration.equiv_apply {p : C ⥤ B}
+    (H : IsDiscreteFibration p) (a : Arrow C) : H.equiv a = codPair p a := rfl
+
+/-- Classical converse: a bijective `codPair p` yields lifting data.  Uses
+`Classical.choice`; kept apart from the constructive development. -/
+noncomputable def IsDiscreteFibration.toDiscreteFibration {p : C ⥤ B}
+    (H : IsDiscreteFibration p) : DiscreteFibration p := by
+  have hl : ∀ q, codPair p (H.equiv.symm q) = q := fun q =>
+    (H.equiv_apply _).symm.trans (H.equiv.apply_symm_apply q)
+  have hr : ∀ {b : B} {c : C} (g : b ⟶ p.obj c),
+      (H.equiv.symm ⟨(Arrow.mk g, c), rfl⟩).right = c :=
+    fun g => congrArg (fun q : CodPullback p => q.1.2) (hl _)
+  have hm : ∀ {b : B} {c : C} (g : b ⟶ p.obj c),
+      Arrow.mk (p.map (H.equiv.symm ⟨(Arrow.mk g, c), rfl⟩).hom) =
+        Arrow.mk g :=
+    fun g => congrArg (fun q : CodPullback p => q.1.1) (hl _)
+  refine
+    { src := fun {b c} g => (H.equiv.symm ⟨(Arrow.mk g, c), rfl⟩).left
+      hom := fun {b c} g =>
+        (H.equiv.symm ⟨(Arrow.mk g, c), rfl⟩).hom ≫ eqToHom (hr g)
+      obj_src := fun {b c} g =>
+        congrArg (fun q : CodPullback p => q.1.1.left) (hl _)
+      map_hom := fun {b c} g => ?_
+      unique := fun {b c} g {c'} h eh hh => ?_ }
+  · obtain ⟨hX, hY, hf⟩ := (Arrow.mk_eq_mk_iff _ _).1 (hm g)
+    simp only [Functor.id_obj] at hf ⊢
+    simp only [Functor.map_comp, eqToHom_map, hf]
+    simp
+  · refine sigma_eq_of_arrow_eq h _ ?_ (hr g)
+    apply H.equiv.injective
+    rw [H.equiv.apply_symm_apply, H.equiv_apply]
+    exact Subtype.ext (Prod.ext
+      ((Arrow.mk_eq_mk_iff _ _).2 ⟨eh, rfl, by simpa using hh⟩).symm rfl)
+
+/-- A discrete fibration in the pullback sense admits lifting data. -/
+theorem IsDiscreteFibration.nonempty {p : C ⥤ B}
+    (H : IsDiscreteFibration p) : Nonempty (DiscreteFibration p) :=
+  ⟨H.toDiscreteFibration⟩
+
+/-- The two formulations agree: the codomain square is a pullback exactly
+when lifting data exists.  Lifting data is a `Subsingleton`, so the
+`Nonempty` on the right loses nothing. -/
+theorem isDiscreteFibration_iff_nonempty {p : C ⥤ B} :
+    IsDiscreteFibration p ↔ Nonempty (DiscreteFibration p) :=
+  ⟨fun H => H.nonempty, fun ⟨D⟩ => D.isDiscreteFibration⟩
+
+namespace DiscreteFibration
+
+variable {p : C ⥤ B} (D : DiscreteFibration p)
+include D
+
+/-- `toElements` lies over `B`. -/
+theorem toElements_comp_π :
+    D.toElements ⋙ Functor.CoElements.π D.fiberPresheaf = p := rfl
+
+/-- `ofElements` lies over `B`. -/
+theorem ofElements_comp : D.ofElements ⋙ p = Functor.CoElements.π D.fiberPresheaf :=
+  Functor.ext (fun x => D.obj_elt x) (fun x y f => by
+    rw [Functor.comp_map, D.map_ofElements_map]
+    rfl)
+
+/-- `ofElements` undoes `toElements`. -/
+theorem toElements_comp_ofElements : D.toElements ⋙ D.ofElements = 𝟭 C :=
+  Functor.ext (fun c => rfl) (fun c c' f => by
+    change D.ofElements.map (D.toElements.map f) = 𝟙 _ ≫ f ≫ 𝟙 _
+    rw [D.ofElements_map_toElements_map, Category.id_comp, Category.comp_id])
+
+/-- `toElements` undoes `ofElements`. -/
+theorem ofElements_comp_toElements :
+    D.ofElements ⋙ D.toElements = 𝟭 D.fiberPresheaf.CoElements :=
+  Functor.ext (fun x => (D.coElements_eq_toElements_obj x).symm) (fun x y f => by
+    obtain ⟨c, rfl⟩ : ∃ c, x = D.toElements.obj c :=
+      ⟨_, D.coElements_eq_toElements_obj x⟩
+    obtain ⟨c', rfl⟩ : ∃ c', y = D.toElements.obj c' :=
+      ⟨_, D.coElements_eq_toElements_obj y⟩
+    change D.toElements.map (D.ofElements.map f) = 𝟙 _ ≫ f ≫ 𝟙 _
+    rw [D.toElements_map_ofElements_map, Category.id_comp, Category.comp_id])
+
+/-- The two functors assemble into an equivalence, so a discrete fibration
+over `B` is the category of elements of its own fibre presheaf.  Both
+composites are identity functors on the nose, so the unit and counit are
+`eqToIso`s. -/
+def elementsEquivalence : C ≌ D.fiberPresheaf.CoElements :=
+  .mk D.toElements D.ofElements (eqToIso D.toElements_comp_ofElements.symm)
+    (eqToIso D.ofElements_comp_toElements)
+
+end DiscreteFibration
+
+namespace Functor.CoElements
+
+variable (F : Bᵒᵖ ⥤ Type v₃)
+
+/-- The fiber presheaf of `π F` is naturally isomorphic to `F` (up to the
+universe lift forced by `F.CoElements : Type (max u₂ v₃)`): the fiber over
+`b` is `{x : F.CoElements // x.base = b}`, and `x ↦ x.elt`, transported
+along `x.base = b`, is a bijection onto `F b`. -/
+def fiberPresheafIso :
+    (discreteFibration F).fiberPresheaf ≅ F ⋙ uliftFunctor.{u₂, v₃} :=
+  NatIso.ofComponents
+    (fun b => ((fiberPresheafEquiv F b.unop).trans Equiv.ulift.symm).toIso)
+    (fun {b b'} g => funext fun x => by
+      have h := fiberPresheafEquiv_restrict F g.unop x
+      rw [Quiver.Hom.op_unop] at h
+      exact congrArg ULift.up h)
+
+end Functor.CoElements
+
+end CategoryTheory

--- a/geb-lean/vendor/geb-mathlib/Geb/Mathlib/CategoryTheory/DiscreteFibration/Pullback.lean
+++ b/geb-lean/vendor/geb-mathlib/Geb/Mathlib/CategoryTheory/DiscreteFibration/Pullback.lean
@@ -1,0 +1,99 @@
+/-
+Copyright (c) 2026 Terence Rokop. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Terence Rokop
+-/
+module
+
+public import Geb.Mathlib.CategoryTheory.DiscreteFibration.Basic
+
+/-!
+# Discrete fibrations: the codomain square
+
+The internal formulation of a discrete fibration ([LoregianRiehl2018]
+§ 2.1, Definition `internaldefn`; [nLabDiscreteFibration]): the square
+
+```
+Arrow C ---right---> C
+   |                 |
+   | p               | p
+   v                 v
+Arrow B ---right---> B
+```
+
+of codomain maps is a pullback of types.
+
+## Main definitions
+
+* `CodPullback p`, the pullback `Arrow B ×_B C` of types.
+* `codPair p`, the comparison map `Arrow C → Arrow B ×_B C`.
+* `IsDiscreteFibration p`, the proposition that `codPair p` is a
+  bijection.
+
+## Main statements
+
+* `DiscreteFibration.isDiscreteFibration`: lifting data forces the square
+  to be a pullback.  The converse needs `Classical.choice` and lives in
+  `Geb/Mathlib/CategoryTheory/DiscreteFibration/Packaged.lean`.
+
+## References
+
+* [LoregianRiehl2018]
+* [nLabDiscreteFibration]
+
+## Tags
+
+discrete fibration, pullback, arrow category
+-/
+
+@[expose] public section
+
+universe v₁ v₂ u₁ u₂
+
+namespace CategoryTheory
+
+variable {C : Type u₁} [Category.{v₁} C] {B : Type u₂} [Category.{v₂} B]
+
+/-- The set-theoretic pullback `Arrow B ×_B C` of `right : Arrow B → B`
+along `p : C → B`: an arrow of `B` with an object of `C` over its
+codomain. -/
+abbrev CodPullback (p : C ⥤ B) : Type (max u₁ u₂ v₂) :=
+  { q : Arrow B × C // q.1.right = p.obj q.2 }
+
+/-- The comparison map `(p, right) : Arrow C → Arrow B ×_B C`. -/
+def codPair (p : C ⥤ B) (a : Arrow C) : CodPullback p :=
+  ⟨(Arrow.mk (p.map a.hom), a.right), rfl⟩
+
+@[simp] theorem codPair_val (p : C ⥤ B) (a : Arrow C) :
+    (codPair p a).1 = (Arrow.mk (p.map a.hom), a.right) := rfl
+
+/-- The pullback-square formulation: `p` is a discrete fibration iff its
+codomain square is a pullback of sets, i.e. iff `codPair p` is a
+bijection. -/
+def IsDiscreteFibration (p : C ⥤ B) : Prop := Function.Bijective (codPair p)
+
+/-- Lifting data forces the codomain square to be a pullback.
+No choice is used. -/
+theorem DiscreteFibration.isDiscreteFibration {p : C ⥤ B}
+    (D : DiscreteFibration p) : IsDiscreteFibration p := by
+  constructor
+  · rintro ⟨x₁, y₁, f₁⟩ ⟨x₂, y₂, f₂⟩ h
+    have hy : y₁ = y₂ := congrArg (fun q : CodPullback p => q.1.2) h
+    subst hy
+    have hf : Arrow.mk (p.map f₁) = Arrow.mk (p.map f₂) :=
+      congrArg (fun q : CodPullback p => q.1.1) h
+    exact (D.eq_liftArrow (p.map f₂) f₁ hf).trans
+      (D.eq_liftArrow (p.map f₂) f₂ rfl).symm
+  · rintro ⟨⟨⟨X, Y, g⟩, c⟩, (hg : Y = p.obj c)⟩
+    subst hg
+    exact ⟨D.liftArrow g, Subtype.ext (Prod.ext (D.arrow_mk_map_hom g) rfl)⟩
+
+/-- Auxiliary: an arrow equal to `Arrow.mk h` gives back `h` up to
+transport of the codomain. -/
+theorem sigma_eq_of_arrow_eq {c c' : C} (h : c' ⟶ c) (a : Arrow C)
+    (ha' : a = Arrow.mk h) (ha : a.right = c) :
+    (⟨c', h⟩ : Σ c', c' ⟶ c) = ⟨a.left, a.hom ≫ eqToHom ha⟩ := by
+  subst ha'
+  simp
+
+end CategoryTheory

--- a/geb-lean/vendor/geb-mathlib/PROVENANCE.md
+++ b/geb-lean/vendor/geb-mathlib/PROVENANCE.md
@@ -1,7 +1,7 @@
 # Vendored geb-mathlib provenance
 
 - Source: https://github.com/rokopt/geb-mathlib.git
-- Source commit: a3e78987794b27e82f0c6047dd5f8457ecb5ba32
-- Back-port patch: scripts/geb-mathlib-backport.patch (sha256 02e9b21570d91c0c04a917b12ba6d53d89ded5c46e9c827344cbe0fa4616f82d)
+- Source commit: 133ff2aef3dd97f07e07c991f13431f8fa650d96
+- Back-port patch: scripts/geb-mathlib-backport.patch (sha256 b376b2147dfa91fc2a8734a5d9eef881547ba8c383a2294c6fe96592e6636df3)
 - Excluded modules: Geb.Internal.Computability.TreeScanner. Each is dropped along with its submodules and every import of it; see scripts/refresh-geb-mathlib.sh.
 - The files under `Geb/` are an unmodified mirror of the source commit except where the back-port patch changes them and where the exclusion above removes them; modified files carry a change notice in their header comment.


### PR DESCRIPTION
Refresh the vendored `Geb` mirror to upstream `133ff2a`, which adds the `Geb.Internal.Computability.CobhamFoldProto` and
`Geb.Mathlib.CategoryTheory.DiscreteFibration` module groups, and extend `scripts/geb-mathlib-backport.patch` to cover them under v4.29.0-rc6.

Five back-port categories carry the new modules: the conditional-rewrite renames (11) and the unreduced beta-redex (4) recur, and three are new — `unusedArguments` on a constant function (13), a declaration reached upstream only through a wider import closure (14), and `Arrow.mk_eq_mk_iff` stating its endpoints through `𝟭 C` (15). The `ConcreteCategory` redesign (3) gains two further sites.