### PR TITLE
chore(vendor): refresh geb-mathlib and drop GebMeta in the refresh sc…

### DIFF
--- a/geb-lean/docs/geb-mathlib-backport-notes.md
+++ b/geb-lean/docs/geb-mathlib-backport-notes.md
@@ -41,10 +41,25 @@ genuinely new (decide the adaptation, add a category here).
 
 ### 1. `GebMeta` not vendored
 
-- Upstream cause: the `Geb` index imports `GebMeta`, a separate library
-  not vendored (its `@[env_linter]` would mis-audit `geb-lean`).
-- v4.29 symptom: `unknown module GebMeta` building the `Geb` index.
-- Adaptation: delete the `import GebMeta` line from `Geb.lean`.
+- Upstream cause: `GebMeta` is a separate library, not vendored (its
+  `@[env_linter]` would mis-audit `geb-lean`). The `Geb` index imports
+  it, and each literate module (upstream `docs/rules/lean-coding.md`
+  § Literate modules) carries `meta import GebMeta` for the `{cite}`
+  docstring role it defines, writing its docstrings as Verso markup
+  under `set_option doc.verso true`.
+- v4.29 symptom: `unknown module prefix 'GebMeta'` building the `Geb`
+  index or a literate module. The pinned toolchain accepts `doc.verso`
+  and the `{name}`, `{lit}`, and `{option}` roles; only `{cite}` is
+  unknown to it, and a bare `[Key]` under `doc.verso` is a link-syntax
+  error.
+- Adaptation: `scripts/refresh-geb-mathlib.sh` deletes every import of
+  `GebMeta`, in any of the module system's four import forms, and
+  rewrites each ``{cite}`Key` `` span to `\[Key\]`, the `doc.verso`
+  spelling of mathlib's bare `[Key]` citation form (the conversion
+  upstream's `scripts/extract-pr.sh` applies at extraction). The pass
+  runs after `git apply`, as module exclusion does, so no patch hunk is
+  involved and a newly-ingested literate module needs no patch
+  extension. `PROVENANCE.md` records the pass.
 
 ### 2. `linter.checkUnivs` configuration absent in v4.29
 

--- a/geb-lean/scripts/geb-mathlib-backport.patch
+++ b/geb-lean/scripts/geb-mathlib-backport.patch
@@ -2485,23 +2485,3 @@ index 03de8f0..5917140 100644
              parseChildren_print _ (List.ofFn ch) (g + 1) rest hchild hfuel,
              Option.map_some, Rose.ofList_ofFn]) r
  
-diff --git a/vendor/geb-mathlib/Geb.lean b/vendor/geb-mathlib/Geb.lean
-index a1b5d12..0a5b56a 100644
---- a/vendor/geb-mathlib/Geb.lean
-+++ b/vendor/geb-mathlib/Geb.lean
-@@ -3,14 +3,13 @@ Copyright (c) 2026 Terence Rokop. All rights reserved.
- Released under Apache 2.0 license as described in the file LICENSE.
- Authors: Terence Rokop
- -/
-+-- Modified from geb-mathlib by scripts/geb-mathlib-backport.patch.
- module -- shake: keep-all, shake: keep-downstream
- 
- public import Geb.Cslib
- public import Geb.Prototypes
- public import Geb.Mathlib
- 
--import GebMeta
--
- /-!
- # Geb root module
- 

--- a/geb-lean/scripts/refresh-geb-mathlib.sh
+++ b/geb-lean/scripts/refresh-geb-mathlib.sh
@@ -49,6 +49,7 @@ cat > "$VENDOR/PROVENANCE.md" <<EOF
 - Source commit: $SRC_SHA
 - Back-port patch: scripts/geb-mathlib-backport.patch (sha256 $PATCH_SHA256)
 - Excluded modules: $EXCLUDED_RENDERED. Each is dropped along with its submodules and every import of it; see scripts/refresh-geb-mathlib.sh.
+- \`GebMeta\` is not vendored: every import of it is dropped and each \`{cite}\` docstring role it supplies is rewritten to its escaped bracketed key; see scripts/refresh-geb-mathlib.sh.
 - The files under \`Geb/\` are an unmodified mirror of the source commit except where the back-port patch changes them and where the exclusion above removes them; modified files carry a change notice in their header comment.
 EOF
 
@@ -70,6 +71,18 @@ for mod in "${EXCLUDED_MODULES[@]}"; do
   find "$VENDOR" -name '*.lean' -exec \
     sed -i -E "/^(public )?import ${mod}(\.|\$)/d" {} +
 done
+
+# GebMeta is not vendored (its env_linter would mis-audit geb-lean). It
+# supplies the `{cite}` docstring role, which upstream's literate
+# modules use under `doc.verso`; the pinned toolchain supports every
+# other role such a module writes. Drop each import of GebMeta, in any
+# of the module system's four forms, and rewrite each `{cite}` span to
+# the escaped bracketed key, `\[Key\]`, the `doc.verso` spelling of
+# mathlib's bare `[Key]` citation form. See
+# docs/geb-mathlib-backport-notes.md § 1.
+find "$VENDOR" -name '*.lean' -exec sed -i -E \
+  -e '/^(public[[:space:]]+)?(meta[[:space:]]+)?import[[:space:]]+GebMeta([[:space:]]|$)/d' \
+  -e 's/[{]cite[}]`([^`]*)`/\\[\1\\]/g' {} +
 
 # A refresh that changes no vendored content (an upstream revision
 # touching none of the mirrored files) leaves at most PROVENANCE.md

--- a/geb-lean/vendor/geb-mathlib/Geb.lean
+++ b/geb-lean/vendor/geb-mathlib/Geb.lean
@@ -3,12 +3,12 @@ Copyright (c) 2026 Terence Rokop. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Terence Rokop
 -/
--- Modified from geb-mathlib by scripts/geb-mathlib-backport.patch.
 module -- shake: keep-all, shake: keep-downstream
 
 public import Geb.Cslib
 public import Geb.Prototypes
 public import Geb.Mathlib
+
 
 /-!
 # Geb root module

--- a/geb-lean/vendor/geb-mathlib/Geb/Mathlib/Data/W/Basic.lean
+++ b/geb-lean/vendor/geb-mathlib/Geb/Mathlib/Data/W/Basic.lean
@@ -9,51 +9,57 @@ module
 public import Mathlib.Data.W.Basic
 public import Geb.Mathlib.Data.FinEnum
 
+set_option doc.verso true
+
 /-!
 # The W-type fold and paramorphism: computation rules and uniqueness
 
-`WType.elim` is the non-dependent fold of a W-type: the morphism into a
-given algebra of the polynomial endofunctor `X ↦ Σ a, β a → X`. mathlib
-states the fold but neither its computation rule as a named `@[simp]`
-lemma nor its uniqueness. Together the two make `WType β` the initial
-algebra of that endofunctor, stated concretely. `WType.para` generalises
-the fold to a paramorphism, whose step additionally sees each node's
-children as subtrees, not only as their folded values.
+{name}`WType.elim` is the non-dependent fold of a W-type: the morphism
+into a given algebra of the polynomial endofunctor
+{lit}`X ↦ Σ a, β a → X`. mathlib states the fold but neither its
+computation rule as a named {lit}`@[simp]` lemma nor its uniqueness.
+Together the two make {lit}`WType β` the initial algebra of that
+endofunctor, stated concretely. {lit}`WType.para` generalises the fold
+to a paramorphism, whose step additionally sees each node's children as
+subtrees, not only as their folded values.
 
 ## Main definitions
 
-* `WType.para` — the paramorphism: a fold whose step function receives
-  each child as a subtree paired with its folded value.
-* `WType.beq` — Boolean equality of W-trees, decidable when the shape
-  type has decidable equality and every direction type is finitely
-  enumerable.
+* {lit}`WType.para` — the paramorphism: a fold whose step function
+  receives each child as a subtree paired with its folded value.
+* {lit}`WType.beq` — Boolean equality of W-trees, decidable when the
+  shape type has decidable equality and every direction type is
+  finitely enumerable.
 
 ## Main statements
 
-* `WType.elim_mk` — the computation rule: the fold of a constructor
-  application is the algebra applied to the folded children.
-* `WType.elim_unique` — uniqueness: a function satisfying the
+* {lit}`WType.elim_mk` — the computation rule: the fold of a
+  constructor application is the algebra applied to the folded
+  children.
+* {lit}`WType.elim_unique` — uniqueness: a function satisfying the
   computation rule is the fold.
-* `WType.para_mk` — the paramorphism's computation rule.
-* `WType.beq_eq_true_iff` — `beq` decides equality of W-trees.
-* `WType.instDecidableEq` — the resulting `DecidableEq (WType β)`
-  instance.
+* {lit}`WType.para_mk` — the paramorphism's computation rule.
+* {lit}`WType.beq_eq_true_iff` — {lit}`beq` decides equality of
+  W-trees.
+* {lit}`WType.instDecidableEq` — the resulting
+  {lit}`DecidableEq (WType β)` instance.
 
 ## Implementation notes
 
-`elim_mk` holds by `rfl`; mathlib's equation compiler generates the
-equation, and the named `@[simp]` form is what makes the hypothesis
-shape of `elim_unique` usable by `simp` at call sites. `elim_unique`
-drives its recursion through an explicit `WType.rec` application into a
-`Prop`-valued motive. `para` is `elim` at the product carrier
-`WType β × γ`, whose first component reconstructs the subtree; its
-computation rule `para_mk` does not hold by `rfl` and is proved through
-that reconstruction.
+{lit}`elim_mk` holds by {name}`rfl`; mathlib's equation compiler
+generates the equation, and the named {lit}`@[simp]` form is what makes
+the hypothesis shape of {lit}`elim_unique` usable by {lit}`simp` at
+call sites. {lit}`elim_unique` drives its recursion through an explicit
+{name}`WType.rec` application into a {lit}`Prop`-valued motive.
+{lit}`para` is {name}`WType.elim` at the product carrier
+{lit}`WType β × γ`, whose first component reconstructs the subtree;
+its computation rule {lit}`para_mk` does not hold by {name}`rfl` and is
+proved through that reconstruction.
 
 ## References
 
-* [GambinoHyland2004]
-* [Meertens1992]
+* \[GambinoHyland2004\]
+* \[Meertens1992\]
 
 ## Tags
 
@@ -74,8 +80,8 @@ applies the algebra to the children's folds. -/
   rfl
 
 /-- The fold is the unique function satisfying its computation rule.
-With `elim` itself, this is the initiality of `WType β` among algebras
-of the polynomial endofunctor `X ↦ Σ a, β a → X`. -/
+With {name}`WType.elim` itself, this is the initiality of {lit}`WType β`
+among algebras of the polynomial endofunctor {lit}`X ↦ Σ a, β a → X`. -/
 theorem elim_unique {α : Type uA} {β : α → Type uB} {γ : Type uC}
     (fγ : (Σ a : α, β a → γ) → γ) (g : WType β → γ)
     (hg : ∀ (a : α) (f : β a → WType β),
@@ -101,16 +107,17 @@ private theorem paraStep_fst {α : Type uA} {β : α → Type uB} (γ : Type uC)
 
 /-- The paramorphism of a W-type: a fold whose step sees each node's
 children as subtrees together with their folded values. Obtained from
-`elim` at the product carrier `WType β × γ`, whose first component
-reconstructs the subtree, so no new recursion is introduced.
-[Meertens1992] -/
+{name}`WType.elim` at the product carrier {lit}`WType β × γ`, whose
+first component reconstructs the subtree, so no new recursion is
+introduced. \[Meertens1992\] -/
 @[expose] def para {α : Type uA} {β : α → Type uB} (γ : Type uC)
     (fγ : (Σ a : α, β a → WType β × γ) → γ) : WType β → γ :=
   fun w ↦ (elim (WType β × γ) (paraStep γ fγ) w).2
 
 /-- The paramorphism's computation rule: it applies the step to the node's
-children paired with their own paramorphisms. Unlike `elim_mk` this does
-not hold by `rfl`; it is `paraStep_fst` under a `congrArg`. -/
+children paired with their own paramorphisms. Unlike {name}`WType.elim_mk`
+this does not hold by {name}`rfl`; it is {lit}`paraStep_fst` under a
+{name}`congrArg`. -/
 @[simp] theorem para_mk {α : Type uA} {β : α → Type uB} {γ : Type uC}
     (fγ : (Σ a : α, β a → WType β × γ) → γ) (a : α) (f : β a → WType β) :
     para γ fγ (mk a f) = fγ ⟨a, fun b ↦ (f b, para γ fγ (f b))⟩ :=
@@ -118,8 +125,9 @@ not hold by `rfl`; it is `paraStep_fst` under a `congrArg`. -/
     (funext fun b ↦ Prod.ext (paraStep_fst γ fγ (f b)) rfl)
 
 /-- Boolean equality of W-trees: compare the shapes, then compare the
-children pointwise over the finite direction type. A fold by `elim` at
-the carrier `WType β → Bool`, so no recursion is introduced. -/
+children pointwise over the finite direction type. A fold by
+{name}`WType.elim` at the carrier {lit}`WType β → Bool`, so no recursion
+is introduced. -/
 @[expose] def beq {α : Type uA} {β : α → Type uB} [DecidableEq α]
     [∀ a, FinEnum (β a)] : WType β → WType β → Bool :=
   elim (WType β → Bool) fun x t' ↦
@@ -127,7 +135,7 @@ the carrier `WType β → Bool`, so no recursion is introduced. -/
       decide (∀ b : β x.1, x.2 b ((toSigma t').2 (h ▸ b)) = true)
     else false
 
-/-- `beq` unfolded on two constructor applications. -/
+/-- {name}`WType.beq` unfolded on two constructor applications. -/
 theorem beq_mk {α : Type uA} {β : α → Type uB} [DecidableEq α]
     [∀ a, FinEnum (β a)] (a : α) (f : β a → WType β) (a' : α)
     (f' : β a' → WType β) :
@@ -135,7 +143,7 @@ theorem beq_mk {α : Type uA} {β : α → Type uB} [DecidableEq α]
       if h : a = a' then decide (∀ b : β a, beq (f b) (f' (h ▸ b)) = true) else false :=
   rfl
 
-/-- `beq` decides equality of W-trees. -/
+/-- {name}`WType.beq` decides equality of W-trees. -/
 theorem beq_eq_true_iff {α : Type uA} {β : α → Type uB} [DecidableEq α]
     [∀ a, FinEnum (β a)] (s t : WType β) : beq s t = true ↔ s = t :=
   rec (motive := fun s ↦ ∀ t, beq s t = true ↔ s = t)
@@ -155,7 +163,7 @@ theorem beq_eq_true_iff {α : Type uA} {β : α → Type uB} [DecidableEq α]
 
 /-- Equality of W-trees is decidable when shapes have decidable equality
 and every direction type is finitely enumerable. mathlib reaches this
-only through `Encodable`, which additionally requires the shape and
+only through {name}`Encodable`, which additionally requires the shape and
 direction types countable. -/
 instance instDecidableEq {α : Type uA} {β : α → Type uB} [DecidableEq α]
     [∀ a, FinEnum (β a)] : DecidableEq (WType β) :=

--- a/geb-lean/vendor/geb-mathlib/PROVENANCE.md
+++ b/geb-lean/vendor/geb-mathlib/PROVENANCE.md
@@ -1,7 +1,8 @@
 # Vendored geb-mathlib provenance
 
 - Source: https://github.com/rokopt/geb-mathlib.git
-- Source commit: caf42eed39714f96794bed4135330c7dbf2bf2a2
-- Back-port patch: scripts/geb-mathlib-backport.patch (sha256 5e8e0ce34854825cadd7c58fc8fa58f41ce53615b73ce5fbbef1a07e2b244b67)
+- Source commit: 673cfcaf782f1668c54193bf5ae532df547cf4aa
+- Back-port patch: scripts/geb-mathlib-backport.patch (sha256 b3ed5fe2ba40fff470aecbf99618781590d8f00e68599d3b612d024de5bb1de2)
 - Excluded modules: Geb.Prototypes.Computability.TreeScanner. Each is dropped along with its submodules and every import of it; see scripts/refresh-geb-mathlib.sh.
+- `GebMeta` is not vendored: every import of it is dropped and each `{cite}` docstring role it supplies is rewritten to its escaped bracketed key; see scripts/refresh-geb-mathlib.sh.
 - The files under `Geb/` are an unmodified mirror of the source commit except where the back-port patch changes them and where the exclusion above removes them; modified files carry a change notice in their header comment.


### PR DESCRIPTION
…ript

Refresh vendor/geb-mathlib to upstream 673cfca, which writes the docstrings of Geb/Mathlib/Data/W/Basic.lean as Verso markup under doc.verso and imports GebMeta for the {cite} docstring role.

GebMeta is not vendored. The pinned v4.29.0-rc6 toolchain accepts doc.verso and the name, lit, and option roles; only cite is unknown to it, and a bare [Key] under doc.verso is a link-syntax error. Handle the library in scripts/refresh-geb-mathlib.sh rather than in the patch: after git apply, delete every import of GebMeta and rewrite each {cite}`Key` span to \[Key\], the doc.verso spelling of mathlib's bare citation form. Upstream's rule makes every new module literate, so a script pass covers each future module where a patch hunk would need extending per module. Retire the patch's Geb.lean hunk, which deleted the same import, and record the pass in PROVENANCE.md and in category 1 of the back-port notes.


Claude-Session: https://claude.ai/code/session_01EGpcRbAKyuSP4z7SP2VXih